### PR TITLE
Create a cache for phred -> double values instead of recalculating

### DIFF
--- a/adam-core/src/main/scala/edu/berkeley/cs/amplab/adam/converters/GenotypesToVariantsConverter.scala
+++ b/adam-core/src/main/scala/edu/berkeley/cs/amplab/adam/converters/GenotypesToVariantsConverter.scala
@@ -121,7 +121,7 @@ private[adam] class GenotypesToVariantsConverter(validateSamples: Boolean = fals
    */
   def rms(values: Seq[Int]): Int = {
     if (values.length > 0) {
-      PhredUtils.doubleToPhred(rms(values.map(PhredUtils.phredToDouble(_))))
+      PhredUtils.successProbabilityToPhred(rms(values.map(PhredUtils.phredToSuccessProbability)))
     } else {
       0
     }
@@ -344,10 +344,10 @@ private[adam] class GenotypesToVariantsConverter(validateSamples: Boolean = fals
     } else {
       val quals = genotypes.map(_.getGenotypeQuality)
         .filter(_ != null)
-        .map(PhredUtils.phredToDouble(_))
+        .map(PhredUtils.phredToSuccessProbability(_))
 
       if (quals.length != 0) {
-        builder.setQuality(PhredUtils.doubleToPhred(variantQualityFromGenotypes(quals)))
+        builder.setQuality(PhredUtils.successProbabilityToPhred(variantQualityFromGenotypes(quals)))
       }
     }
 

--- a/adam-core/src/main/scala/edu/berkeley/cs/amplab/adam/util/PhredUtils.scala
+++ b/adam-core/src/main/scala/edu/berkeley/cs/amplab/adam/util/PhredUtils.scala
@@ -19,9 +19,24 @@ import scala.math.{pow, log10}
 
 object PhredUtils {
 
-  // conversion methods going to/from phred
-  def phredToDouble(phred: Int): Double = 1.0 - pow(10.0, -(phred.toDouble) / 10.0)
+  lazy val phredToErrorProbabilityCache: Array[Double] = {
+    (0 until 256).map{p => pow(10.0, -p / 10.0)}.toArray
+  }
 
-  def doubleToPhred(p: Double): Int = (-10.0 * log10(1.0 - p)).toInt
+  lazy val phredToSuccessProbabilityCache: Array[Double] = {
+    phredToErrorProbabilityCache.map{p => 1.0 - p}
+  }
+
+  def phredToSuccessProbability(phred: Int): Double = phredToSuccessProbabilityCache(phred)
+
+  private def probabilityToPhred(p: Double): Int = (-10.0 * log10(p)).toInt
+
+  def successProbabilityToPhred(p: Double): Int = probabilityToPhred(1.0 - p)
+
+  def errorProbabilityToPhred(p: Double): Int = probabilityToPhred(p)
+
+  def main(args: Array[String]) = {
+    phredToErrorProbabilityCache.zipWithIndex.foreach(p => println("%3d = %f".format(p._2, p._1)))
+  }
 
 }

--- a/adam-core/src/test/scala/edu/berkeley/cs/amplab/adam/converters/GenotypesToVariantsConverterSuite.scala
+++ b/adam-core/src/test/scala/edu/berkeley/cs/amplab/adam/converters/GenotypesToVariantsConverterSuite.scala
@@ -23,7 +23,7 @@ class GenotypesToVariantsConverterSuite extends FunSuite {
 
   test("Simple test of integer RMS") {
     val v = new GenotypesToVariantsConverter
-    assert(v.rms(List(1, -1)) === 1)
+    assert(v.rms(List(1, 1)) === 1)
   }
 
   test("Simple test of floating point RMS") {

--- a/adam-core/src/test/scala/edu/berkeley/cs/amplab/adam/rdd/AdamContextSuite.scala
+++ b/adam-core/src/test/scala/edu/berkeley/cs/amplab/adam/rdd/AdamContextSuite.scala
@@ -46,14 +46,14 @@ class AdamContextSuite extends SparkFunSuite {
   }
 
   test("Can convert to phred") {
-    assert(doubleToPhred(0.9) === 10)
-    assert(doubleToPhred(0.99999) === 50)
+    assert(successProbabilityToPhred(0.9) === 10)
+    assert(successProbabilityToPhred(0.99999) === 50)
   }
 
   test("Can convert from phred") {
     // result is floating point, so apply tolerance
-    assert(phredToDouble(10) > 0.89 && phredToDouble(10) < 0.91)
-    assert(phredToDouble(50) > 0.99998 && phredToDouble(50) < 0.999999)
+    assert(phredToSuccessProbability(10) > 0.89 && phredToSuccessProbability(10) < 0.91)
+    assert(phredToSuccessProbability(50) > 0.99998 && phredToSuccessProbability(50) < 0.999999)
   }
 
 }


### PR DESCRIPTION
Since a phred score is only a byte in size, we can create a small
cache of values instead of recalculating the probabilities on each
request.

This update should have a measurable impact on BQSR performance
given the number of times this calculation is done.
