### PR TITLE
Fixes to sorting in ReferencePosition

### DIFF
--- a/adam-commands/src/main/scala/edu/berkeley/cs/amplab/adam/models/ReferencePosition.scala
+++ b/adam-commands/src/main/scala/edu/berkeley/cs/amplab/adam/models/ReferencePosition.scala
@@ -20,6 +20,7 @@ import edu.berkeley.cs.amplab.adam.avro.ADAMRecord
 import edu.berkeley.cs.amplab.adam.rdd.AdamContext._
 import com.esotericsoftware.kryo.{Kryo, Serializer}
 import com.esotericsoftware.kryo.io.{Input, Output}
+import Ordering.Option
 
 object ReferencePositionWithOrientation {
 
@@ -57,8 +58,8 @@ case class ReferencePositionWithOrientation(refPos: Option[ReferencePosition], n
 object ReferencePosition {
 
   def mappedPositionCheck(record: ADAMRecord): Boolean = {
-    val referenceId = Option(record.getReferenceId)
-    val start = Option(record.getStart)
+    val referenceId = Some(record.getReferenceId)
+    val start = Some(record.getStart)
     record.getReadMapped && referenceId.isDefined && start.isDefined
   }
 

--- a/adam-commands/src/main/scala/edu/berkeley/cs/amplab/adam/models/ReferencePositionPair.scala
+++ b/adam-commands/src/main/scala/edu/berkeley/cs/amplab/adam/models/ReferencePositionPair.scala
@@ -3,6 +3,7 @@ package edu.berkeley.cs.amplab.adam.models
 import com.esotericsoftware.kryo.{Kryo, Serializer}
 import com.esotericsoftware.kryo.io.{Input, Output}
 import org.apache.spark.Logging
+import Ordering.Option
 
 object ReferencePositionPair extends Logging {
   initLogging()


### PR DESCRIPTION
When using the ReferencePositionWithOrientation, we were getting the Scala error: `diverging implicit expansion for type scala.math.Ordering[Option[edu.berkeley.cs.amplab.adam.models.ReferencePosition]]`
This is because the Option ordering wasn't implicitly included; this is fixed by importing `Ordering.Option`.

Because of this change, `Option(x)` needs to become `Some()` instead.
