### PR TITLE
Update Spark to 0.8.1 and add hadoop2.2 profile

### DIFF
--- a/adam-cli/pom.xml
+++ b/adam-cli/pom.xml
@@ -1,4 +1,5 @@
-<?xml version="1.0" encoding="UTF-8"?>
+<?xml version="1.0"
+        encoding="UTF-8"?>
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
@@ -30,6 +31,12 @@
                     </transformers>
                     <finalName>adam-${project.version}</finalName>
                     <filters>
+                        <filter>
+                            <artifact>org.apache.hadoop:hadoop-common</artifact>
+                            <excludes>
+                                <exclude>META-INF/services/org.apache.hadoop.fs.FileSystem</exclude>
+                            </excludes>
+                        </filter>
                         <filter>
                             <artifact>*:*</artifact>
                             <excludes>
@@ -99,6 +106,22 @@
         <dependency>
             <groupId>edu.berkeley.cs.amplab.adam</groupId>
             <artifactId>adam-core</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>${akka.group}</groupId>
+            <artifactId>akka-actor</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>${akka.group}</groupId>
+            <artifactId>akka-remote</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>${akka.group}</groupId>
+            <artifactId>akka-slf4j</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>${akka.group}</groupId>
+            <artifactId>akka-zeromq</artifactId>
         </dependency>
         <dependency>
             <groupId>org.slf4j</groupId>

--- a/adam-core/pom.xml
+++ b/adam-core/pom.xml
@@ -52,6 +52,22 @@
 
     <dependencies>
         <dependency>
+            <groupId>${akka.group}</groupId>
+            <artifactId>akka-actor</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>${akka.group}</groupId>
+            <artifactId>akka-remote</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>${akka.group}</groupId>
+            <artifactId>akka-slf4j</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>${akka.group}</groupId>
+            <artifactId>akka-zeromq</artifactId>
+        </dependency>
+        <dependency>
             <groupId>org.apache.hadoop</groupId>
             <artifactId>hadoop-client</artifactId>
         </dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -19,8 +19,11 @@
         <scala.version>2.9.3</scala.version>
         <avro.version>1.7.4</avro.version>
         <hadoop.version>2.2.0</hadoop.version>
-        <spark.version>0.8.0-incubating</spark.version>
+        <spark.version>0.8.1-incubating</spark.version>
         <parquet.version>1.2.5</parquet.version>
+        <protobuf.version>2.4.1</protobuf.version>
+        <akka.version>2.0.5</akka.version>
+        <akka.group>com.typesafe.akka</akka.group>
     </properties>
 
     <modules>
@@ -124,6 +127,10 @@
 
     <repositories>
         <repository>
+            <id>akka.repo</id>
+            <url>http://repo.akka.io/releases/</url>
+        </repository>
+        <repository>
             <id>hadoop-bam</id>
             <url>http://hadoop-bam.sourceforge.net/maven/</url>
         </repository>
@@ -132,9 +139,57 @@
     <dependencyManagement>
         <dependencies>
             <dependency>
+                <groupId>commons-io</groupId>
+                <artifactId>commons-io</artifactId>
+                <version>2.1</version>
+            </dependency>
+            <dependency>
+                <groupId>${akka.group}</groupId>
+                <artifactId>akka-actor</artifactId>
+                <version>${akka.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>${akka.group}</groupId>
+                <artifactId>akka-remote</artifactId>
+                <version>${akka.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>${akka.group}</groupId>
+                <artifactId>akka-slf4j</artifactId>
+                <version>${akka.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>${akka.group}</groupId>
+                <artifactId>akka-zeromq</artifactId>
+                <version>${akka.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>com.google.protobuf</groupId>
+                <artifactId>protobuf-java</artifactId>
+                <version>${protobuf.version}</version>
+            </dependency>
+            <dependency>
                 <groupId>edu.berkeley.cs.amplab.adam</groupId>
                 <artifactId>adam-core</artifactId>
                 <version>${project.version}</version>
+                <exclusions>
+                    <exclusion>
+                        <groupId>com.typesafe.akka</groupId>
+                        <artifactId>akka-actor</artifactId>
+                    </exclusion>
+                    <exclusion>
+                        <groupId>com.typesafe.akka</groupId>
+                        <artifactId>akka-remote</artifactId>
+                    </exclusion>
+                    <exclusion>
+                        <groupId>com.typesafe.akka</groupId>
+                        <artifactId>akka-slf4j</artifactId>
+                    </exclusion>
+                    <exclusion>
+                        <groupId>com.typesafe.akka</groupId>
+                        <artifactId>akka-zeromq</artifactId>
+                    </exclusion>
+                </exclusions>
             </dependency>
             <dependency>
                 <groupId>edu.berkeley.cs.amplab.adam</groupId>
@@ -229,5 +284,17 @@
             </dependency>
         </dependencies>
     </dependencyManagement>
+    <profiles>
+        <profile>
+            <id>hadoop22</id>
+            <properties>
+                <protobuf.version>2.5.0</protobuf.version>
+                <akka.version>2.0.5-protobuf-2.5-java-1.5</akka.version>
+                <akka.group>org.spark-project</akka.group>
+            </properties>
+        </profile>
+
+    </profiles>
+
 
 </project>


### PR DESCRIPTION
This upgrades the Spark version to 0.8.1 and adds a hadoop22 maven profile that fixes issues with connecting to Hadoop 2.2 clusters.

To make that work we added updated google-protobuf and akka dependencies.  The regular build leaves these dependencies off, even though the default hadoop.version was 2.2  Not sure if anyone actually had that working though.

However, the filesystem filter in adam-cli/pom.xml applies to all builds to fix the error: "No Filesystem found for scheme: hdfs" but after this addition, the local file paths throw an error.  

Not ready to be merged then, I just wanted to put this out there so any else could see what was necessary to get ADAM working on hadoop2.2 cluster
