### PR TITLE
Moved record field name enum over to the projections package.

### DIFF
--- a/adam-commands/src/main/scala/edu/berkeley/cs/amplab/adam/commands/FlagStat.scala
+++ b/adam-commands/src/main/scala/edu/berkeley/cs/amplab/adam/commands/FlagStat.scala
@@ -21,8 +21,7 @@ import edu.berkeley.cs.amplab.adam.rdd.AdamContext._
 import org.kohsuke.args4j.Argument
 import org.apache.hadoop.mapreduce.Job
 import edu.berkeley.cs.amplab.adam.avro.ADAMRecord
-import edu.berkeley.cs.amplab.adam.projections.Projection
-import edu.berkeley.cs.amplab.adam.predicates.ADAMRecordField
+import edu.berkeley.cs.amplab.adam.projections.{Projection, ADAMRecordField}
 import java.util.logging.Level
 import org.apache.spark.SparkContext
 import org.apache.spark.rdd.RDD

--- a/adam-commands/src/main/scala/edu/berkeley/cs/amplab/adam/predicates/LocusPredicate.scala
+++ b/adam-commands/src/main/scala/edu/berkeley/cs/amplab/adam/predicates/LocusPredicate.scala
@@ -23,6 +23,7 @@ import parquet.column.ColumnReader
 import parquet.filter.AndRecordFilter.and
 import parquet.filter.ColumnPredicates.equalTo
 import parquet.filter.ColumnRecordFilter.column
+import edu.berkeley.cs.amplab.adam.projections.ADAMRecordField
 
 class LocusPredicate extends UnboundRecordFilter {
   def bind(readers: Iterable[ColumnReader]): RecordFilter = {

--- a/adam-commands/src/main/scala/edu/berkeley/cs/amplab/adam/projections/ADAMRecordField.scala
+++ b/adam-commands/src/main/scala/edu/berkeley/cs/amplab/adam/projections/ADAMRecordField.scala
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package edu.berkeley.cs.amplab.adam.predicates
+package edu.berkeley.cs.amplab.adam.projections
 
 /**
  * This enumeration exist in order to reduce typo errors in the code. It needs to be kept

--- a/adam-commands/src/main/scala/edu/berkeley/cs/amplab/adam/projections/Projection.scala
+++ b/adam-commands/src/main/scala/edu/berkeley/cs/amplab/adam/projections/Projection.scala
@@ -3,7 +3,6 @@ package edu.berkeley.cs.amplab.adam.projections
 import org.apache.avro.Schema
 import scala.collection.JavaConversions._
 import org.apache.avro.Schema.Field
-import edu.berkeley.cs.amplab.adam.predicates.ADAMRecordField
 import edu.berkeley.cs.amplab.adam.avro.ADAMRecord
 
 /**


### PR DESCRIPTION
There is an enum for the field names of each field in the ADAM record that was in the predicate directory. I've moved that over to the projection directory, and updated all references to it. I believe this is a better place for it, as you project fields, and you push down predicates on projections.
