### PR TITLE
ReferenceRegion represents a contiguous genomic region.

### DIFF
--- a/adam-commands/src/main/scala/edu/berkeley/cs/amplab/adam/models/ReferenceRegion.scala
+++ b/adam-commands/src/main/scala/edu/berkeley/cs/amplab/adam/models/ReferenceRegion.scala
@@ -1,0 +1,96 @@
+/**
+ * Copyright 2013 Genome Bridge LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package edu.berkeley.cs.amplab.adam.models
+
+import com.esotericsoftware.kryo.{Kryo, Serializer}
+import com.esotericsoftware.kryo.io.{Input, Output}
+import scala.math.{min, max}
+
+/**
+ * Represents a contiguous region of the reference genome.
+ *
+ * @param refId The index of the sequence (chromosome) in the reference genome
+ * @param start The 0-based residue-coordinate for the start of the region
+ * @param end The 0-based residue-coordinate for the first residue <i>after</i> the start
+ *            which is <i>not</i> in the region -- i.e. [start, end) define a 0-based
+ *            half-open interval.
+ */
+case class ReferenceRegion(refId : Int, start : Long, end : Long) extends Ordered[ReferenceRegion] {
+
+  assert(start >= 0)
+  assert(end >= start)
+
+  def width : Long = end - start
+
+  def union(region : ReferenceRegion) : ReferenceRegion = {
+    assert(overlaps(region), "Cannot compute union of two non-overlapping regions")
+    ReferenceRegion(refId, min(start, region.start), max(end, region.end))
+  }
+
+  def distance(other : ReferencePosition) : Option[Long] =
+    if(refId == other.refId)
+      if(other.pos < start)
+        Some(start - other.pos)
+      else if (other.pos >= end)
+        Some(other.pos - end)
+      else
+        Some(0)
+    else
+      None
+
+  def distance(other : ReferenceRegion) : Option[Long] =
+    if(refId == other.refId)
+      if(overlaps(other))
+        Some(0)
+      else if (other.start >= end)
+        Some(other.start - end)
+      else
+        Some(start - other.end)
+    else
+      None
+
+  def contains(other : ReferencePosition) : Boolean =
+    refId == other.refId && start <= other.pos && end > other.pos
+
+  def contains(other : ReferenceRegion) : Boolean =
+    refId == other.refId && start <= other.start && end >= other.end
+
+  def overlaps(other : ReferenceRegion) : Boolean =
+    refId == other.refId && end > other.start && start < other.end
+
+  def compare(that: ReferenceRegion): Int =
+    if(refId != that.refId)
+      refId.compareTo(that.refId)
+    else if(start != that.start)
+      start.compareTo(that.start)
+    else
+      end.compareTo(that.end)
+}
+
+class ReferenceRegionSerializer extends Serializer[ReferenceRegion] {
+  def write(kryo: Kryo, output: Output, obj: ReferenceRegion) = {
+    output.writeInt(obj.refId)
+    output.writeLong(obj.start)
+    output.writeLong(obj.end)
+  }
+
+  def read(kryo: Kryo, input: Input, klazz: Class[ReferenceRegion]): ReferenceRegion = {
+    val refId = input.readInt()
+    val start = input.readLong()
+    val end = input.readLong()
+    new ReferenceRegion(refId, start, end)
+  }
+}

