### PR TITLE
Support for loading/combining multiple ADAM files into a single RDD.

### DIFF
--- a/adam-core/src/main/scala/edu/berkeley/cs/amplab/adam/models/ReferenceMapping.scala
+++ b/adam-core/src/main/scala/edu/berkeley/cs/amplab/adam/models/ReferenceMapping.scala
@@ -1,0 +1,22 @@
+/*
+ * Copyright 2014 Genome Bridge LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package edu.berkeley.cs.amplab.adam.models
+
+trait ReferenceMapping[T] {
+
+  def getReferenceId( value : T ) : Int
+  def remapReferenceId( value : T, newId : Int) : T
+}

--- a/adam-core/src/main/scala/edu/berkeley/cs/amplab/adam/rich/ADAMRecordContext.scala
+++ b/adam-core/src/main/scala/edu/berkeley/cs/amplab/adam/rich/ADAMRecordContext.scala
@@ -1,0 +1,32 @@
+/*
+ * Copyright 2014 Genome Bridge LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package edu.berkeley.cs.amplab.adam.rich
+
+import edu.berkeley.cs.amplab.adam.avro.ADAMRecord
+import edu.berkeley.cs.amplab.adam.models.ReferenceMapping
+
+object ADAMRecordContext {
+
+  implicit def adamRecordToReferenceMapped(rec : ADAMRecord) : ReferenceMapping[ADAMRecord] =
+    ADAMRecordReferenceMapping
+}
+
+object ADAMRecordReferenceMapping extends ReferenceMapping[ADAMRecord] with Serializable {
+  def getReferenceId(value: ADAMRecord): Int = value.getReferenceId
+
+  def remapReferenceId(value: ADAMRecord, newId: Int): ADAMRecord =
+    ADAMRecord.newBuilder(value).setReferenceId(newId).build()
+}

--- a/adam-core/src/main/scala/edu/berkeley/cs/amplab/adam/rich/RichRDDReferenceRecords.scala
+++ b/adam-core/src/main/scala/edu/berkeley/cs/amplab/adam/rich/RichRDDReferenceRecords.scala
@@ -1,0 +1,49 @@
+/*
+ * Copyright 2014 Genome Bridge LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package edu.berkeley.cs.amplab.adam.rich
+
+import edu.berkeley.cs.amplab.adam.avro.ADAMRecord
+import org.apache.spark.rdd.RDD
+import org.apache.spark.SparkContext
+
+import edu.berkeley.cs.amplab.adam.models.ReferenceMapping
+import org.apache.avro.specific.SpecificRecord
+
+class RichRDDReferenceRecords[T <: SpecificRecord : ClassManifest](rdd: RDD[T],
+                                                                   mapping : ReferenceMapping[T])
+  extends Serializable {
+
+  def remapReferenceId(map: Map[Int, Int])(implicit sc : SparkContext): RDD[T] = {
+    // If the reference IDs match, we don't need to do any remapping, just return the previous RDD
+    if (map.forall({case (a, b)=> a == b})) rdd
+    else {
+      // Broadcast the map variable
+      val bc = sc.broadcast(map)
+      rdd.map(r => {
+        val refId = mapping.getReferenceId(r)
+        // If the reference ID is the same, we don't need to create a new ADAMRecord
+        if (bc.value(refId) == refId.toInt) r
+        else mapping.remapReferenceId(r, bc.value(refId))
+      })
+    }
+  }
+}
+
+object RichRDDReferenceRecords extends Serializable {
+  implicit def adamRDDToRichADAMRDD(rdd: RDD[ADAMRecord]) : RichRDDReferenceRecords[ADAMRecord] =
+    new RichRDDReferenceRecords(rdd, ADAMRecordReferenceMapping)
+}

--- a/adam-core/src/test/scala/edu/berkeley/cs/amplab/adam/rdd/AdamContextSuite.scala
+++ b/adam-core/src/test/scala/edu/berkeley/cs/amplab/adam/rdd/AdamContextSuite.scala
@@ -22,6 +22,9 @@ import edu.berkeley.cs.amplab.adam.avro.ADAMRecord
 import edu.berkeley.cs.amplab.adam.util.SparkFunSuite
 import edu.berkeley.cs.amplab.adam.rdd.AdamContext._
 import edu.berkeley.cs.amplab.adam.util.PhredUtils._
+import java.io.File
+import org.apache.hadoop.fs.Path
+import java.util.UUID
 
 class AdamContextSuite extends SparkFunSuite {
 
@@ -54,6 +57,106 @@ class AdamContextSuite extends SparkFunSuite {
     // result is floating point, so apply tolerance
     assert(phredToSuccessProbability(10) > 0.89 && phredToSuccessProbability(10) < 0.91)
     assert(phredToSuccessProbability(50) > 0.99998 && phredToSuccessProbability(50) < 0.999999)
+  }
+
+  sparkTest("loadAdamFromPaths can load simple RDDs that have just been saved") {
+    val a0 = ADAMRecord.newBuilder()
+      .setRecordGroupName("group0")
+      .setReadName("read0")
+      .setReferenceId(0)
+      .setReferenceName("abc")
+      .setReferenceUrl("http://abc")
+      .setReferenceLength(1000000)
+      .setStart(100)
+      .setPrimaryAlignment(true)
+      .setReadPaired(false)
+      .setReadMapped(true)
+      .build()
+    val a1 = ADAMRecord.newBuilder(a0)
+      .setReadName("read1")
+      .setStart(200)
+      .build()
+
+    val saved = sc.parallelize(Seq(a0, a1))
+    val loc = tempLocation()
+    val path = new Path(loc)
+
+    saved.adamSave(loc)
+    try {
+      val loaded = sc.loadAdamFromPaths(Seq(path))
+
+
+    assert(loaded.count() === saved.count())
+    } catch {
+      case (e: Exception) => {
+        println(e)
+        throw e
+      }
+    }
+  }
+
+  sparkTest("findFiles correctly finds a nested set of directories") {
+
+    /**
+     * Create the following directory structure, in the temp file location:
+     *
+     * .
+     * ├── parent-dir/
+     *     ├── subDir1/
+     *     |   ├── match1/
+     *     |   └── match2/
+     *     └── subDir2/
+     *     |   ├── match3/
+     *     |   └── nomatch4/
+     *     ├── match5/
+     *     └── nomatch6/
+     */
+
+    val tempDir = File.createTempFile("AdamContextSuite", "").getParentFile
+
+    def createDir(dir : File, name : String) : File = {
+      val dirFile = new File(dir, name)
+      dirFile.mkdir()
+      dirFile
+    }
+
+    val parentName : String = "parent-" + UUID.randomUUID().toString
+    val parentDir : File = createDir(tempDir, parentName)
+    val subDir1 : File = createDir(parentDir, "subDir1")
+    val subDir2 : File = createDir(parentDir, "subDir2")
+    val match1 : File = createDir(subDir1, "match1")
+    val match2 : File = createDir(subDir1, "match2")
+    val match3 : File = createDir(subDir2, "match3")
+    val nomatch4 : File = createDir(subDir2, "nomatch4")
+    val match5 : File = createDir(parentDir, "match5")
+    val nomatch6 : File = createDir(parentDir, "nomatch6")
+
+    /**
+     * Now, run findFiles() on the parentDir, and make sure we find match{1, 2, 3, 5} and _do not_
+     * find nomatch{4, 6}
+     */
+
+    val paths = sc.findFiles(new Path(parentDir.getAbsolutePath), "^match.*")
+
+    assert(paths.size === 4)
+
+    val pathNames = paths.map(_.getName)
+    assert(pathNames.contains("match1"))
+    assert(pathNames.contains("match2"))
+    assert(pathNames.contains("match3"))
+    assert(pathNames.contains("match5"))
+  }
+
+  /*
+  Little helper function -- because apparently createTempFile creates an actual file, not
+  just a name?  Whereas, this returns the name of something that could be mkdir'ed, in the
+  same location as createTempFile() uses, so therefore the returned path from this method
+  should be suitable for adamSave().
+   */
+  def tempLocation(suffix : String = "adam") : String = {
+    val tempFile = File.createTempFile("AdamContextSuite", "")
+    val tempDir = tempFile.getParentFile
+    new File(tempDir, tempFile.getName + suffix).getAbsolutePath
   }
 
 }

