### PR TITLE
Modified reads2ref code to fix performance issue. 

### DIFF
--- a/adam-commands/src/main/scala/edu/berkeley/cs/amplab/adam/commands/Reads2Ref.scala
+++ b/adam-commands/src/main/scala/edu/berkeley/cs/amplab/adam/commands/Reads2Ref.scala
@@ -15,22 +15,19 @@
  */
 package edu.berkeley.cs.amplab.adam.commands
 
-import edu.berkeley.cs.amplab.adam.util._
-import net.sf.samtools.{CigarOperator, TextCigarCodec}
 import org.apache.hadoop.mapreduce.Job
 import edu.berkeley.cs.amplab.adam.predicates.LocusPredicate
 import scala.collection.JavaConversions._
 import org.kohsuke.args4j.{Option => option, Argument}
-import scala.collection.immutable.StringOps
 import edu.berkeley.cs.amplab.adam.rdd.AdamContext._
 import edu.berkeley.cs.amplab.adam.avro.{Base, ADAMPileup, ADAMRecord}
 import org.apache.spark.SparkContext
 import org.apache.spark.rdd.RDD
+import edu.berkeley.cs.amplab.adam.util._
 
 object Reads2Ref extends AdamCommandCompanion {
   val commandName: String = "reads2ref"
   val commandDescription: String = "Convert an ADAM read-oriented file to an ADAM reference-oriented file"
-  val CIGAR_CODEC: TextCigarCodec = TextCigarCodec.getSingleton
 
   def apply(cmdLine: Array[String]) = {
     new Reads2Ref(Args4j[Reads2RefArgs](cmdLine))
@@ -55,195 +52,24 @@ class Reads2RefArgs extends Args4jBase with ParquetArgs with SparkArgs {
   var aggregate: Boolean = false
 }
 
-class ReadProcessor extends Serializable {
-
-  def readToPileups(record: ADAMRecord): List[ADAMPileup] = {
-    if (record == null || record.getCigar == null || record.getMismatchingPositions == null) {
-      // TODO: log this later... We can't create a pileup without the CIGAR and MD tag
-      // in the future, we can also get reference information from a reference file
-      return List.empty
-    }
-
-    def baseFromSequence(pos: Int): Base = {
-      Base.valueOf(record.getSequence.subSequence(pos, pos + 1).toString)
-    }
-
-    def sangerScoreToInt(score: String, position: Int): Int = score(position).toInt - 33
-
-    def populatePileupFromReference(record: ADAMRecord, referencePos: Long, isReverseStrand: Boolean, readPos: Int): ADAMPileup.Builder = {
-
-      var reverseStrandCount = 0
-
-      if (isReverseStrand) {
-        reverseStrandCount = 1
-      }
-
-      // check read mapping locations
-      assert(record.getStart != null, "Read is mapped but has a null start position.")
-
-      val end: Long = record.end match {
-        case Some(o) => o.asInstanceOf[Long]
-        case None => -1L
-      }
-
-      assert(end != -1L, "Read is mapped but has a null end position.")
-
-      ADAMPileup.newBuilder()
-        .setReferenceName(record.getReferenceName)
-        .setReferenceId(record.getReferenceId)
-        .setMapQuality(record.getMapq)
-        .setPosition(referencePos)
-        .setRecordGroupSequencingCenter(record.getRecordGroupSequencingCenter)
-        .setRecordGroupDescription(record.getRecordGroupDescription)
-        .setRecordGroupRunDateEpoch(record.getRecordGroupRunDateEpoch)
-        .setRecordGroupFlowOrder(record.getRecordGroupFlowOrder)
-        .setRecordGroupKeySequence(record.getRecordGroupKeySequence)
-        .setRecordGroupLibrary(record.getRecordGroupLibrary)
-        .setRecordGroupPredictedMedianInsertSize(record.getRecordGroupPredictedMedianInsertSize)
-        .setRecordGroupPlatform(record.getRecordGroupPlatform)
-        .setRecordGroupPlatformUnit(record.getRecordGroupPlatformUnit)
-        .setRecordGroupSample(record.getRecordGroupSample)
-        .setSangerQuality(sangerScoreToInt(record.getQual.toString, readPos))
-        .setNumReverseStrand(reverseStrandCount)
-        .setNumSoftClipped(0)
-        .setReadName(record.getReadName)
-        .setReadStart(record.getStart)
-        .setReadEnd(end)
-        .setCountAtPosition(1)
-
-    }
-
-    var referencePos = record.getStart
-    val isReverseStrand = record.getReadNegativeStrand
-    var readPos = 0
-
-    val cigar = Reads2Ref.CIGAR_CODEC.decode(record.getCigar.toString)
-    val mdTag = MdTag(record.getMismatchingPositions.toString, referencePos)
-
-    var pileupList = List[ADAMPileup]()
-
-    cigar.getCigarElements.foreach(cigarElement =>
-      cigarElement.getOperator match {
-
-        // INSERT
-        case CigarOperator.I =>
-          var insertPos = 0
-
-          for (b <- new StringOps(record.getSequence.toString.substring(readPos, readPos + cigarElement.getLength - 1))) {
-            val insertBase = Base.valueOf(b.toString)
-
-            val pileup = populatePileupFromReference(record, referencePos, isReverseStrand, readPos)
-              .setReadBase(insertBase)
-              .setRangeOffset(insertPos)
-              .setRangeLength(cigarElement.getLength)
-              .setReferenceBase(null)
-              .build()
-            pileupList ::= pileup
-            // Consumes the read bases but NOT the reference bases
-            readPos += 1
-            insertPos += 1
-          }
-        // MATCH (sequence match or mismatch)
-        case CigarOperator.M =>
-
-          for (i <- 0 until cigarElement.getLength) {
-
-            val readBase = if (mdTag.isMatch(referencePos)) {
-              baseFromSequence(readPos)
-            } else {
-              mdTag.mismatchedBase(referencePos) match {
-                case None => throw new IllegalArgumentException("Cigar match has no MD (mis)match @" + referencePos + " " + record.getCigar + " " + record.getMismatchingPositions) fillInStackTrace()
-                case Some(read) => Base.valueOf(read.toString)
-              }
-            }
-
-            // sequence match
-            val pileup = populatePileupFromReference(record, referencePos, isReverseStrand, readPos)
-              .setReadBase(readBase)
-              .setReferenceBase(baseFromSequence(readPos))
-              .build()
-            pileupList ::= pileup
-
-            readPos += 1
-            referencePos += 1
-          }
-
-        // DELETE
-        case CigarOperator.D =>
-          for (i <- 0 until cigarElement.getLength) {
-            val deletedBase = mdTag.deletedBase(referencePos)
-            if (deletedBase.isEmpty) {
-              throw new IllegalArgumentException("CIGAR delete but the MD tag is not a delete")
-            }
-            val pileup = populatePileupFromReference(record, referencePos, isReverseStrand, readPos)
-              .setReferenceBase(Base.valueOf(deletedBase.get.toString))
-              .setRangeOffset(i)
-              .setRangeLength(cigarElement.getLength)
-              .build()
-
-            pileupList ::= pileup
-            // Consume reference bases but not read bases
-            referencePos += 1
-          }
-
-        // Soft clip
-        case CigarOperator.S =>
-
-          var clipPos = 0
-
-          for (i <- 0 until cigarElement.getLength) {
-            val readBase = baseFromSequence(readPos)
-
-            // sequence match
-            val pileup = populatePileupFromReference(record, referencePos, isReverseStrand, readPos)
-              .setReadBase(readBase)
-              .setNumSoftClipped(1)
-              .setRangeOffset(clipPos)
-              .setRangeLength(cigarElement.getLength)
-              .setReferenceBase(null)
-              .build()
-            pileupList ::= pileup
-
-            readPos += 1
-            clipPos += 1
-          }
-
-        // All other cases (TODO: add X and EQ?)
-        case _ =>
-          if (cigarElement.getOperator.consumesReadBases()) {
-            readPos += cigarElement.getLength
-          }
-          if (cigarElement.getOperator.consumesReferenceBases()) {
-            referencePos += cigarElement.getLength
-          }
-      }
-    )
-
-    pileupList
-  }
-}
-
 class Reads2Ref(protected val args: Reads2RefArgs) extends AdamSparkCommand[Reads2RefArgs] {
   val companion = Reads2Ref
 
   def run(sc: SparkContext, job: Job) {
     val reads: RDD[ADAMRecord] = sc.adamLoad(args.readInput, Some(classOf[LocusPredicate]))
+   
+    val readCount = reads.count()
+ 
+    val pileups: RDD[ADAMPileup] = reads.adamRecords2Pileup()
+ 
+    val pileupCount = pileups.count()
 
-    val readProcessor = new ReadProcessor
-    val pileups: RDD[ADAMPileup] = reads.filter(_.getReadMapped).flatMap {
-      readProcessor.readToPileups
-    }
-
+    val coverage = pileupCount / readCount
+   
     if (args.aggregate) {
-      pileups.adamAggregatePileups().adamSave(args.pileupOutput, args)
+      pileups.adamAggregatePileups(coverage.toInt).adamSave(args.pileupOutput, args)
     } else {
-      pileups.adamSave(args.pileupOutput)
+      pileups.adamSave(args.pileupOutput, args)
     }
   }
-
-  def sangerQuality(qualities: String, index: Int) {
-    qualities charAt index - 33
-  }
-
-
 }

--- a/adam-commands/src/main/scala/edu/berkeley/cs/amplab/adam/rdd/AdamRDDFunctions.scala
+++ b/adam-commands/src/main/scala/edu/berkeley/cs/amplab/adam/rdd/AdamRDDFunctions.scala
@@ -105,13 +105,22 @@ class AdamRecordRDDFunctions(rdd: RDD[ADAMRecord]) extends Serializable with Log
   def adamSingleReadBuckets(): RDD[SingleReadBucket] = {
     SingleReadBucket(rdd)
   }
+
+  /**
+   * Groups all reads by reference position and returns a non-aggregated pileup RDD.
+   * @return ADAMPileup without aggregation
+   */
+  def adamRecords2Pileup(): RDD[ADAMPileup] = {
+    val helper = new Reads2PileupProcessor
+    helper.process(rdd)
+  }
 }
 
 class AdamPileupRDDFunctions(rdd: RDD[ADAMPileup]) extends Serializable {
 
-  def adamAggregatePileups(): RDD[ADAMPileup] = {
+  def adamAggregatePileups(coverage: Int = 30): RDD[ADAMPileup] = {
     val helper = new PileupAggregator
-    helper.aggregate(rdd)
+    helper.aggregate(rdd, coverage)
   }
 
 }

--- a/adam-commands/src/main/scala/edu/berkeley/cs/amplab/adam/rdd/PileupAggregator.scala
+++ b/adam-commands/src/main/scala/edu/berkeley/cs/amplab/adam/rdd/PileupAggregator.scala
@@ -1,15 +1,32 @@
+/*
+ * Copyright (c) 2013. Regents of the University of California
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package edu.berkeley.cs.amplab.adam.rdd
 
 import edu.berkeley.cs.amplab.adam.avro.{Base, ADAMPileup}
 import org.apache.spark.rdd.RDD
+import org.apache.spark.Logging
 
-private[rdd] class PileupAggregator extends Serializable {
+private[rdd] class PileupAggregator extends Serializable with Logging {
 
-  def mapPileup(a: ADAMPileup): (Option[Long], Option[Base], Option[java.lang.Integer], Option[CharSequence]) = {
-    (Option(a.getPosition), Option(a.getReadBase), Option(a.getRangeOffset), Option(a.getRecordGroupSample))
+  def mapPileup(a: ADAMPileup): (Option[Base], Option[java.lang.Integer], Option[CharSequence]) = {
+    (Option(a.getReadBase), Option(a.getRangeOffset), Option(a.getRecordGroupSample))
   }
 
-  def aggregatePileup(pileupList: List[ADAMPileup]): List[ADAMPileup] = {
+  def aggregatePileup(pileupList: List[ADAMPileup]): ADAMPileup = {
 
     def combineEvidence(pileupGroup: List[ADAMPileup]): ADAMPileup = {
       val pileup = pileupGroup.reduce((a: ADAMPileup, b: ADAMPileup) => {
@@ -30,14 +47,30 @@ private[rdd] class PileupAggregator extends Serializable {
       pileup
     }
 
-    List(combineEvidence(pileupList))
+    combineEvidence(pileupList)
   }
 
-  def aggregate(pileups: RDD[ADAMPileup]): RDD[ADAMPileup] = {
-    def flatten(kv: ((Option[Long], Option[Base], Option[java.lang.Integer], Option[CharSequence]), Seq[ADAMPileup])): List[ADAMPileup] = {
-      aggregatePileup(kv._2.toList)
+  def aggregate(pileups: RDD[ADAMPileup], coverage: Int = 30): RDD[ADAMPileup] = {
+    def flatten(kv: Seq[ADAMPileup]): List[ADAMPileup] = {
+      val splitUp = kv.toList.groupBy(mapPileup)
+      
+      splitUp.map(kv => aggregatePileup(kv._2)).toList
     }
 
-    pileups.groupBy(mapPileup).flatMap(flatten)
+    log.info ("Aggregating " + pileups.count + " pileups.")
+
+    /* need to manually set partitions here, as this is a large reduction if there are long reads, or there is high coverage.
+     * if this is not set, then you will encounter out-of-memory errors, as the working set for each reducer becomes very large.
+     * as a first order approximation, we use coverage as a proxy for setting the number of reducers needed.
+     */
+    val grouping = pileups.groupBy((p: ADAMPileup) => p.getPosition, pileups.partitions.length * coverage / 2)
+
+    log.info ("Pileups grouped into " + grouping.count + " positions.")
+
+    val aggregated = grouping.flatMap(kv => flatten(kv._2))
+
+    log.info ("Aggregation reduces down to " + aggregated.count + " pileups.")
+
+    aggregated
   }
 }