--- a/adam-commands/src/main/scala/edu/berkeley/cs/amplab/adam/util/IntervalListReader.scala
+++ b/adam-commands/src/main/scala/edu/berkeley/cs/amplab/adam/util/IntervalListReader.scala
@@ -1,0 +1,107 @@
+/**
+ * Copyright 2013 Genome Bridge LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package edu.berkeley.cs.amplab.adam.util
+
+import java.io.File
+import scala.io._
+import scala.collection._
+import java.util.regex._
+import edu.berkeley.cs.amplab.adam.models.{SequenceDictionary, SequenceRecord, ReferenceRegion}
+
+/**
+ * Reads GATK-style interval list files
+ * e.g. example file taken from this page:
+ * http://www.broadinstitute.org/gatk/guide/article?id=1204
+ *
+ * @param file a File whose contents are a (line-based tab-separated) interval file in UTF-8 encoding
+ */
+class IntervalListReader(file : File) extends Traversable[(ReferenceRegion,String)] {
+
+  val encoding = "UTF-8"
+  private var seqDict : SequenceDictionary = null
+
+  /**
+   * The interval list file contains a SAM-style sequence dictionary as a header --
+   * this value holds that dictionary, reading it if necessary (if the file hasn't been
+   * opened before).
+   */
+  lazy val sequenceDictionary = loadSequenceDictionary()
+
+  private def loadSequenceDictionary() : SequenceDictionary = {
+    val headerLines = Source.fromFile(file, encoding).getLines().filter(_.startsWith("@SQ"))
+    val headerReader = new HeaderReader()
+    headerLines.foreach(headerReader.takeLine)
+
+    headerReader.sequenceDictionary
+  }
+
+  def foreach[U](f: ((ReferenceRegion, String)) => U) {
+    val lines : Iterator[String] = Source.fromFile(file, encoding).getLines()
+
+    lines.filter(!_.startsWith("@")).foreach {
+      line =>
+        val array = line.split("\t")
+        val refId = array(0).toInt
+        val start = array(1).toLong
+        val end = array(2).toLong
+        val strand = array(3)
+        val name = array(4)
+
+        assert(strand=="+")
+
+        f( (ReferenceRegion(refId, start, end), name) )
+    }
+  }
+
+  class HeaderReader {
+
+    val sequenceRecords = mutable.ListBuffer[SequenceRecord]()
+    val regex = Pattern.compile("(\\w{2}):(.*)")
+    var nextSequenceId = 0
+
+    def sequenceDictionary : SequenceDictionary = SequenceDictionary(sequenceRecords : _*)
+
+    def takeLine(line : String) {
+      if(line.startsWith("@SQ")) {
+        val array : Array[String] = line.split("\t")
+
+        var name : String = null
+        var length : Long = null.asInstanceOf[Long]
+        var url : String = null
+
+        (1 until array.length).foreach {
+          idx =>
+            val matcher = regex.matcher(array(idx))
+            if(matcher.matches()) {
+              val tag = matcher.group(1)
+              val arg = matcher.group(2)
+
+              tag match {
+                case "SN" => name = arg
+                case "UR" => url = arg
+                case "LN" => length = arg.toLong
+                case _ => None
+              }
+            }
+        }
+
+        sequenceRecords ++= List(SequenceRecord(nextSequenceId, name, length, url))
+        nextSequenceId += 1
+      }
+
+    }
+  }
+}

--- a/adam-commands/src/test/resources/example_intervals.list
+++ b/adam-commands/src/test/resources/example_intervals.list
@@ -1,0 +1,9 @@
+@HD	VN:1.0	SO:coordinate
+@SQ	SN:1	LN:249250621	AS:GRCh37	UR:http://www.broadinstitute.org/ftp/pub/seq/references/Homo_sapiens_assembly19.fasta	M5:1b22b98cdeb4a9304cb5d48026a85128	SP:Homo Sapiens
+@SQ	SN:2	LN:243199373	AS:GRCh37	UR:http://www.broadinstitute.org/ftp/pub/seq/references/Homo_sapiens_assembly19.fasta	M5:a0d9851da00400dec1098a9255ac712e	SP:Homo Sapiens
+1	30366	30503	+	target_1
+1	69089	70010	+	target_2
+1	367657	368599	+	target_3
+1	621094	622036	+	target_4
+1	861320	861395	+	target_5
+1	865533	865718	+	target_6