--- a/adam-core/src/test/scala/edu/berkeley/cs/amplab/adam/rich/ADAMRecordReferenceMappingSuite.scala
+++ b/adam-core/src/test/scala/edu/berkeley/cs/amplab/adam/rich/ADAMRecordReferenceMappingSuite.scala
@@ -1,0 +1,35 @@
+/*
+ * Copyright 2014 Genome Bridge LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package edu.berkeley.cs.amplab.adam.rich
+
+import edu.berkeley.cs.amplab.adam.util.SparkFunSuite
+import edu.berkeley.cs.amplab.adam.avro.ADAMRecord
+
+class ADAMRecordReferenceMappingSuite extends SparkFunSuite {
+
+  sparkTest("test getReferenceId returns the right referenceId") {
+    val rec = ADAMRecord.newBuilder().setReferenceId(12).build()
+    assert(ADAMRecordReferenceMapping.getReferenceId(rec) === 12)
+  }
+
+  sparkTest("test that remapReferenceId really changes the referenceId") {
+    val rec = ADAMRecord.newBuilder().setReferenceId(12).build()
+    val rec2 = ADAMRecordReferenceMapping.remapReferenceId(rec, 15)
+
+    assert(ADAMRecordReferenceMapping.getReferenceId(rec) === 12)
+    assert(ADAMRecordReferenceMapping.getReferenceId(rec2) === 15)
+  }
+}

--- a/adam-core/src/test/scala/edu/berkeley/cs/amplab/adam/rich/RichRDDReferenceRecordsSuite.scala
+++ b/adam-core/src/test/scala/edu/berkeley/cs/amplab/adam/rich/RichRDDReferenceRecordsSuite.scala
@@ -1,0 +1,53 @@
+/*
+ * Copyright 2014 Genome Bridge LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package edu.berkeley.cs.amplab.adam.rich
+
+import edu.berkeley.cs.amplab.adam.util.SparkFunSuite
+import edu.berkeley.cs.amplab.adam.avro.ADAMRecord
+
+import edu.berkeley.cs.amplab.adam.rich.RichRDDReferenceRecords._
+
+class RichRDDReferenceRecordsSuite extends SparkFunSuite {
+
+  sparkTest("can convert referenceId values of RDD[ADAMRecord]") {
+
+    val r1 = adamRecord(0, "foo", "read1", 1000L, true)
+    val r2 = adamRecord(1, "bar", "read2", 2000L, true)
+
+    val map = Map(r1.getReadName->r1, r2.getReadName->r2)
+
+    val rdd = sc.parallelize(Seq(r1, r2))
+
+    val remap = Map(0->10, 1->11)
+    val remapped = rdd.remapReferenceId(remap)(sc)
+
+    val seq = remapped.collect().sortBy(_.getReadName.toString)
+    assert(seq.size === 2)
+    assert(seq(0).getReadName.toString === "read1")
+    assert(seq(1).getReadName.toString === "read2")
+    assert(seq(0).getReferenceId === 10)
+    assert(seq(1).getReferenceId === 11)
+  }
+
+  def adamRecord(referenceId: Int, referenceName: String, readName: String, start: Long, readMapped: Boolean) =
+    ADAMRecord.newBuilder()
+      .setReferenceId(referenceId)
+      .setReferenceName(referenceName)
+      .setReadName(readName)
+      .setReadMapped(readMapped)
+      .setStart(start)
+      .build()
+}


### PR DESCRIPTION
A new method, AdamContext.loadAdamFromPaths, loads a set of ADAMRecord files separately and then returns the union -- it should handle the case where the different files have different sequence dictionaries associated with them.

A method, findFiles, recursively searches a path for sub-directories whose names match a given regex.  We (Genome Bridge) are using these methods to load multiple ADAM files, each produced from a separate BAM that came from a single sample (but were separated by chromosome or, more generically, genomic region).
