### PR TITLE
Added ability to create regions from reads, and to merge adjacent regions

### DIFF
--- a/adam-core/src/main/scala/edu/berkeley/cs/amplab/adam/models/ReferenceRegion.scala
+++ b/adam-core/src/main/scala/edu/berkeley/cs/amplab/adam/models/ReferenceRegion.scala
@@ -17,7 +17,29 @@ package edu.berkeley.cs.amplab.adam.models
 
 import com.esotericsoftware.kryo.{Kryo, Serializer}
 import com.esotericsoftware.kryo.io.{Input, Output}
+import edu.berkeley.cs.amplab.adam.avro.ADAMRecord
+import edu.berkeley.cs.amplab.adam.rich.RichADAMRecord
+import edu.berkeley.cs.amplab.adam.rich.RichADAMRecord._
 import scala.math.{min, max}
+
+object ReferenceRegion {
+  
+  /**
+   * Generates a reference region from read data. Returns None if the read is not mapped;
+   * else, returns the inclusive region from the start to the end of the read alignment.
+   *
+   * @param record Read to create region from.
+   * @return Region corresponding to inclusive region of read alignment, if read is mapped.
+   */
+  def apply (record: ADAMRecord): Option[ReferenceRegion] = {
+    if (record.getReadMapped) {
+      Some(ReferenceRegion(record.getReferenceId, record.getStart, record.end.get + 1))
+    } else {
+      None
+    }
+  }
+  
+}
 
 /**
  * Represents a contiguous region of the reference genome.
@@ -35,30 +57,89 @@ case class ReferenceRegion(refId: Int, start: Long, end: Long) extends Ordered[R
 
   def width: Long = end - start
 
-  def union(region: ReferenceRegion): ReferenceRegion = {
-    assert(overlaps(region), "Cannot compute union of two non-overlapping regions")
+  /**
+   * Merges two reference regions that are contiguous.
+   *
+   * @throws AssertionError Thrown if regions are not overlapping or adjacent.
+   *
+   * @param region Other region to merge with this region.
+   * @return The merger of both unions.
+   *
+   * @see hull
+   */
+  def merge(region: ReferenceRegion): ReferenceRegion = {
+    assert(overlaps(region) || isAdjacent(region), "Cannot merge two regions that do not overlap or are not adjacent")
+    hull(region)
+  }
+
+  /**
+   * Creates a region corresponding to the convex hull of two regions. Has no preconditions about the adjacency or
+   * overlap of two regions. However, regions must be in the same reference space.
+   *
+   * @throws AssertionError Thrown if regions are in different reference spaces.
+   * 
+   * @param region Other region to compute hull of with this region.
+   * @return The convex hull of both unions.
+   *
+   * @see hull
+   */
+  def hull(region: ReferenceRegion): ReferenceRegion = {
+    assert(refId == region.refId, "Cannot compute convex hull of regions on different references.")
     ReferenceRegion(refId, min(start, region.start), max(end, region.end))
   }
 
+  /**
+   * Returns whether two regions are adjacent. Adjacent regions do not overlap, but have no separation between start/end.
+   *
+   * @param region Region to compare against.
+   * @return True if regions are adjacent.
+   */
+  def isAdjacent(region: ReferenceRegion): Boolean = distance(region) match {
+    case Some(d) => d == 1
+    case None => false
+  }
+
+  /**
+   * Returns the distance between this reference region and a point in the reference space.
+   *
+   * @note Distance here is defined as the minimum distance between any point within this region, and
+   * the point we are measuring against. If the point is within this region, its distance will be 0.
+   * Else, the distance will be greater than or equal to 1.
+   *
+   * @param other Point to compare against.
+   * @return Returns an option containing the distance between two points. If the point is not in
+   * our reference space, we return an empty option (None).
+   */
   def distance(other: ReferencePosition): Option[Long] =
     if (refId == other.refId)
       if (other.pos < start)
         Some(start - other.pos)
       else if (other.pos >= end)
-        Some(other.pos - end)
+        Some(other.pos - end + 1)
       else
         Some(0)
     else
       None
 
+  /**
+   * Returns the distance between this reference region and another region in the reference space.
+   *
+   * @note Distance here is defined as the minimum distance between any point within this region, and
+   * any point within the other region we are measuring against. If the two sets overlap, the distance
+   * will be 0. If the sets abut, the distance will be 1. Else, the distance will be greater.
+   *
+   * @param other Region to compare against.
+   * @return Returns an option containing the distance between two points. If the point is not in
+   * our reference space, we return an empty option (None).
+   */
   def distance(other: ReferenceRegion): Option[Long] =
     if (refId == other.refId)
       if (overlaps(other))
         Some(0)
       else if (other.start >= end)
-        Some(other.start - end)
+        Some(other.start - end + 1)
       else
-        Some(start - other.end)
+        Some(start - other.end + 1)
     else
       None
 

--- a/adam-core/src/test/scala/edu/berkeley/cs/amplab/adam/models/ReferenceRegionSuite.scala
+++ b/adam-core/src/test/scala/edu/berkeley/cs/amplab/adam/models/ReferenceRegionSuite.scala
@@ -16,6 +16,7 @@
 package edu.berkeley.cs.amplab.adam.models
 
 import org.scalatest._
