### PR TITLE
Adding ability to convert reference FASTA files for nucleotide sequences

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -12,6 +12,10 @@ Trunk (not yet released)
     pipelines based on their read-by-read concordance across a number of fields: position, alignment,
     mapping and base quality scores, and can be extended to support new metrics or aggregations.
 
+  * Added FASTA import, and RDD convenience functions for remapping contig IDs. This allows for reference
+    sequences to be imported into an efficient record where bases are stored as a list of enums. Additionally,
+    convenience values are calculated. This feature was introduced in PR #79.
+
   OPTIMIZATIONS
 
   IMPROVEMENTS

--- a/adam-cli/src/main/scala/edu/berkeley/cs/amplab/adam/cli/AdamMain.scala
+++ b/adam-cli/src/main/scala/edu/berkeley/cs/amplab/adam/cli/AdamMain.scala
@@ -32,7 +32,8 @@ object AdamMain extends Logging {
     Bam2Adam,
     Adam2Vcf,
     Vcf2Adam,
-    FindReads)
+    FindReads,
+    Fasta2Adam)
 
   private def printCommands() {
     println("\n")

--- a/adam-cli/src/main/scala/edu/berkeley/cs/amplab/adam/cli/Fasta2Adam.scala
+++ b/adam-cli/src/main/scala/edu/berkeley/cs/amplab/adam/cli/Fasta2Adam.scala
@@ -1,0 +1,93 @@
+/*
+ * Copyright (c) 2014. Regents of the University of California
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package edu.berkeley.cs.amplab.adam.cli
+
+import edu.berkeley.cs.amplab.adam.avro.{ADAMNucleotideContig, ADAMRecord}
+import edu.berkeley.cs.amplab.adam.converters.FastaConverter
+import edu.berkeley.cs.amplab.adam.rdd.AdamContext._
+import org.apache.hadoop.io.{LongWritable, Text}
+import org.apache.hadoop.mapreduce.Job
+import org.apache.hadoop.mapreduce.lib.input.TextInputFormat
+import org.apache.spark.{SparkContext, Logging}
+import org.apache.spark.rdd.RDD
+import org.kohsuke.args4j.{Option => Args4jOption, Argument}
+
+object Fasta2Adam extends AdamCommandCompanion {
+  val commandName: String = "fasta2adam"
+  val commandDescription: String = "Converts a text FASTA sequence file into an ADAMNucleotideContig Parquet file which represents assembled sequences."
+
+  def apply(cmdLine: Array[String]): AdamCommand = {
+    new Fasta2Adam(Args4j[Fasta2AdamArgs](cmdLine))
+  }
+}
+
+class Fasta2AdamArgs extends Args4jBase with ParquetArgs with SparkArgs {
+  @Argument(required = true, metaVar = "FASTA", usage = "The FASTA file to convert", index = 0)
+  var fastaFile: String = null
+  @Argument(required = true, metaVar = "ADAM", usage = "Location to write ADAM data", index = 1)
+  var outputPath: String = null
+  @Args4jOption(required = false, name = "-verbose", usage = "Prints enhanced debugging info, including contents of seq dict.")
+  var verbose: Boolean = false
+  @Args4jOption(required = false, name = "-reads", usage = "Maps contig IDs to match contig IDs of reads.")
+  var reads: String = ""
+}
+
+class Fasta2Adam(protected val args: Fasta2AdamArgs) extends AdamSparkCommand[Fasta2AdamArgs] with Logging {
+  val companion = Fasta2Adam
+
+  def run(sc: SparkContext, job: Job) {
+    log.info("Loading FASTA data from disk.")
+    val fastaData: RDD[(LongWritable, Text)] = sc.newAPIHadoopFile(args.fastaFile,
+                                                                   classOf[TextInputFormat],
+                                                                   classOf[LongWritable],
+                                                                   classOf[Text])
+
+    val remapData = fastaData.map(kv => (kv._1.get.toInt, kv._2.toString.toString))
+
+    log.info("Converting FASTA to ADAM.")
+    val adamFasta = FastaConverter(remapData)
+
+    if (args.verbose) {
+      println("FASTA contains:")
+      println(adamFasta.adamGetSequenceDictionary())
+    }
+
+    val remapped = if (args.reads != "") {
+      val readDict = sc.adamDictionaryLoad[ADAMRecord](args.reads)
+
+      if (args.verbose) {
+        println("Remapping with:")
+        println(readDict)
+      }
+
+      val remapFasta = adamFasta.adamRewriteContigIds(readDict)
+
+      if (args.verbose) {
+        println("After remapping, have:")
+        println(remapFasta.adamGetSequenceDictionary())
+      }
+
+      remapFasta
+    } else {
+      adamFasta
+    }
+
+    log.info("Writing records to disk.")
+    remapped.adamSave(args.outputPath, blockSize = args.blockSize, pageSize = args.pageSize,
+                      compressCodec = args.compressionCodec, disableDictionaryEncoding = args.disableDictionary)
+  }
+}
+

--- a/adam-core/src/main/scala/edu/berkeley/cs/amplab/adam/converters/FastaConverter.scala
+++ b/adam-core/src/main/scala/edu/berkeley/cs/amplab/adam/converters/FastaConverter.scala
@@ -1,0 +1,166 @@
+/*
+ * Copyright (c) 2014. Regents of the University of California
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package edu.berkeley.cs.amplab.adam.converters
+
+import edu.berkeley.cs.amplab.adam.avro.{ADAMNucleotideContig, Base}
+import edu.berkeley.cs.amplab.adam.rdd.AdamContext._
+import org.apache.spark.rdd.RDD
+import org.apache.spark.SparkContext._
+import scala.math.Ordering._
+
+/**
+ * Object for converting an RDD containing FASTA sequence data into ADAM FASTA data.
+ */
+private[adam] object FastaConverter {
+
+  /**
+   * Converts an RDD containing ints and strings into an RDD containing ADAM nucleotide contig assemblies.
+   *
+   * @note Input dataset is assumed to have come in from a Hadoop TextInputFormat reader. This sets
+   * a specific format for the RDD's Key-Value pairs.
+   *
+   * @throws AssertionError Thrown if there appear to be multiple sequences in a single file
+   * that do not have descriptions.
+   * @throws IllegalArgumentError Thrown if a sequence does not have sequence data.
+   * 
+   * @param rdd RDD containing Int,String tuples, where the Int corresponds to the number
+   * of the file line, and the String is the line of the file.
+   * @return An RDD of ADAM FASTA data.
+   */
+  def apply (rdd: RDD[(Int, String)]): RDD[ADAMNucleotideContig] = {
+    val filtered = rdd.map(kv => (kv._1, kv._2.trim()))
+      .filter((kv: (Int, String)) => !kv._2.startsWith(";"))
+
+    val indices: Map[Int, Int] = rdd.filter(kv => kv._2.startsWith(">"))
+      .map(kv => kv._1)
+      .collect()
+      .sortWith(_ < _)
+      .zipWithIndex
+      .reverse
+      .toMap
+
+    val groupedContigs: RDD[(Int, Seq[(Int, String)])] = if (indices.size == 0) {
+      filtered.keyBy(kv => -1)
+        .groupByKey()
+    } else {
+      filtered.keyBy((kv: (Int, String)) => indices.find(p => p._1 <= kv._1))
+        .filter((kv: (Option[(Int, Int)], (Int, String))) => kv._1.isDefined)
+        .map(kv => (kv._1.get._2, kv._2))
+        .groupByKey()
+    }
+    
+    val converter = new FastaConverter
+
+    val convertedData = groupedContigs.map(kv => {
+      val (id, lines) = kv
+
+      val descriptionLine = lines.filter(kv => kv._2.startsWith(">"))
+
+      val (name, comment): (Option[String], Option[String]) = if (descriptionLine.size == 0) {
+        assert(id == -1, "Cannot have a headerless line in a file with more than one fragment.")
+        (None, None)
+      } else if (descriptionLine.forall(kv => kv._2.contains(' '))) {
+        val description: String = descriptionLine.head._2
+        val splitIndex = description.indexOf(' ')
+        val split = description.splitAt(splitIndex)
+
+        val contigName: String = split._1.stripPrefix(">").trim
+        val contigDescription: String = split._2.trim
+        
+        (Some(contigName), Some(contigDescription))
+      } else {
+        (Some(descriptionLine.head._2.stripPrefix(">").trim), None)
+      }
+
+      val seqId = if (id == -1) {
+        0
+      } else {
+        id
+      }
+      
+      val sequenceLines = lines.filter(kv => !kv._2.startsWith(">"))
+      assert(sequenceLines.length != 0, "Sequence " + seqId + " has no sequence data.")
+
+      val sequence = sequenceLines.sortBy(kv => kv._1)
+          .map(kv => kv._2.stripSuffix("*"))
+          .reduce(_ + _)
+
+      converter.convert(name, seqId, sequence, comment)
+    })
+
+    convertedData
+  }
+}
+
+/**
+ * Conversion methods for single FASTA sequences into ADAM FASTA data.
+ */
+private[converters] class FastaConverter extends Serializable {
+
+  /**
+   * Converts a string of nucleotides into an array of Base.
+   *
+   * @see Base
+   * @throws IllegalArgumentException Thrown if sequence contains an illegal character.
+   *
+   * @param sequence Nucleotide string.
+   * @return An array of Base enums.
+   */
+  def convertSequence (sequence: String): List[Base] = {
+    sequence.toList.map((c: Char) => {
+      try {
+        Base.valueOf(c.toString.toUpperCase)
+      } catch {
+        case iae: java.lang.IllegalArgumentException => {
+          throw new IllegalArgumentException(c + " in FASTA is an invalid base.")
+        }
+      }
+    })
+  }
+
+  /**
+   * Converts a single FASTA sequence into an ADAM FASTA contig.
+   *
+   * @throws IllegalArgumentException Thrown if sequence contains an illegal character.
+   *
+   * @param name String option for the sequence name.
+   * @param id Numerical identifier for the sequence.
+   * @param sequence Nucleotide sequence.
+   * @param description Optional description of the sequence.
+   * @return The converted ADAM FASTA contig.
+   */
+  def convert (name: Option[String], 
+               id: Int, 
+               sequence: String,
+               description: Option[String]): ADAMNucleotideContig = {
+
+    // convert sequence to sequence array
+    val bases = convertSequence(sequence)
+    
+    // make new builder and set up non-optional fields
+    val builder = ADAMNucleotideContig.newBuilder()
+      .setContigId(id)
+      .setSequence(bases)
+      .setSequenceLength(sequence.length)
+
+    // map over optional fields
+    name.foreach((n: String) => builder.setContigName(n))
+    description.foreach(builder.setDescription(_))
+    
+    // build and return
+    builder.build()
+  }
+}

--- a/adam-core/src/main/scala/edu/berkeley/cs/amplab/adam/projections/ADAMNucleotideContigField.scala
+++ b/adam-core/src/main/scala/edu/berkeley/cs/amplab/adam/projections/ADAMNucleotideContigField.scala
@@ -1,0 +1,36 @@
+/*
+ * Copyright (c) 2013. Regents of the University of California
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package edu.berkeley.cs.amplab.adam.projections
+
+import edu.berkeley.cs.amplab.adam.avro.ADAMNucleotideContig
+
+/**
+ * This enumeration exist in order to reduce typo errors in the code. It needs to be kept
+ * in sync with any changes to ADAMRecord.
+ *
+ * This enumeration is necessary because Parquet needs the field string names
+ * for predicates and projections.
+ */
+object ADAMNucleotideContigField extends FieldEnumeration(ADAMNucleotideContig.SCHEMA$) {
+
+  val contigName,
+  contigId,
+  description,
+  sequence,
+  sequenceLength,
+  url = SchemaValue
+}

--- a/adam-core/src/main/scala/edu/berkeley/cs/amplab/adam/rdd/AdamRDDFunctions.scala
+++ b/adam-core/src/main/scala/edu/berkeley/cs/amplab/adam/rdd/AdamRDDFunctions.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2013. Regents of the University of California
+ * Copyright (c) 2013-2014. Regents of the University of California
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -21,7 +21,7 @@ import parquet.hadoop.ParquetOutputFormat
 import parquet.avro.{AvroParquetOutputFormat, AvroWriteSupport}
 import parquet.hadoop.util.ContextUtil
 import org.apache.avro.specific.SpecificRecord
-import edu.berkeley.cs.amplab.adam.avro.{ADAMPileup, ADAMRecord, ADAMVariant, ADAMGenotype, ADAMVariantDomain}
+import edu.berkeley.cs.amplab.adam.avro.{ADAMPileup, ADAMRecord, ADAMVariant, ADAMGenotype, ADAMVariantDomain, ADAMNucleotideContig}
 import edu.berkeley.cs.amplab.adam.models.{SequenceRecord, SequenceDictionary, SingleReadBucket, SnpTable, ReferencePosition, ADAMRod}
 import org.apache.spark.rdd.RDD
 import org.apache.spark.SparkContext._
@@ -372,4 +372,58 @@ class AdamGenotypeRDDFunctions(rdd: RDD[ADAMGenotype]) extends Serializable {
 
     groupedGenotypesWithVariants.map(_._2).flatMap(vg => computer.convert(vg._1, vg._2, variantProjection))
   }
+}
+
+class AdamNucleotideContigRDDFunctions(rdd: RDD[ADAMNucleotideContig]) extends Serializable with Logging {
+  
+  /**
+   * Rewrites the contig IDs of a FASTA reference set to match the contig IDs present in a
+   * different sequence dictionary. Sequences are matched by name.
+   *
+   * @note Contigs with names that aren't present in the provided dictionary are filtered out of the RDD.
+   *
+   * @param sequenceDict A sequence dictionary containing the preferred IDs for the contigs.
+   * @return New set of contigs with IDs rewritten.
+   */
+  def adamRewriteContigIds (sequenceDict: SequenceDictionary): RDD[ADAMNucleotideContig] = {
+    // broadcast sequence dictionary
+    val bcastDict = rdd.context.broadcast(sequenceDict)
+
+    /**
+     * Remaps a single contig.
+     *
+     * @param contig Contig to remap.
+     * @param dictionary A sequence dictionary containing the IDs to use for remapping.
+     * @return An option containing the remapped contig if it's sequence name was found in the dictionary.
+     */
+    def remapContig (contig: ADAMNucleotideContig, dictionary: SequenceDictionary): Option[ADAMNucleotideContig] = {
+      val name: CharSequence = contig.getContigName
+      
+      if (dictionary.containsRefName(name)) {
+        val newId = dictionary(contig.getContigName).id
+        val newContig = ADAMNucleotideContig.newBuilder(contig)
+          .setContigId(newId)
+          .build()
+        
+        Some(newContig)
+      } else {
+        None
+      }
+    }
+
+    // remap all contigs
+    rdd.flatMap(c => remapContig(c, bcastDict.value))
+  }
+
+  /**
+   * From this set of contigs, returns a sequence dictionary.
+   *
+   * @see AdamRecordRDDFunctions#sequenceDictionary
+   * 
+   * @return Sequence dictionary representing this reference.
+   */
+  def adamGetSequenceDictionary(): SequenceDictionary =
+    rdd.distinct().aggregate(SequenceDictionary())(
+      (dict: SequenceDictionary, ctg: ADAMNucleotideContig) => dict ++ Seq(SequenceRecord.fromADAMContig(ctg)),
+      (dict1: SequenceDictionary, dict2: SequenceDictionary) => dict1 ++ dict2)
 }

