### PR TITLE
Change RecalTable to use optimized phred calculations

### DIFF
--- a/adam-core/src/main/scala/edu/berkeley/cs/amplab/adam/rdd/recalibration/RecalTable.scala
+++ b/adam-core/src/main/scala/edu/berkeley/cs/amplab/adam/rdd/recalibration/RecalTable.scala
@@ -17,6 +17,7 @@ package edu.berkeley.cs.amplab.adam.rdd.recalibration
 
 import scala.collection.immutable.Map
 import scala.collection.mutable
+import edu.berkeley.cs.amplab.adam.util.PhredUtils
 
 
 class RecalTable(_counts: mutable.HashMap[Int, Array[ErrorCounts]], _expectedMM: Double) extends Serializable {
@@ -57,7 +58,7 @@ class RecalTable(_counts: mutable.HashMap[Int, Array[ErrorCounts]], _expectedMM:
     errorCounts zip info.covar foreach (errorCovar => {
       errorCovar._1(errorCovar._2) += info
     })
-    expectedMismatch += RecalUtil.qualToErrorProb(info.qual)
+    expectedMismatch += PhredUtils.phredToErrorProbability(info.qual)
   }
 
   /*val BASES = "ACGT".toCharArray.map(_.toByte)
@@ -132,13 +133,13 @@ class RecalTable(_counts: mutable.HashMap[Int, Array[ErrorCounts]], _expectedMM:
   def getQualScoreDelta(baseCovar: BaseCovariates): Double = {
     val readGroupDelta = getReadGroupDelta(baseCovar)
     val empiricalCounts = qualByRGCounts(baseCovar.qualByRG)
-    val reportedErr = RecalUtil.qualToErrorProb(baseCovar.qual)
+    val reportedErr = PhredUtils.phredToErrorProbability(baseCovar.qual)
     val errAdjusted = reportedErr + readGroupDelta
     empiricalCounts.getErrorProb.getOrElse(errAdjusted) - errAdjusted
   }
 
   def getCovariateDelta(baseCovar: BaseCovariates): Seq[Double] = {
-    val errAdjusted = RecalUtil.qualToErrorProb(baseCovar.qual) + getReadGroupDelta(baseCovar) + getQualScoreDelta(baseCovar)
+    val errAdjusted = PhredUtils.phredToErrorProbability(baseCovar.qual) + getReadGroupDelta(baseCovar) + getQualScoreDelta(baseCovar)
     val errs = this.lookup(baseCovar.qualByRG, baseCovar.covar.size).zip(baseCovar.covar).map(t => t._1(t._2).getErrorProb)
     errs.map(_.getOrElse(errAdjusted) - errAdjusted)
   }

--- a/adam-core/src/main/scala/edu/berkeley/cs/amplab/adam/util/PhredUtils.scala
+++ b/adam-core/src/main/scala/edu/berkeley/cs/amplab/adam/util/PhredUtils.scala
@@ -29,6 +29,8 @@ object PhredUtils {
 
   def phredToSuccessProbability(phred: Int): Double = phredToSuccessProbabilityCache(phred)
 
+  def phredToErrorProbability(phred: Int): Double = phredToErrorProbabilityCache(phred)
+
   private def probabilityToPhred(p: Double): Int = (-10.0 * log10(p)).toInt
 
   def successProbabilityToPhred(p: Double): Int = probabilityToPhred(1.0 - p)


### PR DESCRIPTION
Replacing RecalTable phred conversion functions with optimized versions from PhredUtils
1) Should be faster due to caching done in PhredUtils
2) The ones in recal table actually had a bug as well, due to integer division in the exponent.

scala> def qualToErrorProb(q: Byte): Double = math.pow(10.0, -q / 10)
qualToErrorProb: (q: Byte)Double

scala> qualToErrorProb(5)
res0: Double = 1.0

scala> math.pow(10.0, -0.5)
res1: Double = 0.31622776601683794

scala> math.pow(10.0, -5/10)
res2: Double = 1.0
