### PR TITLE
Adding containsRefName to SequenceDictionary

### DIFF
--- a/adam-core/src/main/scala/edu/berkeley/cs/amplab/adam/models/SequenceDictionary.scala
+++ b/adam-core/src/main/scala/edu/berkeley/cs/amplab/adam/models/SequenceDictionary.scala
@@ -56,7 +56,9 @@ class SequenceDictionary(recordsIn: Iterable[SequenceRecord]) extends Serializab
   // Maps referenceName -> SequenceRecord
   private val recordNames: mutable.Map[CharSequence, SequenceRecord] =
     mutable.Map(recordsIn.map {
-      rec => (rec.name, rec)
+      // Call toString explicitly, since otherwise we were picking up an Avro-specific Utf8 value here,
+      // which was making the containsRefName method below fail in a hard-to-understand way.
+      rec => (rec.name.toString, rec)
     }.toSeq: _*)
 
   def assignments: Map[Int, CharSequence] = recordIndices.map {
@@ -67,6 +69,8 @@ class SequenceDictionary(recordsIn: Iterable[SequenceRecord]) extends Serializab
   def apply(id: Int): SequenceRecord = recordIndices(id)
 
   def apply(name: CharSequence): SequenceRecord = recordNames(name)
+
+  def containsRefName(name : CharSequence) : Boolean = recordNames.contains(name)
 
   /**
    * Produces a Map of Int -> Int which maps the referenceIds from this SequenceDictionary

--- a/adam-core/src/test/scala/edu/berkeley/cs/amplab/adam/models/SequenceDictionarySuite.scala
+++ b/adam-core/src/test/scala/edu/berkeley/cs/amplab/adam/models/SequenceDictionarySuite.scala
@@ -25,6 +25,14 @@ class SequenceDictionarySuite extends FunSuite {
     assert(SequenceDictionary(rec1, rec2)(rec1.id) === rec1)
   }
 
+  test("containsRefName works as expected") {
+    val rec1 = record(0, "foo")
+    val rec2 = record(1, "bar")
+    assert(SequenceDictionary(rec1, rec2).containsRefName("foo"))
+    assert(SequenceDictionary(rec1, rec2).containsRefName("bar"))
+    assert(!SequenceDictionary(rec1, rec2).containsRefName("foo "))
+  }
+
   test("Can retrieve sequence by Name") {
     val rec1 = record(0, "foo")
     val rec2 = record(1, "bar")


### PR DESCRIPTION
(A little update, I'm separating this out and filing it as a separate pull request from a larger request which will follow from us here at GenomeBridge later this week.) 

Added containsRefName to SequenceDictionary, allowing us to check whether a SequenceDictionary object contains a particular sequence.

SequenceDictionary recordNames keys should be Strings (they had been Avro Utf8 objects, which was messing up lookups into the map itself from Strings).
