### PR TITLE
ADAM variant and genotype formats; and a VCF->ADAM converter

### DIFF
--- a/adam-commands/src/main/scala/edu/berkeley/cs/amplab/adam/commands/Vcf2Adam.scala
+++ b/adam-commands/src/main/scala/edu/berkeley/cs/amplab/adam/commands/Vcf2Adam.scala
@@ -1,0 +1,154 @@
+/*
+ * Copyright (c) 2013. The Broad Institute of MIT/Harvard
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package edu.berkeley.cs.amplab.adam.commands
+
+import edu.berkeley.cs.amplab.adam.util.{Args4j, Args4jBase}
+import org.apache.spark.rdd.RDD
+import org.apache.spark.{Logging, SparkContext}
+import org.kohsuke.args4j.{Argument, Option => Args4jOption}
+import edu.berkeley.cs.amplab.adam.avro._
+import java.io.{ByteArrayInputStream, BufferedInputStream, FileInputStream}
+import edu.berkeley.cs.amplab.adam.util._
+import edu.berkeley.cs.amplab.adam.rdd.AdamContext._
+import parquet.hadoop.{ParquetOutputFormat, ParquetInputFormat}
+import org.apache.hadoop.mapreduce.Job
+import org.kohsuke.args4j.{Option => option, Argument}
+import scala.collection.JavaConversions._
+import java.lang.{Integer => JInt}
+import parquet.avro.{AvroReadSupport, AvroWriteSupport}
+import edu.berkeley.cs.amplab.adam.rdd.AdamContext._
+
+object Vcf2Adam extends AdamCommandCompanion {
+
+  val commandName = "vcf2adam"
+  val commandDescription = "Convert a VCF file to the corresponding ADAM format"
+
+  def apply(cmdLine: Array[String]) = {
+    new Vcf2Adam(Args4j[Vcf2AdamArgs](cmdLine))
+  }
+
+}
+
+class Vcf2AdamArgs extends Args4jBase with ParquetArgs with SparkArgs {
+  @Argument(required=true, metaVar="VCF", usage="The VCF file to convert", index=0)
+  var vcfFile: String = _
+  @Argument(required = true, metaVar = "ADAMVariants", usage = "Location to write ADAM Variant data", index = 1)
+  var outputPathV: String = null
+  @Argument(required = true, metaVar = "ADAMGenotypes", usage = "Location to write ADAM genotype data", index = 2)
+  var outputPathG: String = null
+ }
+
+class Vcf2Adam(val args: Vcf2AdamArgs) extends AdamSparkCommand[Vcf2AdamArgs] with Logging {
+  val companion = Vcf2Adam
+
+  def run(sc: SparkContext, job: Job) {
+
+    val source : RDD[String] = sc.textFile(args.vcfFile)
+    val header = source.filter(_.startsWith("#")).collect()
+    val converter = new VcfConverter(header)
+
+    val converted = source.filter(u => ! u.startsWith("#")).map(converter.convert)
+    val variants = converted.map(_._1)
+    val genotypes = converted.flatMap(_._2)
+
+    variants.adamSave(args.outputPathV, args)
+    genotypes.adamSave(args.outputPathG, args)
+  }
+}
+
+class VcfConverter(val header: Array[String]) extends Serializable {
+  def this() = this(Array[String]())
+  // the only important thing for decoding is the map from offset to samples; thus
+
+  val samples = header.filter(_.startsWith("#CHR")).head.split("\t").drop(9)
+
+  def convert(record: String) : (ADAMVariant, List[ADAMGenotype]) = {
+    val fields = record.split("\t")
+
+    val variant = ADAMVariant.newBuilder().setReferenceName(fields(0).asInstanceOf[CharSequence])
+      .setStartPosition(fields(1).toLong)
+      .setVariantId(fields(2))
+      .setReferenceAllele(fields(3))
+      .setAlternateAlleles(fields(4))
+      .setSiteFilter(fields(6))
+      .setType(getType(fields(3),fields(4)))
+
+    // TODO: add back .setInfo(fields(7))
+
+    if ( fields.size == 7 ) {
+      return (variant.build(), List[ADAMGenotype]())
+    }
+
+    val ft = fields(8)
+    val pl_idx = ft.split(":").indexOf("PL")
+    val gl_idx = ft.split(":").indexOf("GL")
+    val hasPL = pl_idx >= 0
+    val hasGL = gl_idx >= 0
+    val records = fields.slice(9,fields.size).map(_.split(":")).zip(samples).map(formatSample => {
+      val gtFormat = formatSample._1
+      val sampleId = formatSample._2
+      val adamGenotype : ADAMGenotype.Builder = ADAMGenotype.newBuilder()
+      val gtField = gtFormat(0)
+      
+      val gt = gtField.split("/|\\|").map(_.toInt.asInstanceOf[JInt]).toList
+      adamGenotype.setGenotype(gt.map(_.toString).reduce(_ + "," + _))
+      
+      adamGenotype.setSampleId(sampleId)
+      if ( hasPL && gtFormat.size > pl_idx) { // TODO: Add back "&& gtFormat(pl_idx).find(".") < 0"
+        val pl = gtFormat(pl_idx).split(",").map(_.toInt.asInstanceOf[JInt]).toList
+        adamGenotype.setPhredLikelihoods(pl.map(_.toString).reduce(_ + "," + _))
+      } else if ( hasGL && gtFormat.size > gl_idx && gtFormat(gl_idx) != ".") {
+        val pl = gtFormat(gl_idx).split(",").map(x => (-10*x.toDouble).toInt.asInstanceOf[JInt]).toList
+        adamGenotype.setPhredLikelihoods(pl.map(_.toString).reduce(_ + "," + _))
+      }
+      if ( gtFormat.size > 2 ) {
+        val keys = ft.split(":").slice(2,gtFormat.size)
+        val vals = gtFormat.slice(2,gtFormat.size)
+        adamGenotype.setFormat(keys.zip(vals).map(c => c._1 + "=" + c._2).reduce(_ + ";" + _))
+      }
+      adamGenotype.setPosition(fields(1).toLong)
+      val geno = adamGenotype.build()
+      geno
+    }).toList
+    
+    val counts = records.flatMap(g => List(g.allele1, g.allele2)).distinct.length
+    variant.setAlleleCount(counts)
+        
+    (variant.build(), records)
+  }
+
+  def getType( ref: String, alt: String) : VariantType = {
+    val altAlleles = alt.split(",")
+    if ( altAlleles.forall(_.startsWith("<")) ) {
+      VariantType.SV
+    }
+    val altSize = altAlleles.map(_.size)
+    val matches = altSize.forall(_ == ref.size)
+    if ( matches ) {
+      if (ref.size == 1 ) VariantType.SNP else VariantType.MNP
+    } else {
+      val isInsert = altAlleles.forall(_.startsWith(ref))
+      if ( isInsert ) {
+        VariantType.Insertion
+      } else if ( altAlleles.forall(ref.startsWith) ) {
+        VariantType.Deletion
+      } else {
+        VariantType.Complex
+      }
+    }
+  }
+}

--- a/adam-format/src/main/resources/avro/adam.avdl
+++ b/adam-format/src/main/resources/avro/adam.avdl
@@ -4,13 +4,11 @@ protocol ADAM {
 record ADAMRecord {
     // Reference name
     union { null, string } referenceName = null;
-
     // Reference id
     union { null, int } referenceId = null;
-
     // 0-based reference position start
     union { null, long } start = null;
-
+    // 0-based reference position end
     union { null, int } mapq = null;
     union { null, string } readName = null;
     union { null, string } sequence = null;
@@ -82,10 +80,6 @@ record ADAMPileup {
     union { null, int } numReverseStrand = null;
     union { null, int } countAtPosition = null;
 
-    union { null, string } readName = null;
-    union { null, long } readStart = null;
-    union { null, long } readEnd = null;
-
     union { null, string } recordGroupSequencingCenter = null;
     union { null, string } recordGroupDescription = null;
     union { null, long } recordGroupRunDateEpoch = null;
@@ -105,26 +99,93 @@ record ADAMNestedPileup {
      array<ADAMRecord> readEvidence;
 }
 
-record ADAMGenotype { // TODO: update with revised qual and likelihood
-    union { null, string } referenceName = null;
-    union { null, int } referenceId = null;
-    union { null, long } position = null;
-    union { null, Base } referenceBase = null;
-    union { null, string } genotype = null;
-    union { null, int } likelihood = null;
-    union { null, string } filter = null;
-    union { null, string } information = null;
+enum VariantType {
+    SNP,
+    MNP,
+    Insertion,
+    Deletion,
+    Complex,
+    SV
+}
 
-    union { null, string } recordGroupSequencingCenter = null;
-    union { null, string } recordGroupDescription = null;
-    union { null, long } recordGroupRunDateEpoch = null;
-    union { null, string } recordGroupFlowOrder = null;
-    union { null, string } recordGroupKeySequence = null;
-    union { null, string } recordGroupLibrary = null;
-    union { null, int } recordGroupPredictedMedianInsertSize = null;
-    union { null, string } recordGroupPlatform = null;
-    union { null, string } recordGroupPlatformUnit = null;
-    union { null, string } recordGroupSample = null;
+record ADAMVariant {
+  union { null, string } domainIds;                      // the domain of the samples (e.g. 1000G or 'Hapmap,1000G' etc)
+  union { null, int } referenceId = null;
+  union { null, string } referenceName = null;
+  union { null, long } startPosition = null;
+  union { null, string } siteId = null;
+  union { null, double } siteQuality = null;
+  union { null, string } siteFilter = null;
+  union { null, string } ancestralAllele = null;
+  union { null, int } alleleCount = null;
+  union { null, string } alleleFrequency = null;
+  union { null, int } alleleNumber = null;
+  union { null, double } rmsBaseQuality = null;
+  union { null, string } allelicAlignments = null;
+  union { null, boolean } inDbSNP = null;
+  union { null, boolean } inHM2 = null;
+  union { null, boolean } inHM3 = null;
+  union { null, boolean } in1000G = null;
+  union { null, double } siteRmsMappingQuality = null;
+  union { null, int } siteMapQZeroCounts = null;
+  union { null, int } numberOfSamplesWithData = null;
+  union { null, double } strandBias = null;
+  union { null, boolean } isSomatic = null;
+  union { null, boolean } validated = null;
+  union { null, string } referenceAllele = null;
+  union { null, string } alternateAlleles = null;
+  union { null, VariantType } type;
+  union { null, string } variantId;
+
+  /* ** site level information -- convenience fields ** */
+  union { null, string } callsetIds = null;
+  union { null, int } callsetsPresent = null;
+  union { null, int } callsetsFiltered = null;
+  union { null, string } geneIds = null;
+  union { null, string } transcriptIds = null;
+
+}
+
+record ADAMGenotype {
+
+  union { null, string } genotype = null;
+  union { null, long } position = null;
+  union { null, string } sampleId = null;
+  union { null, string } referenceAllele = null;
+  union { null, string } siteAlleles = null;
+  union { null, string } allele1 = null;
+  union { null, string } allele2 = null;
+  union { null, double } expectedAllele1Dosage = null;
+  union { null, double } expectedAllele2Dosage = null;
+  union { null, int } genotypeQuality = null;
+  union { null, string } phredLikelihoods = null;
+  union { null, string } phredPosteriorLikelihoods = null;
+  union { null, string } ploidyStateGenotypeLikelihoods = null;
+  union { boolean, null } isPhased = false;
+  union { null, boolean } isPhaseSwitch = false;
+  union { null, string } phaseSetId = null;
+  union { null, double } phaseLikelihood = null;
+  union { null, int } haplotype1Quality = null;
+  union { null, int } haplotype2Quality = null;
+  union { null, double } rmsMappingQuality = null;
+  union { null, int } depth = null;
+  union { null, string } format = null;
+
+  /* ** sample level information -- convenience fields ** */
+  union { null, string } sampleEthnicity = null;
+  union { null, string } sampleCohort = null;
+  
+  union { null, string } recordGroupSequencingCenter = null;
+  union { null, string } recordGroupDescription = null;
+  union { null, long } recordGroupRunDateEpoch = null;
+  union { null, string } recordGroupFlowOrder = null;
+  union { null, string } recordGroupKeySequence = null;
+  union { null, string } recordGroupLibrary = null;
+  union { null, int } recordGroupPredictedMedianInsertSize = null;
+  union { null, string } recordGroupPlatform = null;
+  union { null, string } recordGroupPlatformUnit = null;
+  union { null, string } recordGroupSample = null;
+
 }
 
 }


### PR DESCRIPTION
This is from the old repository, https://github.com/massie/adam/pull/12. This work was contributed by Chris Hartl as part of the work he did during his time at the AMPLab. He's unable to continue contributing work to this project as he's moved on to his next challenge (and will be missed).

This code is not fully clean nor complete yet, but I wanted to get it out into the open. There was a significant amount of discussion around this code when it originally hit the old repository, especially surrounding how to handle additional info fields. In the last PR, Chris had thrown some ideas out. We'd like to find someone to own this code moving forward — barring any volunteers, I will continue the cleanup efforts towards the end of this week.

@massie Matt, can you check the copyright info on the Vcf2Adam.scala file?
