### PR TITLE
Make MdTag immutable

### DIFF
--- a/adam-core/src/main/scala/edu/berkeley/cs/amplab/adam/util/MdTag.scala
+++ b/adam-core/src/main/scala/edu/berkeley/cs/amplab/adam/util/MdTag.scala
@@ -15,6 +15,7 @@
  */
 package edu.berkeley.cs.amplab.adam.util
 
+import scala.collection.immutable
 import scala.collection.immutable.NumericRange
 import scala.util.matching.Regex
 
@@ -24,12 +25,70 @@ object MdTagEvent extends Enumeration {
 
 object MdTag {
 
-  val digitPattern = new Regex("\\d+")
+  private val digitPattern = new Regex("\\d+")
   // for description, see base enum in adam schema
-  val basesPattern = new Regex("[AaGgCcTtNnUuKkMmRrSsWwBbVvHhDdXx]+")
+  private val basesPattern = new Regex("[AaGgCcTtNnUuKkMmRrSsWwBbVvHhDdXx]+")
 
-  def apply(mdTag: String, referenceStart: Long): MdTag = {
-    new MdTag(mdTag, referenceStart)
+  def apply(mdTagInput: String, referenceStart: Long): MdTag = {
+    var matches = List[NumericRange[Long]]()
+    var mismatches = Map[Long, Char]()
+    var deletes = Map[Long, Char]()
+
+    if (mdTagInput != null && mdTagInput.length > 0) {
+      val mdTag = mdTagInput.toUpperCase
+      val end = mdTag.length
+
+      var offset = 0
+      var referencePos = referenceStart
+
+      def readMatches(errMsg: String): Unit = {
+        digitPattern.findPrefixOf(mdTag.substring(offset)) match {
+          case None => throw new IllegalArgumentException(errMsg)
+          case Some(s) =>
+            val length = s.toInt
+            if (length > 0) {
+              matches ::= NumericRange(referencePos, referencePos + length, 1L)
+            }
+            offset += s.length
+            referencePos += length
+        }
+      }
+
+      readMatches("MD tag must start with a digit")
+
+      while (offset < end) {
+        val mdTagType = {
+          if (mdTag.charAt(offset) == '^') {
+            offset += 1
+            MdTagEvent.Delete
+          } else {
+            MdTagEvent.Mismatch
+          }
+        }
+        basesPattern.findPrefixOf(mdTag.substring(offset)) match {
+          case None => throw new IllegalArgumentException("Failed to find deleted or mismatched bases after a match: %s".format(mdTagInput))
+          case Some(bases) =>
+            mdTagType match {
+              case MdTagEvent.Delete =>
+                bases.foreach {
+                  base =>
+                    deletes += (referencePos -> base)
+                    referencePos += 1
+                }
+              case MdTagEvent.Mismatch =>
+                bases.foreach {
+                  base =>
+                    mismatches += (referencePos -> base)
+                    referencePos += 1
+                }
+            }
+            offset += bases.length
+        }
+        readMatches("MD tag should have matching bases after mismatched or missing bases")
+      }
+    }
+
+    new MdTag(matches, mismatches, deletes)
   }
 
   def apply(mdTag: String): MdTag = {
@@ -37,65 +96,10 @@ object MdTag {
   }
 }
 
-class MdTag(mdTagInput: String, referenceStart: Long) {
-
-  private var matches = List[NumericRange[Long]]()
-  private var mismatches = Map[Long, Char]()
-  private var deletes = Map[Long, Char]()
-
-  if (mdTagInput != null && mdTagInput.length > 0) {
-    val mdTag = mdTagInput.toUpperCase
-    val end = mdTag.length
-
-    var offset = 0
-    var referencePos = referenceStart
-
-    def readMatches(errMsg: String): Unit = {
-      MdTag.digitPattern.findPrefixOf(mdTag.substring(offset)) match {
-        case None => throw new IllegalArgumentException(errMsg)
-        case Some(s) =>
-          val length = s.toInt
-          if (length > 0) {
-            matches ::= NumericRange(referencePos, referencePos + length, 1L)
-          }
-          offset += s.length
-          referencePos += length
-      }
-    }
-
-    readMatches("MD tag must start with a digit")
-
-    while (offset < end) {
-      val mdTagType = {
-        if (mdTag.charAt(offset) == '^') {
-          offset += 1
-          MdTagEvent.Delete
-        } else {
-          MdTagEvent.Mismatch
-        }
-      }
-      MdTag.basesPattern.findPrefixOf(mdTag.substring(offset)) match {
-        case None => throw new IllegalArgumentException("Failed to find deleted or mismatched bases after a match: %s".format(mdTagInput))
-        case Some(bases) =>
-          mdTagType match {
-            case MdTagEvent.Delete =>
-              bases.foreach {
-                base =>
-                  deletes += (referencePos -> base)
-                  referencePos += 1
-              }
-            case MdTagEvent.Mismatch =>
-              bases.foreach {
-                base =>
-                  mismatches += (referencePos -> base)
-                  referencePos += 1
-              }
-          }
-          offset += bases.length
-      }
-      readMatches("MD tag should have matching bases after mismatched or missing bases")
-    }
-  }
+class MdTag(
+    private val matches: immutable.List[NumericRange[Long]],
+    private val mismatches: immutable.Map[Long, Char],
+    private val deletes: immutable.Map[Long, Char]) {
 
   def isMatch(pos: Long): Boolean = {
     matches.exists(_.contains(pos))


### PR DESCRIPTION
Moves the parsing to `MdTag.apply()` and makes the `MdTag` class an immutable value type.