--- a/adam-commands/src/main/scala/edu/berkeley/cs/amplab/adam/rdd/Reads2PileupProcessor.scala
+++ b/adam-commands/src/main/scala/edu/berkeley/cs/amplab/adam/rdd/Reads2PileupProcessor.scala
@@ -1,0 +1,209 @@
+/*
+ * Copyright (c) 2013. Regents of the University of California
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package edu.berkeley.cs.amplab.adam.rdd
+
+import edu.berkeley.cs.amplab.adam.avro.{Base, ADAMPileup, ADAMRecord}
+import org.apache.spark.rdd.RDD
+import org.apache.spark.Logging
+import edu.berkeley.cs.amplab.adam.rich.RichADAMRecord._
+import edu.berkeley.cs.amplab.adam.rich.RichADAMRecord
+import edu.berkeley.cs.amplab.adam.util._
+import net.sf.samtools.{CigarOperator, TextCigarCodec}
+import scala.collection.JavaConverters._
+import scala.collection.immutable.StringOps
+
+private[rdd] object Reads2PileupProcessor {
+  val CIGAR_CODEC: TextCigarCodec = TextCigarCodec.getSingleton
+}
+
+private[rdd] class Reads2PileupProcessor extends Serializable with Logging {
+
+  def readToPileups(record: ADAMRecord): List[ADAMPileup] = {
+    if (record == null || record.getCigar == null || record.getMismatchingPositions == null) {
+      // TODO: log this later... We can't create a pileup without the CIGAR and MD tag
+      // in the future, we can also get reference information from a reference file
+      return List.empty
+    }
+
+    def baseFromSequence(pos: Int): Base = {
+      Base.valueOf(record.getSequence.subSequence(pos, pos + 1).toString)
+    }
+
+    def sangerScoreToInt(score: String, position: Int): Int = score(position).toInt - 33
+
+    def populatePileupFromReference(record: ADAMRecord, referencePos: Long, isReverseStrand: Boolean, readPos: Int): ADAMPileup.Builder = {
+
+      var reverseStrandCount = 0
+
+      if (isReverseStrand) {
+        reverseStrandCount = 1
+      }
+
+      // check read mapping locations
+      assert(record.getStart != null, "Read is mapped but has a null start position.")
+
+      val end: Long = record.end match {
+        case Some(o) => o.asInstanceOf[Long]
+        case None => -1L
+      }
+
+      assert(end != -1L, "Read is mapped but has a null end position.")
+
+      ADAMPileup.newBuilder()
+        .setReferenceName(record.getReferenceName)
+        .setReferenceId(record.getReferenceId)
+        .setMapQuality(record.getMapq)
+        .setPosition(referencePos)
+        .setRecordGroupSequencingCenter(record.getRecordGroupSequencingCenter)
+        .setRecordGroupDescription(record.getRecordGroupDescription)
+        .setRecordGroupRunDateEpoch(record.getRecordGroupRunDateEpoch)
+        .setRecordGroupFlowOrder(record.getRecordGroupFlowOrder)
+        .setRecordGroupKeySequence(record.getRecordGroupKeySequence)
+        .setRecordGroupLibrary(record.getRecordGroupLibrary)
+        .setRecordGroupPredictedMedianInsertSize(record.getRecordGroupPredictedMedianInsertSize)
+        .setRecordGroupPlatform(record.getRecordGroupPlatform)
+        .setRecordGroupPlatformUnit(record.getRecordGroupPlatformUnit)
+        .setRecordGroupSample(record.getRecordGroupSample)
+        .setSangerQuality(record.qualityScores(readPos).toInt)
+        .setNumReverseStrand(reverseStrandCount)
+        .setNumSoftClipped(0)
+        .setReadName(record.getReadName)
+        .setReadStart(record.getStart)
+        .setReadEnd(end)
+        .setCountAtPosition(1)
+
+    }
+
+    var referencePos = record.getStart
+    val isReverseStrand = record.getReadNegativeStrand
+    var readPos = 0
+
+    val cigar = Reads2PileupProcessor.CIGAR_CODEC.decode(record.getCigar.toString)
+    val mdTag = MdTag(record.getMismatchingPositions.toString, referencePos)
+
+    var pileupList = List[ADAMPileup]()
+
+    cigar.getCigarElements.asScala.foreach(cigarElement =>
+      cigarElement.getOperator match {
+
+        // INSERT
+        case CigarOperator.I =>
+          var insertPos = 0
+
+          for (b <- new StringOps(record.getSequence.toString.substring(readPos, readPos + cigarElement.getLength - 1))) {
+            val insertBase = Base.valueOf(b.toString)
+
+            val pileup = populatePileupFromReference(record, referencePos, isReverseStrand, readPos)
+              .setReadBase(insertBase)
+              .setRangeOffset(insertPos)
+              .setRangeLength(cigarElement.getLength)
+              .setReferenceBase(null)
+              .build()
+            pileupList ::= pileup
+            // Consumes the read bases but NOT the reference bases
+            readPos += 1
+            insertPos += 1
+          }
+        // MATCH (sequence match or mismatch)
+        case CigarOperator.M =>
+
+          for (i <- 0 until cigarElement.getLength) {
+
+            val readBase = if (mdTag.isMatch(referencePos)) {
+              baseFromSequence(readPos)
+            } else {
+              mdTag.mismatchedBase(referencePos) match {
+                case None => throw new IllegalArgumentException("Cigar match has no MD (mis)match @" + referencePos + " " + record.getCigar + " " + record.getMismatchingPositions) fillInStackTrace()
+                case Some(read) => Base.valueOf(read.toString)
+              }
+            }
+
+            // sequence match
+            val pileup = populatePileupFromReference(record, referencePos, isReverseStrand, readPos)
+              .setReadBase(readBase)
+              .setReferenceBase(baseFromSequence(readPos))
+              .build()
+            pileupList ::= pileup
+
+            readPos += 1
+            referencePos += 1
+          }
+
+        // DELETE
+        case CigarOperator.D =>
+          for (i <- 0 until cigarElement.getLength) {
+            val deletedBase = mdTag.deletedBase(referencePos)
+            if (deletedBase.isEmpty) {
+              throw new IllegalArgumentException("CIGAR delete but the MD tag is not a delete")
+            }
+            val pileup = populatePileupFromReference(record, referencePos, isReverseStrand, readPos)
+              .setReferenceBase(Base.valueOf(deletedBase.get.toString))
+              .setRangeOffset(i)
+              .setRangeLength(cigarElement.getLength)
+              .build()
+
+            pileupList ::= pileup
+            // Consume reference bases but not read bases
+            referencePos += 1
+          }
+
+        // Soft clip
+        case CigarOperator.S =>
+
+          var clipPos = 0
+
+          for (i <- 0 until cigarElement.getLength) {
+            val readBase = baseFromSequence(readPos)
+
+            // sequence match
+            val pileup = populatePileupFromReference(record, referencePos, isReverseStrand, readPos)
+              .setReadBase(readBase)
+              .setNumSoftClipped(1)
+              .setRangeOffset(clipPos)
+              .setRangeLength(cigarElement.getLength)
+              .setReferenceBase(null)
+              .build()
+            pileupList ::= pileup
+
+            readPos += 1
+            clipPos += 1
+          }
+
+        // All other cases (TODO: add X and EQ?)
+        case _ =>
+          if (cigarElement.getOperator.consumesReadBases()) {
+            readPos += cigarElement.getLength
+          }
+          if (cigarElement.getOperator.consumesReferenceBases()) {
+            referencePos += cigarElement.getLength
+          }
+      }
+    )
+
+    pileupList
+  }
+
+  def process (reads: RDD[ADAMRecord]): RDD[ADAMPileup] = {
+    log.info ("Converting " + reads.count + " reads into pileups.")
+    
+    val pileups: RDD[ADAMPileup] = reads.flatMap(readToPileups(_))
+
+    log.info ("Total of " + pileups.count + " pileups after conversion.")
+
+    pileups
+  }
+}


### PR DESCRIPTION
There was an issue in the reads2ref aggregation code that would cause out of memory errors when doing a groupBy. I changed this code to set the partition number roughly off of the coverage. I believe this is preferable, but I have provided mechanisms for overriding this if one does not want to increase their partition number, or if one wants to otherwise set the partitioning.

Also, I broke the code up to add a reads2pileups RDD function.
