### PR TITLE
Added Apache License 2.0 boilerplate to tops of all the GB-(c) files

### DIFF
--- a/adam-commands/src/main/scala/edu/berkeley/cs/amplab/adam/commands/CompareAdam.scala
+++ b/adam-commands/src/main/scala/edu/berkeley/cs/amplab/adam/commands/CompareAdam.scala
@@ -1,5 +1,17 @@
 /**
- * Copyright (c) 2013. Genome Bridge LLC.
+ * Copyright 2013 Genome Bridge LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 package edu.berkeley.cs.amplab.adam.commands
 

--- a/adam-commands/src/main/scala/edu/berkeley/cs/amplab/adam/commands/ListDict.scala
+++ b/adam-commands/src/main/scala/edu/berkeley/cs/amplab/adam/commands/ListDict.scala
@@ -1,5 +1,17 @@
 /**
- * Copyright (c) 2013 Genome Bridge LLC
+ * Copyright 2013 Genome Bridge LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 package edu.berkeley.cs.amplab.adam.commands
 

--- a/adam-commands/src/main/scala/edu/berkeley/cs/amplab/adam/models/SequenceDictionary.scala
+++ b/adam-commands/src/main/scala/edu/berkeley/cs/amplab/adam/models/SequenceDictionary.scala
@@ -1,5 +1,17 @@
 /**
- * Copyright (c) 2013 Genome Bridge LLC
+ * Copyright 2013 Genome Bridge LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 package edu.berkeley.cs.amplab.adam.models
 

--- a/adam-commands/src/test/scala/edu/berkeley/cs/amplab/adam/commands/CompareAdamSuite.scala
+++ b/adam-commands/src/test/scala/edu/berkeley/cs/amplab/adam/commands/CompareAdamSuite.scala
@@ -1,5 +1,17 @@
 /**
- * Copyright (c) 2013 Genome Bridge LLC
+ * Copyright 2013 Genome Bridge LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 package edu.berkeley.cs.amplab.adam.commands
 

--- a/adam-commands/src/test/scala/edu/berkeley/cs/amplab/adam/commands/Vcf2AdamSuite.scala
+++ b/adam-commands/src/test/scala/edu/berkeley/cs/amplab/adam/commands/Vcf2AdamSuite.scala
@@ -1,5 +1,17 @@
 /**
- * Copyright (c) 2013 Genome Bridge LLC
+ * Copyright 2013 Genome Bridge LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 package edu.berkeley.cs.amplab.adam.commands
 

--- a/adam-commands/src/test/scala/edu/berkeley/cs/amplab/adam/models/SequenceDictionarySuite.scala
+++ b/adam-commands/src/test/scala/edu/berkeley/cs/amplab/adam/models/SequenceDictionarySuite.scala
@@ -1,5 +1,17 @@
 /**
- * Copyright (c) 2013 Genome Bridge LLC
+ * Copyright 2013 Genome Bridge LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 package edu.berkeley.cs.amplab.adam.models
 

--- a/adam-commands/src/test/scala/edu/berkeley/cs/amplab/adam/rdd/AdamContextSuite.scala
+++ b/adam-commands/src/test/scala/edu/berkeley/cs/amplab/adam/rdd/AdamContextSuite.scala
@@ -1,5 +1,17 @@
 /**
- * Copyright (c) 2013 Genome Bridge LLC
+ * Copyright 2013 Genome Bridge LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 package edu.berkeley.cs.amplab.adam.rdd
 


### PR DESCRIPTION
Matt, as requested, here's the pull request adding the Apache 2.0 License statement to the tops of all the files with the "Copyright 2013 Genome Bridge LLC" already in them.  
