### PR TITLE
Changing hadoop fs call to be compatible with Hadoop 1.

### DIFF
--- a/adam-core/src/main/scala/edu/berkeley/cs/amplab/adam/rdd/AdamContext.scala
+++ b/adam-core/src/main/scala/edu/berkeley/cs/amplab/adam/rdd/AdamContext.scala
@@ -325,7 +325,7 @@ class AdamContext(sc: SparkContext) extends Serializable with Logging {
     } else {
       val statuses = FileSystem.get(sc.hadoopConfiguration).listStatus(path)
       val r = Pattern.compile(regex)
-      val (matches, recurse) = statuses.filter(s => s.isDirectory).map(s => s.getPath).partition(p => r.matcher(p.getName).matches())
+      val (matches, recurse) = statuses.filter(s => s.isDir).map(s => s.getPath).partition(p => r.matcher(p.getName).matches())
       matches.toSeq ++ recurse.flatMap(p => findFiles(p, regex))
     }
   }


### PR DESCRIPTION
isDir in Hadoop 1 was changed to isDirectory in Hadoop 2. Changed isDirectory method call to isDir to ensure Hadoop 1 compatibility.

@jelson Before we merge this in, can MSR test locally to see if this fixes the Hadoop 1 incompatibility?