--- a/adam-core/src/main/scala/edu/berkeley/cs/amplab/adam/serialization/AdamKryoRegistrator.scala
+++ b/adam-core/src/main/scala/edu/berkeley/cs/amplab/adam/serialization/AdamKryoRegistrator.scala
@@ -19,7 +19,7 @@ import org.apache.avro.specific.{SpecificDatumWriter, SpecificDatumReader, Speci
 import com.esotericsoftware.kryo.{Kryo, Serializer}
 import com.esotericsoftware.kryo.io.{Input, Output}
 import org.apache.avro.io.{BinaryDecoder, DecoderFactory, BinaryEncoder, EncoderFactory}
-import edu.berkeley.cs.amplab.adam.avro.{ADAMGenotype, ADAMPileup, ADAMRecord}
+import edu.berkeley.cs.amplab.adam.avro.{ADAMGenotype, ADAMPileup, ADAMRecord, ADAMNucleotideContig}
 import edu.berkeley.cs.amplab.adam.models._
 import it.unimi.dsi.fastutil.io.{FastByteArrayInputStream, FastByteArrayOutputStream}
 import org.apache.spark.serializer.KryoRegistrator
@@ -67,6 +67,7 @@ class AdamKryoRegistrator extends KryoRegistrator {
     kryo.register(classOf[ADAMRecord], new AvroSerializer[ADAMRecord]())
     kryo.register(classOf[ADAMPileup], new AvroSerializer[ADAMPileup]())
     kryo.register(classOf[ADAMGenotype], new AvroSerializer[ADAMGenotype]())
+    kryo.register(classOf[ADAMNucleotideContig], new AvroSerializer[ADAMNucleotideContig]())
     kryo.register(classOf[ReferencePositionWithOrientation], new ReferencePositionWithOrientationSerializer)
     kryo.register(classOf[ReferencePosition], new ReferencePositionSerializer)
     kryo.register(classOf[ReferencePositionPair], new ReferencePositionPairSerializer)

--- a/adam-core/src/test/scala/edu/berkeley/cs/amplab/adam/converters/FastaConverterSuite.scala
+++ b/adam-core/src/test/scala/edu/berkeley/cs/amplab/adam/converters/FastaConverterSuite.scala
@@ -1,0 +1,169 @@
+/**
+ * Copyright (c) 2014. Regents of the University of California
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package edu.berkeley.cs.amplab.adam.converters
+
+import edu.berkeley.cs.amplab.adam.avro.{ADAMNucleotideContig, Base}
+import edu.berkeley.cs.amplab.adam.rdd.AdamContext._
+import edu.berkeley.cs.amplab.adam.util.SparkFunSuite
+import org.apache.spark.rdd.RDD
+import org.scalatest.FunSuite
+
+class FastaConverterSuite extends SparkFunSuite {
+  
+  val converter = new FastaConverter()
+
+  test ("converting illegal sequence fails") {
+    intercept[IllegalArgumentException] {
+      converter.convertSequence(" *")
+    }
+
+    intercept[IllegalArgumentException] {
+      converter.convert(None, 0, "__", None)
+    }
+  }
+
+  test ("convert short simple sequence") {
+    val convSeq = converter.convertSequence("ACTG")
+    assert(convSeq.length === 4)
+
+    val seqFromSeq = convSeq.map(_.toString).reduce(_ + _)
+    assert(seqFromSeq === "ACTG")
+  }
+
+  test ("convert lowercase sequence") {
+    val convSeq = converter.convertSequence("actg")
+    assert(convSeq.length === 4)
+
+    val seqFromSeq = convSeq.map(_.toString).reduce(_ + _)
+    assert(seqFromSeq === "ACTG")
+  }
+
+  test ("convert a single record without naming information") {
+    val contig = converter.convert(None, 0, "AAATTTGCGC", None)
+
+    assert(contig.getContigId === 0)
+    assert(contig.getSequence.map(_.toString).reduce(_ + _) === "AAATTTGCGC")
+    assert(contig.getSequenceLength === 10)
+    assert(contig.getContigName === null)
+    assert(contig.getDescription === null)
+  }
+
+  test ("convert a single record with naming information") {
+    val contig = converter.convert(Some("chr2"), 1, "NNNN", Some("hg19"))
+
+    assert(contig.getContigId === 1)
+    assert(contig.getSequence.map(_.toString).reduce(_ + _) === "NNNN")
+    assert(contig.getSequenceLength === 4)
+    assert(contig.getContigName === "chr2")
+    assert(contig.getDescription === "hg19")
+  }
+
+  sparkTest ("convert single fasta sequence") {
+    val fasta = List(( 0, "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAGGGGGGGGGGAAAAAAAAAAGGGGGGGGGGAAAAAA"),
+                     ( 1, "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA"),
+                     ( 2, "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA"),
+                     ( 3, "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA"),
+                     ( 4, "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA"),
+                     ( 5, "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA"),
+                     ( 6, "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA"),
+                     ( 7, "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA"),
+                     ( 8, "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA"),
+                     ( 9, "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA"),
+                     (10, "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA"),
+                     (11, "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA"),
+                     (12, "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA"),
+                     (13, "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA"),
+                     (14, "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA"),
+                     (15, "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA"))
+    val rdd = sc.parallelize(fasta.toSeq)
+
+    val adamFasta = FastaConverter(rdd)
+    assert(adamFasta.count === 1)
+
+    val fastaElement = adamFasta.first()
+    val fastaSequence = fasta.map(_._2).reduce(_ + _)
+    val convertedSequence = fastaElement.getSequence.map(_.toString).reduce(_ + _)
+
+    assert(fastaElement.getContigId() === 0)
+    assert(convertedSequence === fastaSequence)
+    assert(fastaElement.getSequenceLength() == fastaSequence.length)
+    assert(fastaElement.getContigName === null)
+    assert(fastaElement.getDescription === null)
+  }
+
+  sparkTest ("convert fasta with multiple sequences") {
+    val fasta1 = List(( 0, ">chr1"),
+                      ( 1, "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAGGGGGGGGGGAAAAAAAAAAGGGGGGGGGGAAAAAA"),
+                      ( 2, "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA"),
+                      ( 3, "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA"),
+                      ( 4, "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA"),
+                      ( 5, "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA"),
+                      ( 6, "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA"),
+                      ( 7, "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA"),
+                      ( 8, "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA"),
+                      ( 9, "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA"),
+                      (10, "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA"),
+                      (11, "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA"),
+                      (12, "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA"),
+                      (13, "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA"),
+                      (14, "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA"),
+                      (15, "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA"),
+                      (16, "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA"))
+    val fasta2 = List((17, ">chr2"),
+                      (18, "CCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCTTTTTTTTTTCCCCCCCCCCTTTTTTTTTTCCCCCC"),
+                      (19, "CCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC"),
+                      (20, "CCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC"),
+                      (21, "CCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC"),
+                      (22, "CCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC"),
+                      (23, "CCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC"),
+                      (24, "CCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC"),
+                      (25, "CCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC"),
+                      (26, "CCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC"),
+                      (27, "CCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC"),
+                      (28, "CCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC"),
+                      (29, "CCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC"),
+                      (30, "CCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC"),
+                      (31, "CCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC"),
+                      (32, "CCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC"),
+                      (33, "CCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC"))
+    val fasta = fasta1 ::: fasta2
+    val rdd = sc.parallelize(fasta.toSeq)
+
+    val adamFasta = FastaConverter(rdd)
+    assert(adamFasta.count === 2)
+
+    val fastaElement1 = adamFasta.filter(_.getContigName == "chr1").first()
+    val fastaSequence1 = fasta1.drop(1).map(_._2).reduce(_ + _)
+    val convertedSequence1 = fastaElement1.getSequence.map(_.toString).reduce(_ + _)
+
+    assert(fastaElement1.getContigId() === 0)
+    assert(convertedSequence1 === fastaSequence1)
+    assert(fastaElement1.getSequenceLength() == fastaSequence1.length)
+    assert(fastaElement1.getContigName().toString === "chr1")
+    assert(fastaElement1.getDescription === null)
+
+    val fastaElement2 = adamFasta.filter(_.getContigName == "chr2").first()
+    val fastaSequence2 = fasta2.drop(1).map(_._2).reduce(_ + _)
+    val convertedSequence2 = fastaElement2.getSequence.map(_.toString).reduce(_ + _)
+
+    assert(fastaElement2.getContigId() === 1)
+    assert(convertedSequence2 === fastaSequence2)
+    assert(fastaElement2.getSequenceLength() == fastaSequence2.length)
+    assert(fastaElement2.getContigName().toString === "chr2")
+    assert(fastaElement2.getDescription === null)
+  }
+
+}

--- a/adam-core/src/test/scala/edu/berkeley/cs/amplab/adam/models/SequenceDictionarySuite.scala
+++ b/adam-core/src/test/scala/edu/berkeley/cs/amplab/adam/models/SequenceDictionarySuite.scala
@@ -177,6 +177,38 @@ class SequenceDictionarySuite extends FunSuite {
     assert(s1 === s3)
   }
 
+  test("containsRefName works correctly") {
+    val dict = SequenceDictionary(record(0, "chr0"),
+                                  record(1, "chr1"),
+                                  record(2, "chr2"),
+                                  record(3, "chr3"))
+    val str0: String = "chr0"
+    val str1: java.lang.String = "chr1"
+    val str2: CharSequence = "chr2"
+    val str3: java.lang.CharSequence = "chr3"
+
+    assert(dict.containsRefName(str0))
+    assert(dict.containsRefName(str1))
+    assert(dict.containsRefName(str2))
+    assert(dict.containsRefName(str3))
+  }
+
+  test("apply on name works correctly") {
+    val dict = SequenceDictionary(record(0, "chr0"),
+                                  record(1, "chr1"),
+                                  record(2, "chr2"),
+                                  record(3, "chr3"))
+    val str0: String = "chr0"
+    val str1: java.lang.String = "chr1"
+    val str2: CharSequence = "chr2"
+    val str3: java.lang.CharSequence = "chr3"
+
+    assert(dict(str0).id === 0)
+    assert(dict(str1).id === 1)
+    assert(dict(str2).id === 2)
+    assert(dict(str3).id === 3)
+  }
+
   def record(id: Int, name: String, length: Int = 1000, url: String = null): SequenceRecord =
     SequenceRecord(id, name, length, url)
 }

--- a/adam-format/src/main/resources/avro/adam.avdl
+++ b/adam-format/src/main/resources/avro/adam.avdl
@@ -67,13 +67,6 @@ record ADAMRecord {
     union { null, string } mateReferenceUrl = null;
 }
 
-record ADAMFastaFragment {
-    union {null, string } description = null;
-    union {null, long } start = null;
-    union {null, long } end = null;
-    union {null, string } sequence = null;
-}
-
 enum Base {
     A,
     C,
@@ -92,6 +85,15 @@ enum Base {
     V, // not T
     H, // not G
     D  // not C
+}
+
+record ADAMNucleotideContig {
+    union { null, string } contigName = null;
+    union { null, int } contigId = null;
+    union { null, string } description = null;
+    array<Base> sequence = [];
+    union { null, long } sequenceLength = null;
+    union { null, string } url = null;
 }
 
 record ADAMPileup {


### PR DESCRIPTION
Added converter, and modified ADAM FASTA record to a more generic ADAMNucleotideContig record. This adds a command which allows for text FASTA files to be imported into ADAM; specifically, we support an _expansion_ of the FASTA standard, where multiple FASTA files that include the name of the contig they specify can be concatenated into a file. Additionally, we allow the referenceIds of sequences from a FASTA to be rewritten to correspond with the referenceIds present in a current read file.
