### PR TITLE
sonatype-nexus-snapshots repository is already in parent oss-parent-7 pom

### DIFF
--- a/adam-format/pom.xml
+++ b/adam-format/pom.xml
@@ -34,18 +34,6 @@
             </plugin>
         </plugins>
     </build>
-    <repositories>
-        <repository>
-            <id>sonatype-nexus-snapshots</id>
-            <url>https://oss.sonatype.org/content/repositories/snapshots</url>
-            <releases>
-                <enabled>false</enabled>
-            </releases>
-            <snapshots>
-                <enabled>true</enabled>
-            </snapshots>
-        </repository>
-    </repositories>
     <dependencies>
         <dependency>
             <groupId>org.apache.avro</groupId>


### PR DESCRIPTION
The sonatype-nexus-snapshots repository is already in parent oss-parent-7 pom:

http://repo.maven.apache.org/maven2/org/sonatype/oss/oss-parent/7/oss-parent-7.pom
