### PR TITLE
Filter utility for inverse of Projection

### DIFF
--- a/adam-core/src/main/scala/edu/berkeley/cs/amplab/adam/projections/ADAMRecordField.scala
+++ b/adam-core/src/main/scala/edu/berkeley/cs/amplab/adam/projections/ADAMRecordField.scala
@@ -40,6 +40,7 @@ object ADAMRecordField extends FieldEnumeration(ADAMRecord.SCHEMA$) {
   cigar,
   qual,
   recordGroupId,
+  recordGroupName,
   readPaired,
   properPair,
   readMapped,

--- a/adam-core/src/main/scala/edu/berkeley/cs/amplab/adam/projections/Projection.scala
+++ b/adam-core/src/main/scala/edu/berkeley/cs/amplab/adam/projections/Projection.scala
@@ -9,16 +9,33 @@ import org.apache.avro.Schema.Field
  */
 object Projection {
 
-  private def createProjection(fullSchema: Schema, includedFields: Set[String]): Schema = {
+  private def createProjection(fullSchema: Schema, fields: Set[String], exclude : Boolean = false): Schema = {
     val projectedSchema = Schema.createRecord(fullSchema.getName, fullSchema.getDoc, fullSchema.getNamespace, fullSchema.isError)
-    projectedSchema.setFields(fullSchema.getFields.filter(p => includedFields.contains(p.name)).map(p => new Field(p.name, p.schema, p.doc, p.defaultValue, p.order)))
+    projectedSchema.setFields(fullSchema.getFields.filter(createFilterPredicate(fields, exclude))
+                    .map(p => new Field(p.name, p.schema, p.doc, p.defaultValue, p.order)))
     projectedSchema
+  }
+
+  private def createFilterPredicate(fieldNames : Set[String], exclude : Boolean = false): Field => Boolean = {
+    val filterPred = (f : Field) => fieldNames.contains(f.name)
+    val includeOrExlcude = ( contains : Boolean ) => if (exclude) !contains else contains
+    filterPred.andThen(includeOrExlcude)
   }
 
   def apply(includedFields: FieldValue*): Schema = {
     assert(!includedFields.isEmpty, "Can't project down to zero fields!")
-    val baseSchema = includedFields.head.schema
-    createProjection(baseSchema, includedFields.map(_.toString).toSet)
+    Projection(false, includedFields:_*)
   }
 
+  def apply(exclude:Boolean, includedFields: FieldValue*): Schema = {
+    val baseSchema = includedFields.head.schema
+    createProjection(baseSchema, includedFields.map(_.toString).toSet, exclude)
+  }
+}
+
+object Filter {
+
+  def apply(excludeFields: FieldValue*): Schema = {
+    Projection(true, excludeFields:_*)
+  }
 }

--- a/adam-core/src/test/scala/edu/berkeley/cs/amplab/adam/projections/FieldEnumerationSuite.scala
+++ b/adam-core/src/test/scala/edu/berkeley/cs/amplab/adam/projections/FieldEnumerationSuite.scala
@@ -111,6 +111,35 @@ class FieldEnumerationSuite extends SparkFunSuite with BeforeAndAfter {
     assert(first2.getReadMapped === true)
   }
 
+  sparkTest("Simple filter on ADAMRecord works") {
+
+    val fullReads: RDD[ADAMRecord] = sc.adamLoad(readsParquetFile.getAbsolutePath)
+    val firstFull = fullReads.first()
+    assert(firstFull.getReadName === "simread:1:26472783:false")
+    assert(firstFull.getReadMapped === true)
+    assert(firstFull.getReferenceName === "1")
+    assert(firstFull.getSequence != null)
+
+    val p1 = Filter(ADAMRecordField.referenceName, ADAMRecordField.referenceUrl, ADAMRecordField.referenceLength)
+    val reads1: RDD[ADAMRecord] = sc.adamLoad(readsParquetFile.getAbsolutePath, projection = Some(p1))
+
+    assert(reads1.count() === 200)
+
+    val first1 = reads1.first()
+    assert(first1.getReadName === "simread:1:26472783:false")
+    assert(first1.getReferenceName === null)
+
+    val p2 = Filter(ADAMRecordField.sequence)
+
+    val reads2: RDD[ADAMRecord] = sc.adamLoad(readsParquetFile.getAbsolutePath, projection = Some(p2))
+
+    assert(reads2.count() === 200)
+
+    val first2 = reads2.first()
+    assert(first2.getReadName === "simread:1:26472783:false")
+    assert(first2.getSequence === null)
+  }
+
   sparkTest("Simple projection on ADAMVariant works") {
 
     val p1 = Projection(ADAMVariantField.referenceId, ADAMVariantField.referenceName, ADAMVariantField.position)


### PR DESCRIPTION
Simple wrapper around Projection to allow users to specify all columns to leave out instead of all columns to choose.

Also added readGroupName to ADAMRecordField, it was left out after the last change.
