### PR TITLE
Fixing an issue in pileup generation and in the MdTag util.

### DIFF
--- a/adam-commands/src/main/scala/edu/berkeley/cs/amplab/adam/rdd/Reads2PileupProcessor.scala
+++ b/adam-commands/src/main/scala/edu/berkeley/cs/amplab/adam/rdd/Reads2PileupProcessor.scala
@@ -123,7 +123,7 @@ private[rdd] class Reads2PileupProcessor extends Serializable with Logging {
 
           for (i <- 0 until cigarElement.getLength) {
 
-            val readBase = if (mdTag.isMatch(referencePos)) {
+            val referenceBase = if (mdTag.isMatch(referencePos)) {
               baseFromSequence(readPos)
             } else {
               mdTag.mismatchedBase(referencePos) match {
@@ -134,8 +134,8 @@ private[rdd] class Reads2PileupProcessor extends Serializable with Logging {
 
             // sequence match
             val pileup = populatePileupFromReference(record, referencePos, isReverseStrand, readPos)
-              .setReadBase(readBase)
-              .setReferenceBase(baseFromSequence(readPos))
+              .setReadBase(baseFromSequence(readPos))
+              .setReferenceBase(referenceBase)
               .build()
             pileupList ::= pileup
 

--- a/adam-commands/src/main/scala/edu/berkeley/cs/amplab/adam/util/MdTag.scala
+++ b/adam-commands/src/main/scala/edu/berkeley/cs/amplab/adam/util/MdTag.scala
@@ -25,7 +25,8 @@ object MdTagEvent extends Enumeration {
 object MdTag {
 
   val digitPattern = new Regex("\\d+")
-  val basesPattern = new Regex("[AGCTN]+")
+  // for description, see base enum in adam schema
+  val basesPattern = new Regex("[AaGgCcTtNnUuKkMmRrSsWwBbVvHhDdXx]+")
 
   def apply(mdTag: String, referenceStart: Long): MdTag = {
     new MdTag(mdTag, referenceStart)

--- a/adam-commands/src/test/scala/edu/berkeley/cs/amplab/adam/rdd/PileupConversionSuite.scala
+++ b/adam-commands/src/test/scala/edu/berkeley/cs/amplab/adam/rdd/PileupConversionSuite.scala
@@ -1,0 +1,96 @@
+/*
+ * Copyright (c) 2013. Regents of the University of California
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package edu.berkeley.cs.amplab.adam.rdd
+
+import org.scalatest.FunSuite
+import edu.berkeley.cs.amplab.adam.avro.{ADAMPileup, ADAMRecord, Base}
+
+class PileupConversionSuite extends FunSuite {
+
+  test("can convert a single read with only matches") {
+    val quals = List(30, 20, 40, 20, 10)
+    val qualString: String = quals.map(p => (p + 33).toChar.toString).fold("")(_ + _)
+    val sequence = "ACTAG"
+
+    // build a read with 5 base pairs, all match
+    val record: ADAMRecord = ADAMRecord.newBuilder()
+      .setStart(1L)
+      .setMapq(30)
+      .setSequence(sequence)
+      .setCigar("5M")
+      .setMismatchingPositions("5")
+      .setQual(qualString)
+      .setReadMapped(true)
+      .build()
+
+    val converter = new Reads2PileupProcessor
+
+    // convert pileups
+    val pileups = converter.readToPileups(record)
+    
+    assert(pileups.length === 5)
+    assert(pileups.sortBy(_.getPosition).map(_.getReadBase.toString).fold("")(_ + _) === sequence)
+    assert(pileups.sortBy(_.getPosition).map(p => List(p.getSangerQuality))
+             .fold(List[Int]())(_ ::: _) === quals)
+    assert(pileups.forall(r => r.getReadBase == r.getReferenceBase))
+    assert(pileups.forall(_.getMapQuality == 30))
+    assert(pileups.forall(_.getReadStart == 1L))
+    assert(pileups.forall(_.getReadEnd == 6L))
+    assert(pileups.forall(_.getCountAtPosition == 1))
+    assert(pileups.forall(_.getNumReverseStrand == 0))
+    assert(pileups.forall(_.getNumSoftClipped == 0))
+    assert(pileups.forall(_.getRangeLength == null))
+  }
+
+  test("can convert a single read with matches and mismatches") {
+    val quals = List(30, 20, 40, 20, 10)
+    val qualString: String = quals.map(p => (p + 33).toChar.toString).fold("")(_ + _)
+    val sequence = "ACTAG"
+
+    // build a read with 5 base pairs, all match
+    val record: ADAMRecord = ADAMRecord.newBuilder()
+      .setStart(1L)
+      .setMapq(30)
+      .setSequence(sequence)
+      .setCigar("5M")
+      .setMismatchingPositions("4A0")
+      .setQual(qualString)
+      .setReadMapped(true)
+      .build()
+
+    val converter = new Reads2PileupProcessor
+
+    // convert pileups
+    val pileups = converter.readToPileups(record)
+    
+    assert(pileups.length === 5)
+    assert(pileups.sortBy(_.getPosition).map(_.getReadBase.toString).fold("")(_ + _) === sequence)
+    assert(pileups.sortBy(_.getPosition).map(p => List(p.getSangerQuality))
+             .fold(List[Int]())(_ ::: _) === quals)
+    assert(pileups.filter(_.getPosition < 5L).forall(r => r.getReadBase == r.getReferenceBase))
+    assert(pileups.filter(_.getPosition == 5L).forall(r => r.getReadBase != r.getReferenceBase))
+    assert(pileups.filter(_.getPosition == 5L).forall(r => r.getReferenceBase == Base.A))
+    assert(pileups.forall(_.getMapQuality == 30))
+    assert(pileups.forall(_.getReadStart == 1L))
+    assert(pileups.forall(_.getReadEnd == 6L))
+    assert(pileups.forall(_.getCountAtPosition == 1))
+    assert(pileups.forall(_.getNumReverseStrand == 0))
+    assert(pileups.forall(_.getNumSoftClipped == 0))
+    assert(pileups.forall(_.getRangeLength == null))
+  }
+
+}

--- a/adam-commands/src/test/scala/edu/berkeley/cs/amplab/adam/util/MdTagSuite.scala
+++ b/adam-commands/src/test/scala/edu/berkeley/cs/amplab/adam/util/MdTagSuite.scala
@@ -90,6 +90,20 @@ class MdTagSuite extends FunSuite {
       assert(md6.isMatch(i))
     }
 
+    // seen in 1000G, causes errors in 9c05baa2e0e9c59cbf56e241b8ae3a7b87402fa2
+    val md7 = MdTag("39r36c23")
+    for (i <- 0 until 39) {
+      assert (md7.isMatch(i))
+    }    
+    assert(md7.mismatchedBase(39) == Some('R'))
+    for (i <- 40 until 40 + 36) {
+      assert (md7.isMatch(i))
+    }
+    assert(md7.mismatchedBase(40 + 36) == Some('C'))
+    for (i <- 40 + 37 until 40 + 37 + 23) {
+      assert (md7.isMatch(i))
+    }
+
   }
 
 }

--- a/adam-format/src/main/resources/avro/adam.avdl
+++ b/adam-format/src/main/resources/avro/adam.avdl
@@ -77,7 +77,19 @@ enum Base {
     C,
     T,
     G,
-    N
+    U,
+    N, // any
+    X, // any
+    K, // keto: G/T
+    M, // aMino: A/C
+    R, // puRine: A/G
+    Y, // pYriminidine: C/T
+    S, // Strong: C/G
+    W, // Weak: A/T
+    B, // not A
+    V, // not T
+    H, // not G
+    D  // not C
 }
 
 record ADAMPileup {


### PR DESCRIPTION
This pull request fixes two co-mingled issues that are seen in reads->reference transformation:
- If there is a mismatch, the read and reference bases were swapped in the pileup.
- The MdTag utility could not handle tags with non-[ATGC] bases.

These errors caused significant issues on some 1000Genomes files.

Additionally, I have added test coverage.
