### PR TITLE
Fixing reference position from offset implementation

### DIFF
--- a/adam-core/src/main/scala/edu/berkeley/cs/amplab/adam/rich/RichADAMRecord.scala
+++ b/adam-core/src/main/scala/edu/berkeley/cs/amplab/adam/rich/RichADAMRecord.scala
@@ -148,7 +148,7 @@ class RichADAMRecord(record: ADAMRecord) {
                CigarOperator.EQ |
                CigarOperator.S => {
             val positions = Range(posAtCigar.toInt, posAtCigar.toInt + elem.getLength)
-            (positions.last, basePositions ++ positions.map(t => Some(t.toLong)))
+            (positions.last + 1, basePositions ++ positions.map(t => Some(t.toLong)))
           }
           case CigarOperator.H => {
             runningPos /* do nothing */


### PR DESCRIPTION
Two parts here that I wanted to add:

1) Reference position from offset computation was sometimes mapping two different offsets to the same reference position which shouldn't be possible. i.e. if start= 1 and cigar=1S1M we were getting both mapped to 0 as opposed to 0 and 1.  Correct me if I'm wrong on my understanding of the cigar.

2) Secondly, end and unclippedEnd are exclusive (pointing to 1 past the last read base) currently, I wanted to know if this was intended?  It seemed odd to me that that the final reference position in referencePositions was not the same as end.  I think we had started a conversation on reference coordinate system earlier, so curious to know if end is purposely exclusive?

I had changed it and then changed back ...
