### PR TITLE
fix for wildcard exclusion maven warnings

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -303,11 +303,19 @@
                     </exclusion>
                     <exclusion>
                         <groupId>org.codehaus.jackson</groupId>
-                        <artifactId>*</artifactId>
+                        <artifactId>jackson-core-asl</artifactId>
                     </exclusion>
                     <exclusion>
-                        <groupId>org.sonatype.sisu.inject</groupId>
-                        <artifactId>*</artifactId>
+                        <groupId>org.codehaus.jackson</groupId>
+                        <artifactId>jackson-jaxrs</artifactId>
+                    </exclusion>
+                    <exclusion>
+                        <groupId>org.codehaus.jackson</groupId>
+                        <artifactId>jackson-mapper-asl</artifactId>
+                    </exclusion>
+                    <exclusion>
+                        <groupId>org.codehaus.jackson</groupId>
+                        <artifactId>jackson-xc</artifactId>
                     </exclusion>
                 </exclusions>
             </dependency>


### PR DESCRIPTION
Maven version 3.1 issues warnings against wildcard dependency exclusions

```
$ mvn install
[INFO] Scanning for projects...
[WARNING] 
[WARNING] Some problems were encountered while building the effective model for edu.berkeley.cs.amplab.adam:adam-format:jar:0.6.1-SNAPSHOT
[WARNING] 'dependencyManagement.dependencies.dependency.exclusions.exclusion.artifactId' for org.apache.hadoop:hadoop-client:jar with value '*' does not match a valid id pattern. @ edu.berkeley.cs.amplab.adam:adam-parent:0.6.1-SNAPSHOT, /Users/xxx/working/adam/pom.xml, line 233, column 37
[WARNING] 'dependencyManagement.dependencies.dependency.exclusions.exclusion.artifactId' for org.apache.hadoop:hadoop-client:jar with value '*' does not match a valid id pattern. @ edu.berkeley.cs.amplab.adam:adam-parent:0.6.1-SNAPSHOT, /Users/xxx/working/adam/pom.xml, line 237, column 37
...
[WARNING] 
[WARNING] Some problems were encountered while building the effective model for edu.berkeley.cs.amplab.adam:adam-cli:jar:0.6.1-SNAPSHOT
[WARNING] 'dependencyManagement.dependencies.dependency.exclusions.exclusion.artifactId' for org.apache.hadoop:hadoop-client:jar with value '*' does not match a valid id pattern. @ edu.berkeley.cs.amplab.adam:adam-parent:0.6.1-SNAPSHOT, /Users/xxx/working/adam/pom.xml, line 233, column 37
[WARNING] 'dependencyManagement.dependencies.dependency.exclusions.exclusion.artifactId' for org.apache.hadoop:hadoop-client:jar with value '*' does not match a valid id pattern. @ edu.berkeley.cs.amplab.adam:adam-parent:0.6.1-SNAPSHOT, /Users/xxx/working/adam/pom.xml, line 237, column 37
[WARNING] 
[WARNING] Some problems were encountered while building the effective model for edu.berkeley.cs.amplab.adam:adam-parent:pom:0.6.1-SNAPSHOT
[WARNING] 'dependencyManagement.dependencies.dependency.exclusions.exclusion.artifactId' for org.apache.hadoop:hadoop-client:jar with value '*' does not match a valid id pattern. @ line 233, column 37
[WARNING] 'dependencyManagement.dependencies.dependency.exclusions.exclusion.artifactId' for org.apache.hadoop:hadoop-client:jar with value '*' does not match a valid id pattern. @ line 237, column 37
[WARNING] 
[WARNING] It is highly recommended to fix these problems because they threaten the stability of your build.
[WARNING] 
[WARNING] For this reason, future Maven versions might no longer support building such malformed projects.
[WARNING] 
[INFO] ------------------------------------------------------------------------
```

These warnings are slated to be removed in version Maven 3.2, but it may still be worth removing the wildcards at this point.

Allow wildcards in dependency exclusions
http://jira.codehaus.org/browse/MNG-3832

I also noticed that artifacts from org.sonatype.sisu.inject are being excluded even though after removing the wildcard exclusion none are shown with

```
$ mvn dependency:tree -Ddetail=true | grep sisu -
```

and none are listed by the maven-shade-plugin when building the jar.
