### PR TITLE
Fixing a few issues in the ADAM2VCF2ADAM pipeline.

### DIFF
--- a/adam-commands/src/main/scala/edu/berkeley/cs/amplab/adam/AdamMain.scala
+++ b/adam-commands/src/main/scala/edu/berkeley/cs/amplab/adam/AdamMain.scala
@@ -29,7 +29,9 @@ object AdamMain {
     PileupAggregator,
     ListDict,
     CompareAdam,
-    ComputeVariants)
+    ComputeVariants,
+    Adam2Vcf,
+    Vcf2Adam)
 
   private def printCommands() {
     println("\n")

--- a/adam-commands/src/main/scala/edu/berkeley/cs/amplab/adam/commands/Adam2Vcf.scala
+++ b/adam-commands/src/main/scala/edu/berkeley/cs/amplab/adam/commands/Adam2Vcf.scala
@@ -31,8 +31,9 @@ import edu.berkeley.cs.amplab.adam.models.ADAMVariantContext
 import parquet.hadoop.{ParquetOutputFormat, ParquetInputFormat}
 import parquet.avro.{AvroReadSupport, AvroWriteSupport}
 import org.apache.hadoop.mapreduce.Job
+import org.apache.hadoop.conf.Configuration
 import org.apache.hadoop.io.LongWritable
-import fi.tkk.ics.hadoop.bam.{VariantContextWritable, VCFOutputFormat}
+import fi.tkk.ics.hadoop.bam.{VariantContextWritable, VCFOutputFormat, VCFFormat}
 
 object Adam2Vcf extends AdamCommandCompanion {
 
@@ -72,6 +73,14 @@ class Adam2Vcf(val args: Adam2VcfArgs) extends AdamSparkCommand[Adam2VcfArgs] wi
 
     // add index for writing output format
     val mapIndex = variantContexts.keyBy(r => new LongWritable(r.get.getStart))
+
+    log.info("Counted " + variantContexts.count + " variants.")
+
+    // new context
+    val conf = sc.hadoopConfiguration
+    val vcfFormat = VCFFormat.valueOf("VCF")
+    conf.set(VCFOutputFormat.OUTPUT_VCF_FORMAT_PROPERTY,
+             vcfFormat.toString)
 
     // write out
     mapIndex.saveAsNewAPIHadoopFile(args.outputPath, classOf[LongWritable], classOf[VariantContextWritable],

--- a/adam-commands/src/main/scala/edu/berkeley/cs/amplab/adam/commands/VariantContextConverter.scala
+++ b/adam-commands/src/main/scala/edu/berkeley/cs/amplab/adam/commands/VariantContextConverter.scala
@@ -141,16 +141,24 @@ class VariantContextConverter extends Serializable {
       None
     }
 
+    def getIntOrDoubleAttributeAsInt (key: String): Option[Int] = {
+      vc.getAttribute(key) match {
+        case (d: java.lang.Double) => Some(d.toInt)
+        case (i: java.lang.Integer) => Some(i)
+        case _ => None
+      }
+    }
+
     // RMS quality of bases mapped to site
-    val baseQuality = if (vc.hasAttribute("BQ")) {
-      Some(vc.getAttributeAsInt("BQ", 0))
+    val baseQuality: Option[Int] = if (vc.hasAttribute("BQ")) {
+      getIntOrDoubleAttributeAsInt("BQ")
     } else {
       None
     }
 
     // RMS mapping quality of reads mapped to site
-    val mapQuality = if (vc.hasAttribute("MQ")) {
-      Some(vc.getAttributeAsInt("MQ", 0))
+    val mapQuality: Option[Int] = if (vc.hasAttribute("MQ")) {
+      getIntOrDoubleAttributeAsInt("MQ")
     } else {
       None
     }
@@ -421,7 +429,13 @@ class VariantContextConverter extends Serializable {
         }
 
         if (g.hasExtendedAttribute("MQ")) {
-          builder.setRmsMappingQuality(getAttributeAsInt(g, "MQ"))
+          val mq: Option[Int] = g.getExtendedAttribute("MQ") match {
+            case (d: java.lang.Double) => Some(d.toInt)
+            case (i: java.lang.Integer) => Some(i)
+            case _ => None
+          }
+
+          mq.foreach(builder.setRmsMappingQuality(_))
         }
 
         if (g.hasExtendedAttribute("GQL")) {


### PR DESCRIPTION
Fixed a few issues:
- Adam2VCF and VCF2Adam were not included in AdamMain.
- A few processes in the GenotypesToVariant converter had possibly empty reductions, which could cause runtime exceptions.
- Set additional required fields for the Hadoop-BAM VCFOutputFormat in Adam2VCF.
