### PR TITLE
Missing brackets in VcfConverter.getType

### DIFF
--- a/adam-commands/src/main/scala/edu/berkeley/cs/amplab/adam/commands/Vcf2Adam.scala
+++ b/adam-commands/src/main/scala/edu/berkeley/cs/amplab/adam/commands/Vcf2Adam.scala
@@ -79,7 +79,7 @@ class VcfConverter(val header: Array[String]) extends Serializable {
       .setReferenceAllele(fields(3))
       .setAlternateAlleles(fields(4))
       .setSiteFilter(fields(6))
-      .setType(getType(fields(3), fields(4)))
+      .setType(VcfConverter.getType(fields(3), fields(4)))
 
     // TODO: add back .setInfo(fields(7))
 
@@ -126,23 +126,28 @@ class VcfConverter(val header: Array[String]) extends Serializable {
     (variant.build(), records)
   }
 
+}
+
+object VcfConverter {
+
   def getType(ref: String, alt: String): VariantType = {
     val altAlleles = alt.split(",")
     if (altAlleles.forall(_.startsWith("<"))) {
       VariantType.SV
-    }
-    val altSize = altAlleles.map(_.size)
-    val matches = altSize.forall(_ == ref.size)
-    if (matches) {
-      if (ref.size == 1) VariantType.SNP else VariantType.MNP
     } else {
-      val isInsert = altAlleles.forall(_.startsWith(ref))
-      if (isInsert) {
-        VariantType.Insertion
-      } else if (altAlleles.forall(ref.startsWith)) {
-        VariantType.Deletion
+      val altSize = altAlleles.map(_.size)
+      val matches = altSize.forall(_ == ref.size)
+      if (matches) {
+        if (ref.size == 1) VariantType.SNP else VariantType.MNP
       } else {
-        VariantType.Complex
+        val isInsert = altAlleles.forall(_.startsWith(ref))
+        if (isInsert) {
+          VariantType.Insertion
+        } else if (altAlleles.forall(ref.startsWith)) {
+          VariantType.Deletion
+        } else {
+          VariantType.Complex
+        }
       }
     }
   }

--- a/adam-commands/src/test/scala/edu/berkeley/cs/amplab/adam/commands/Vcf2AdamSuite.scala
+++ b/adam-commands/src/test/scala/edu/berkeley/cs/amplab/adam/commands/Vcf2AdamSuite.scala
@@ -1,0 +1,22 @@
+/**
+ * Copyright (c) 2013 Genome Bridge LLC
+ */
+package edu.berkeley.cs.amplab.adam.commands
+
+import org.scalatest._
+import edu.berkeley.cs.amplab.adam.avro.VariantType
+
+class Vcf2AdamSuite extends FunSuite {
+
+  test("VcfConverter.getType() is able to return all indicates VariantType values") {
+
+    import VcfConverter._
+
+    assert( getType("A", "T") === VariantType.SNP )
+    assert( getType("AA", "AT") === VariantType.MNP )
+    assert( getType("A", "AA") === VariantType.Insertion )
+    assert( getType("AA", "A") === VariantType.Deletion )
+    assert( getType("AAA", "AA,ATGC") === VariantType.Complex )
+    assert( getType("A", "<AA") === VariantType.SV )
+  }
+}


### PR DESCRIPTION
There were missing brackets, I believe, in the method getType in the class VcfConverter,
which caused the VariantType.SV never to be returned correctly.

I've added a test to make sure that all the types are accessible to the getType method, and
I've moved the method itself to an object (since it depends on none of the fields of the
VcfConverter class itself).
