### PR TITLE
Fix build warnings

### DIFF
--- a/adam-commands/src/main/scala/edu/berkeley/cs/amplab/adam/commands/AdamCommand.scala
+++ b/adam-commands/src/main/scala/edu/berkeley/cs/amplab/adam/commands/AdamCommand.scala
@@ -44,7 +44,7 @@ trait AdamSparkCommand[A <: Args4jBase with SparkArgs] extends AdamCommand with 
 
   def run() {
     val sc: SparkContext = createSparkContext(args)
-    val job = new Job()
+    val job = Job.getInstance()
 
     run(sc, job)
   }

--- a/adam-commands/src/main/scala/edu/berkeley/cs/amplab/adam/commands/VariantContextConverter.scala
+++ b/adam-commands/src/main/scala/edu/berkeley/cs/amplab/adam/commands/VariantContextConverter.scala
@@ -319,6 +319,31 @@ class VariantContextConverter extends Serializable {
     vc
   }
 
+  def getAttributeAsString(g: Genotype, attribute: String, default: String = ""): String = {
+    if (g.hasExtendedAttribute(attribute)) {
+      g.getExtendedAttribute(attribute) match {
+        case null => default
+        case s : String => s
+        case o : AnyRef => String.valueOf(o)
+      }
+    } else {
+      default
+    }
+  }
+
+  def getAttributeAsInt(g: Genotype, attribute: String, default: Int = 0): Int = {
+    if (g.hasExtendedAttribute(attribute)) {
+      g.getExtendedAttribute(attribute) match {
+        case null => default
+        case i : java.lang.Integer => i
+        case o : AnyRef => Integer.valueOf(String.valueOf(o))
+      }
+    } else {
+      default
+    }
+  }
+
+
   /**
    * Converts a GATK variant context into a set of genotypes. Genotype numbering corresponds
    * to allele numbering of variants at same locus.
@@ -345,7 +370,7 @@ class VariantContextConverter extends Serializable {
       var haplotype = 0
 
       val haplotypeQual = if (g.hasExtendedAttribute("HQ")) {
-        vcfListToInts(g.getAttributeAsString("HQ", ""))
+        vcfListToInts(getAttributeAsString(g, "HQ"))
       } else {
         List[Int]()
       }
@@ -375,11 +400,11 @@ class VariantContextConverter extends Serializable {
         // set phasing specific fields
         if (g.isPhased) {
           if (g.hasExtendedAttribute("PQ")) {
-            builder.setPhaseQuality(g.getAttributeAsInt("PQ", 0))
+            builder.setPhaseQuality(getAttributeAsInt(g, "PQ"))
           }
         
           if (g.hasExtendedAttribute("PS")) {
-            builder.setPhaseSetId(g.getAttributeAsString("PS", ""))
+            builder.setPhaseSetId(getAttributeAsString(g, "PS"))
           }
         }
 
@@ -392,15 +417,15 @@ class VariantContextConverter extends Serializable {
         }
 
         if (g.hasExtendedAttribute("GP")) {
-          builder.setPhredPosteriorLikelihoods(g.getAttributeAsString("GP", ""))
+          builder.setPhredPosteriorLikelihoods(getAttributeAsString(g, "GP"))
         }
 
         if (g.hasExtendedAttribute("MQ")) {
-          builder.setRmsMappingQuality(g.getAttributeAsInt("MQ", 0))
+          builder.setRmsMappingQuality(getAttributeAsInt(g, "MQ"))
         }
 
         if (g.hasExtendedAttribute("GQL")) {
-          builder.setPloidyStateGenotypeLikelihoods(g.getAttributeAsString("GQL", ""))
+          builder.setPloidyStateGenotypeLikelihoods(getAttributeAsString(g, "GQL"))
         }
 
         // increment haplotype count

--- a/adam-commands/src/main/scala/edu/berkeley/cs/amplab/adam/rdd/AdamContext.scala
+++ b/adam-commands/src/main/scala/edu/berkeley/cs/amplab/adam/rdd/AdamContext.scala
@@ -103,7 +103,7 @@ class AdamContext(sc: SparkContext) extends Serializable with Logging {
     // below).
     val seqDict = adamBamDictionaryLoad(filePath)
 
-    val job = new Job(sc.hadoopConfiguration)
+    val job = Job.getInstance(sc.hadoopConfiguration)
     val records = sc.newAPIHadoopFile(filePath, classOf[AnySAMInputFormat], classOf[LongWritable],
       classOf[SAMRecordWritable], ContextUtil.getConfiguration(job))
     val samRecordConverter = new SAMRecordConverter
@@ -113,7 +113,7 @@ class AdamContext(sc: SparkContext) extends Serializable with Logging {
   private def adamParquetLoad[T <% SpecificRecord : Manifest, U <: UnboundRecordFilter]
   (filePath: String, predicate: Option[Class[U]] = None, projection: Option[Schema] = None): RDD[T] = {
     log.info("Reading the ADAM file at %s to create RDD".format(filePath))
-    val job = new Job(sc.hadoopConfiguration)
+    val job = Job.getInstance(sc.hadoopConfiguration)
     ParquetInputFormat.setReadSupportClass(job, classOf[AvroReadSupport[T]])
     if (predicate.isDefined) {
       log.info("Using the specified push-down predicate")
@@ -207,7 +207,7 @@ class AdamContext(sc: SparkContext) extends Serializable with Logging {
    */
   private def adamVcfLoad (filePath: String): RDD[ADAMVariantContext] = {
     log.info("Reading legacy VCF file format %s to create RDD".format(filePath))
-    val job = new Job(sc.hadoopConfiguration)
+    val job = Job.getInstance(sc.hadoopConfiguration)
     val records = sc.newAPIHadoopFile(filePath, classOf[VCFInputFormat], classOf[LongWritable],
                                       classOf[VariantContextWritable], ContextUtil.getConfiguration(job))
       .map(_._2)

--- a/adam-commands/src/main/scala/edu/berkeley/cs/amplab/adam/rdd/AdamRDDFunctions.scala
+++ b/adam-commands/src/main/scala/edu/berkeley/cs/amplab/adam/rdd/AdamRDDFunctions.scala
@@ -38,7 +38,7 @@ class AdamRDDFunctions[T <% SpecificRecord : Manifest](rdd: RDD[T]) extends Seri
   def adamSave(filePath: String, blockSize: Int = 128 * 1024 * 1024,
                pageSize: Int = 1 * 1024 * 1024, compressCodec: CompressionCodecName = CompressionCodecName.GZIP,
                disableDictionaryEncoding: Boolean = false): RDD[T] = {
-    val job = new Job(rdd.context.hadoopConfiguration)
+    val job = Job.getInstance(rdd.context.hadoopConfiguration)
     ParquetOutputFormat.setWriteSupportClass(job, classOf[AvroWriteSupport])
     ParquetOutputFormat.setCompression(job, compressCodec)
     ParquetOutputFormat.setEnableDictionary(job, !disableDictionaryEncoding)

--- a/adam-commands/src/main/scala/edu/berkeley/cs/amplab/adam/util/ParquetFileTraversable.scala
+++ b/adam-commands/src/main/scala/edu/berkeley/cs/amplab/adam/util/ParquetFileTraversable.scala
@@ -31,7 +31,7 @@ class ParquetFileTraversable[T <: IndexedRecord](sc: SparkContext, file: Path) e
     }
     val status = fs.getFileStatus(file)
     var paths = List[Path]()
-    if (status.isDir) {
+    if (status.isDirectory) {
       val files = fs.listStatus(file)
       files.foreach {
         file =>
@@ -39,8 +39,7 @@ class ParquetFileTraversable[T <: IndexedRecord](sc: SparkContext, file: Path) e
             paths ::= file.getPath
           }
       }
-    }
-    else if (fs.isFile(file)) {
+    } else if (status.isFile) {
       paths ::= file
     } else {
       throw new IllegalArgumentException("The path '%s' is neither file nor directory".format(file))

--- a/adam-commands/src/main/scala/edu/berkeley/cs/amplab/adam/util/PileupTraversable.scala
+++ b/adam-commands/src/main/scala/edu/berkeley/cs/amplab/adam/util/PileupTraversable.scala
@@ -83,7 +83,7 @@ object PileupTraversable {
 class PileupTraversable(sc: SparkContext, reads: RDD[(Void, ADAMRecord)]) extends Traversable[Pileup] with Serializable {
 
   def this(sc: SparkContext, file: String) = this(sc, {
-    val job = new Job()
+    val job = Job.getInstance()
     ParquetInputFormat.setReadSupportClass(job, classOf[AvroReadSupport[ADAMRecord]])
     ParquetInputFormat.setUnboundRecordFilter(job, classOf[LocusPredicate])
     sc.newAPIHadoopFile(file,

--- a/pom.xml
+++ b/pom.xml
@@ -89,6 +89,7 @@
                         <arg>-unchecked</arg>
                         <arg>-optimise</arg>
                         <arg>-deprecation</arg>
+                        <arg>-Xfatal-warnings</arg>
                     </args>
                     <jvmArgs>
                         <jvmArg>-Xms64m</jvmArg>


### PR DESCRIPTION
There were a few build errors that have been collecting. I've fixed them, and also made warnings fatal so that they are addressed earlier.

All of the changes were because of deprecation in an imported library; most were related to Hadoop's Job constructor being deprecated. The biggest change was in Genotype.getAttributeAsString. I don't know why it was deprecated, but I've included a scala version of it.
