### PR TITLE
Adding support for before, after clauses to SparkFunSuite.

### DIFF
--- a/adam-commands/src/test/scala/edu/berkeley/cs/amplab/adam/util/SparkFunSuite.scala
+++ b/adam-commands/src/test/scala/edu/berkeley/cs/amplab/adam/util/SparkFunSuite.scala
@@ -15,47 +15,84 @@
  */
 package edu.berkeley.cs.amplab.adam.util
 
-import org.scalatest.FunSuite
+import org.scalatest.{BeforeAndAfter, FunSuite}
 import org.apache.spark.SparkContext
 import edu.berkeley.cs.amplab.adam.commands.SparkCommand
 import java.net.ServerSocket
+import org.apache.log4j.Level
 
 object SparkTest extends org.scalatest.Tag("edu.berkeley.cs.amplab.util.SparkFunSuite")
 
-trait SparkFunSuite extends FunSuite {
+trait SparkFunSuite extends FunSuite with BeforeAndAfter {
+
   val sparkPortProperty = "spark.driver.port"
   var sc: SparkContext = _
+  var maybeLevels : Option[Map[String,Level]] = None
+
+  def createSpark(sparkName : String, silenceSpark : Boolean = true) : SparkContext = {
+    // Use the same context properties as ADAM commands
+    SparkCommand.setupContextProperties()
+    // Silence the Spark logs if requested
+    maybeLevels = if (silenceSpark) Some(SparkLogUtil.silenceSpark()) else None
+    synchronized {
+      // Find an unused port
+      val s = new ServerSocket(0)
+      System.setProperty(sparkPortProperty, s.getLocalPort.toString)
+      // Allow Spark to take the port we just discovered
+      s.close()
+      // Create a spark context
+      new SparkContext("local[4]", sparkName)
+    }
+  }
+
+  def destroySpark() {
+    // Stop the context
+    sc.stop()
+    sc = null
+    maybeLevels match {
+      case None =>
+      case Some(levels) =>
+        for ((className, level) <- levels) {
+          SparkLogUtil.setLogLevels(level, List(className))
+        }
+    }
+  }
+
+  def sparkBefore(beforeName : String, silenceSpark : Boolean = true)(body : => Unit) {
+    before {
+      sc = createSpark(beforeName, silenceSpark)
+      try {
+        // Run the before block
+        body
+      }
+      finally {
+        destroySpark()
+      }
+    }
+  }
+
+  def sparkAfter(beforeName : String, silenceSpark : Boolean = true)(body : => Unit) {
+    after {
+      sc = createSpark(beforeName, silenceSpark)
+      try {
+        // Run the after block
+        body
+      }
+      finally {
+        destroySpark()
+      }
+    }
+  }
 
   def sparkTest(name: String, silenceSpark: Boolean = true)(body: => Unit) {
     test(name, SparkTest) {
-      // Use the same context properties as ADAM commands
-      SparkCommand.setupContextProperties()
-      // Silence the Spark logs if requested
-      val maybeLevels = if (silenceSpark) Some(SparkLogUtil.silenceSpark()) else None
-      synchronized {
-        // Find an unused port
-        val s = new ServerSocket(0)
-        System.setProperty(sparkPortProperty, s.getLocalPort.toString)
-        // Allow Spark to take the port we just discovered
-        s.close()
-        // Create a spark context
-        sc = new SparkContext("local[4]", name)
-      }
+      sc = createSpark(name, silenceSpark)
       try {
         // Run the test
         body
       }
       finally {
-        // Stop the context
-        sc.stop()
-        sc = null
-        maybeLevels match {
-          case None =>
-          case Some(levels) =>
-            for ((className, level) <- levels) {
-              SparkLogUtil.setLogLevels(level, List(className))
-            }
-        }
+        destroySpark()
       }
     }
   }


### PR DESCRIPTION
I had a problem, with another branch, where I couldn't access the SparkContext inside a before{}
or after{} block in a SparkFunSuite.  This tries to fix that problem -- and refactors the creation
and destruction of the sparkcontext into separate methods for reuse.

I'm not sure if there's a problem though, with multi-threaded execution of tests?  This seems fragile,
somehow, and could use some comments/review.