+import edu.berkeley.cs.amplab.adam.avro.ADAMRecord
 
 class ReferenceRegionSuite extends FunSuite {
 
@@ -35,9 +36,9 @@ class ReferenceRegionSuite extends FunSuite {
     assert(!region(0, 10, 100).contains(point(1, 50)))
   }
 
-  test("union") {
+  test("merge") {
     intercept[AssertionError] {
-      region(0, 10, 100).union(region(1, 10, 100))
+      region(0, 10, 100).merge(region(1, 10, 100))
     }
 
     val r1 = region(0, 10, 100)
@@ -47,9 +48,9 @@ class ReferenceRegionSuite extends FunSuite {
     val r12 = region(0, 0, 100)
     val r13 = region(0, 10, 150)
 
-    assert(r1.union(r1) === r1)
-    assert(r1.union(r2) === r12)
-    assert(r1.union(r3) === r13)
+    assert(r1.merge(r1) === r1)
+    assert(r1.merge(r2) === r12)
+    assert(r1.merge(r3) === r13)
   }
 
   test("overlaps") {
@@ -78,22 +79,22 @@ class ReferenceRegionSuite extends FunSuite {
   test("distance(: ReferenceRegion)") {
 
     // distance on the right
-    assert(region(0, 10, 100).distance(region(0, 200, 300)) === Some(100))
+    assert(region(0, 10, 100).distance(region(0, 200, 300)) === Some(101))
 
     // distance on the left
-    assert(region(0, 100, 200).distance(region(0, 10, 50)) === Some(50))
+    assert(region(0, 100, 200).distance(region(0, 10, 50)) === Some(51))
 
     // different sequences
     assert(region(0, 100, 200).distance(region(1, 10, 50)) === None)
 
     // touches on the right
-    assert(region(0, 10, 100).distance(region(0, 100, 200)) === Some(0))
+    assert(region(0, 10, 100).distance(region(0, 100, 200)) === Some(1))
 
     // overlaps
     assert(region(0, 10, 100).distance(region(0, 50, 150)) === Some(0))
 
     // touches on the left
-    assert(region(0, 10, 100).distance(region(0, 0, 10)) === Some(0))
+    assert(region(0, 10, 100).distance(region(0, 0, 10)) === Some(1))
   }
 
   test("distance(: ReferencePosition)") {
@@ -105,10 +106,10 @@ class ReferenceRegionSuite extends FunSuite {
     assert(region(0, 10, 100).distance(point(0, 10)) === Some(0))
 
     // right edge
-    assert(region(0, 10, 100).distance(point(0, 100)) === Some(0))
+    assert(region(0, 10, 100).distance(point(0, 100)) === Some(1))
 
     // right
-    assert(region(0, 10, 100).distance(point(0, 150)) === Some(50))
+    assert(region(0, 10, 100).distance(point(0, 150)) === Some(51))
 
     // left
     assert(region(0, 100, 200).distance(point(0, 50)) === Some(50))
@@ -116,6 +117,64 @@ class ReferenceRegionSuite extends FunSuite {
     // different sequences
     assert(region(0, 100, 200).distance(point(1, 50)) === None)
 
+  }
+
+  test("create region from unmapped read fails") {
+    val read = ADAMRecord.newBuilder()
+      .setReadMapped(false)
+      .build()
+
+    assert(ReferenceRegion(read).isEmpty)
+  }
+
+  test("create region from mapped read contains read start and end") {
+    val read = ADAMRecord.newBuilder()
+      .setReadMapped(true)
+      .setSequence("AAAAA")
+      .setStart(1L)
+      .setCigar("5M")
+      .setReferenceId(1)
+      .build()
+
+    assert(ReferenceRegion(read).isDefined)
+    assert(ReferenceRegion(read).get.contains(point(1, 1L)))
+    assert(ReferenceRegion(read).get.contains(point(1, 5L)))
+  }
+
+  test("validate that adjacent regions can be merged") {
+    val r1 = region(1, 0L, 6L)
+    val r2 = region(1, 6L, 10L)
+
+    assert(r1.distance(r2).get === 1)
+    assert(r1.isAdjacent(r2))
+    assert(r1.merge(r2) == region(1, 0L, 10L))
+  }
+
+  test("validate that non-adjacent regions cannot be merged") {
+    val r1 = region(1, 0L, 5L)
+    val r2 = region(1, 7L, 10L)
+
+    assert(!r1.isAdjacent(r2))
+
+    intercept[AssertionError] {
+      r1.merge(r2)
+    }
+  }
+
+  test("compute convex hull of two sets") {
+    val r1 = region(1, 0L, 5L)
+    val r2 = region(1, 7L, 10L)
+
+    assert(!r1.isAdjacent(r2))
+
+    val hull1 = r1.hull(r2)
+    val hull2 = r2.hull(r1)
+
+    assert(hull1 === hull2)
+    assert(hull1.overlaps(r1))
+    assert(hull1.overlaps(r2))
+    assert(hull1.start == 0L)
+    assert(hull1.end == 10L)
   }
 
   def region(refId: Int, start: Long, end: Long): ReferenceRegion =


### PR DESCRIPTION
This commit adds the ability to create reference regions from read data, and adds code for checking if two regions are adjacent. Additionally, it changes the union method to allow for adjacent but non-overlapping regions to be added.

@tdanford & @carlyeks , would this change to the union method break any downstream code? I presumed that it would not, but don't know if you all have any tools that you are working on that would be impacted by this change.