--- a/adam-commands/src/test/scala/edu/berkeley/cs/amplab/adam/models/ReferenceRegionSuite.scala
+++ b/adam-commands/src/test/scala/edu/berkeley/cs/amplab/adam/models/ReferenceRegionSuite.scala
@@ -1,0 +1,126 @@
+/**
+ * Copyright 2013 Genome Bridge LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package edu.berkeley.cs.amplab.adam.models
+
+import org.scalatest._
+
+class ReferenceRegionSuite extends FunSuite {
+
+  test("contains(: ReferenceRegion)") {
+    assert( region(0, 10, 100).contains(region(0, 50, 70)) )
+    assert( region(0, 10, 100).contains(region(0, 10, 100)) )
+    assert( !region(0, 10, 100).contains(region(1, 50, 70)))
+    assert( region(0, 10, 100).contains(region(0, 50, 100)) )
+    assert( !region(0, 10, 100).contains(region(0, 50, 101)) )
+  }
+
+  test("contains(: ReferencePosition)") {
+    assert( region(0, 10, 100).contains(point(0, 50)))
+    assert( region(0, 10, 100).contains(point(0, 10)))
+    assert( region(0, 10, 100).contains(point(0, 99)))
+    assert( !region(0, 10, 100).contains(point(0, 100)))
+    assert( !region(0, 10, 100).contains(point(1, 50)))
+  }
+
+  test("union") {
+    intercept[AssertionError] {
+      region(0, 10, 100).union(region(1, 10, 100))
+    }
+
+    val r1 = region(0, 10, 100)
+    val r2 = region(0, 0, 15)
+    val r3 = region(0, 50, 150)
+
+    val r12 = region(0, 0, 100)
+    val r13 = region(0, 10, 150)
+
+    assert(r1.union(r1) === r1)
+    assert(r1.union(r2) === r12)
+    assert(r1.union(r3) === r13)
+  }
+
+  test("overlaps") {
+
+    // contained
+    assert( region(0, 10, 100).overlaps(region(0, 20, 50)))
+
+    // right side
+    assert( region(0, 10, 100).overlaps(region(0, 50, 250)))
+
+    // left side
+    assert( region(0, 10, 100).overlaps(region(0, 5, 15)) )
+
+    // left edge
+    assert( region(0, 10, 100).overlaps(region(0, 5, 11)) )
+    assert( !region(0, 10, 100).overlaps(region(0, 5, 10)) )
+
+    // right edge
+    assert( region(0, 10, 100).overlaps(region(0, 99, 200)) )
+    assert( !region(0, 10, 100).overlaps(region(0, 100, 200)))
+
+    // different sequences
+    assert( !region(0, 10, 100).overlaps(region(1, 50, 200)) )
+  }
+
+  test("distance(: ReferenceRegion)") {
+
+    // distance on the right
+    assert( region(0, 10, 100).distance(region(0, 200, 300)) === Some(100))
+
+    // distance on the left
+    assert( region(0, 100, 200).distance(region(0, 10, 50)) === Some(50))
+
+    // different sequences
+    assert( region(0, 100, 200).distance(region(1, 10, 50)) === None)
+
+    // touches on the right
+    assert( region(0, 10, 100).distance(region(0, 100, 200)) === Some(0))
+
+    // overlaps
+    assert( region(0, 10, 100).distance(region(0, 50, 150)) === Some(0))
+
+    // touches on the left
+    assert( region(0, 10, 100).distance(region(0, 0, 10)) === Some(0))
+  }
+
+  test("distance(: ReferencePosition)") {
+
+    // middle
+    assert( region(0, 10, 100).distance(point(0, 50)) === Some(0))
+
+    // left edge
+    assert( region(0, 10, 100).distance(point(0, 10)) === Some(0))
+
+    // right edge
+    assert( region(0, 10, 100).distance(point(0, 100)) === Some(0))
+
+    // right
+    assert( region(0, 10, 100).distance(point(0, 150)) === Some(50))
+
+    // left
+    assert( region(0, 100, 200).distance(point(0, 50)) === Some(50))
+
+    // different sequences
+    assert( region(0, 100, 200).distance(point(1, 50)) === None)
+
+  }
+
+  def region(refId : Int, start : Long, end : Long) : ReferenceRegion =
+    ReferenceRegion(refId, start, end)
+
+  def point(refId : Int, pos : Long) : ReferencePosition =
+    ReferencePosition(refId, pos)
+}

--- a/adam-commands/src/test/scala/edu/berkeley/cs/amplab/adam/util/IntervalListReaderSuite.scala
+++ b/adam-commands/src/test/scala/edu/berkeley/cs/amplab/adam/util/IntervalListReaderSuite.scala
@@ -1,0 +1,43 @@
+/**
+ * Copyright 2013 Genome Bridge LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package edu.berkeley.cs.amplab.adam.util
+
+import org.scalatest._
+import java.io.File
+import edu.berkeley.cs.amplab.adam.models.ReferenceRegion
+
+class IntervalListReaderSuite extends FunSuite {
+
+  test("Can read the simple GATK-supplied example interval list file") {
+    val file = new File(ClassLoader.getSystemClassLoader.getResource("example_intervals.list").getFile)
+
+    val reader = new IntervalListReader(file)
+
+    val intervals : Seq[(ReferenceRegion,String)] = reader.toSeq
+
+    assert(intervals.size === 6)
+
+    (1 until 6).foreach {
+      idx =>
+        assert(intervals(idx-1)._2 === "target_%d".format(idx))
+    }
+
+    assert(reader.sequenceDictionary != null, "sequence dictionary was null")
+    assert(reader.sequenceDictionary.records.size === 2)
+    assert(reader.sequenceDictionary("1").length === 249250621)
+    assert(reader.sequenceDictionary("2").length === 243199373)
+  }
+}


### PR DESCRIPTION
ReferenceRegion is a model representing a contiguous region of a single reference sequence.
I imagine using RR for:
- interval lists representing the target set in exome or gene panel sequencing
- a base for extending to support reference annotations
- binding events in ChIP-seq
- arbitrary "regions of interest" determined as an intermediate result during other calculations.

Anyway, we should have one base model supporting a lot of the common operations of interest
for regions in general.

Added support for Kryo serialization.

Included methods for calculating distance and overlap.
