### PR TITLE
Attributes: Use '\t' instead of ',', as , is a valid character

### DIFF
--- a/adam-core/src/main/scala/edu/berkeley/cs/amplab/adam/converters/SAMRecordConverter.scala
+++ b/adam-core/src/main/scala/edu/berkeley/cs/amplab/adam/converters/SAMRecordConverter.scala
@@ -116,7 +116,7 @@ class SAMRecordConverter extends Serializable {
             attrs ::= attr.tag + "=" + attr.value
           }
       }
-      builder.setAttributes(attrs.mkString(","))
+      builder.setAttributes(attrs.mkString("\t"))
     }
 
     val recordGroup: SAMReadGroupRecord = samRecord.getReadGroup


### PR DESCRIPTION
The SAM format allows ',' to be specified as part of the attributes. We should pick a different character to delimit our attributes (it seems they use '\t', and that seems a safe choice).
