### PR TITLE
Added function for building variant context from genotypes.

### DIFF
--- a/adam-core/src/main/scala/edu/berkeley/cs/amplab/adam/models/ADAMVariantContext.scala
+++ b/adam-core/src/main/scala/edu/berkeley/cs/amplab/adam/models/ADAMVariantContext.scala
@@ -16,6 +16,7 @@
 package edu.berkeley.cs.amplab.adam.models
 
 import edu.berkeley.cs.amplab.adam.avro.{ADAMVariant, ADAMGenotype, ADAMVariantDomain}
+import edu.berkeley.cs.amplab.adam.converters.GenotypesToVariantsConverter
 import org.apache.spark.SparkContext._
 import org.apache.spark.rdd.RDD
 
@@ -76,6 +77,25 @@ object ADAMVariantContext {
   private def apply(kv: (Long, (Seq[ADAMVariant], Seq[ADAMGenotype], Option[ADAMVariantDomain]))
                      ): ADAMVariantContext = {
     new ADAMVariantContext(kv._1, kv._2._1, kv._2._2, kv._2._3)
+  }
+
+  /**
+   * Builds a variant context off of a set of genotypes. Builds variants from the genotypes.
+   *
+   * @note Genotypes must be at the same position.
+   *
+   * @param genotypes List of genotypes to build variant context from.
+   * @return A variant context corresponding to the variants and genotypes at this site.
+   */
+  def buildFromGenotypes(genotypes: Seq[ADAMGenotype]): ADAMVariantContext = {
+    val position = genotypes.head.getPosition
+    assert(genotypes.map(_.getPosition).forall(_ == position), "Genotypes do not all have the same position.")
+
+    val converter = new GenotypesToVariantsConverter(false, false)
+    
+    val variants = converter.convert(genotypes)
+
+    new ADAMVariantContext(position, variants, genotypes, None)
   }
 }
 

--- a/adam-core/src/test/scala/edu/berkeley/cs/amplab/adam/models/ADAMVariantContextSuite.scala
+++ b/adam-core/src/test/scala/edu/berkeley/cs/amplab/adam/models/ADAMVariantContextSuite.scala
@@ -112,4 +112,148 @@ class ADAMVariantContextSuite extends SparkFunSuite {
     assert(vc.count === 0)
   }
 
+  test("build a variant context from a single genotype") {
+    val genotype0 = ADAMGenotype.newBuilder()
+      .setPosition(0L)
+      .setSampleId("mySample0")
+      .setAllele("A")
+      .setReferenceAllele("A")
+      .setIsReference(true)
+      .setRmsMappingQuality(40)
+      .setRmsBaseQuality(30)
+      .setDepth(2)
+      .setReferenceId(1)
+      .setReferenceName("myRef")
+      .setGenotypeQuality(50)
+      .setReadsMappedMapQ0(0)
+      .setReadsMappedForwardStrand(1)
+      .build()
+
+    val gtSeq = Seq(genotype0)
+
+    val vc = ADAMVariantContext.buildFromGenotypes(gtSeq)
+
+    assert(vc.position === 0L)
+    assert(vc.variants.length === 1L)
+  }
+
+  test("build a variant context from multiple genotypes that represent the same variant") {
+    val genotype0 = ADAMGenotype.newBuilder()
+      .setPosition(0L)
+      .setSampleId("mySample0")
+      .setAllele("A")
+      .setReferenceAllele("A")
+      .setIsReference(true)
+      .setRmsMappingQuality(40)
+      .setRmsBaseQuality(30)
+      .setDepth(2)
+      .setReferenceId(1)
+      .setReferenceName("myRef")
+      .setGenotypeQuality(50)
+      .setReadsMappedMapQ0(0)
+      .setReadsMappedForwardStrand(1)
+      .build()
+    val genotype1 = ADAMGenotype.newBuilder()
+      .setPosition(0L)
+      .setSampleId("mySample1")
+      .setAllele("A")
+      .setReferenceAllele("A")
+      .setIsReference(true)
+      .setRmsMappingQuality(40)
+      .setRmsBaseQuality(30)
+      .setDepth(2)
+      .setReferenceId(1)
+      .setReferenceName("myRef")
+      .setGenotypeQuality(50)
+      .setReadsMappedMapQ0(0)
+      .setReadsMappedForwardStrand(1)
+      .build()
+
+    val gtSeq = Seq(genotype0, genotype1)
+
+    val vc = ADAMVariantContext.buildFromGenotypes(gtSeq)
+
+    assert(vc.position === 0L)
+    assert(vc.variants.length === 1L)
+  }
+
+  test("build a variant context from multiple genotypes that represent different variants") {
+    val genotype0 = ADAMGenotype.newBuilder()
+      .setPosition(0L)
+      .setSampleId("mySample0")
+      .setAllele("A")
+      .setReferenceAllele("A")
+      .setIsReference(true)
+      .setRmsMappingQuality(40)
+      .setRmsBaseQuality(30)
+      .setDepth(2)
+      .setReferenceId(1)
+      .setReferenceName("myRef")
+      .setGenotypeQuality(50)
+      .setReadsMappedMapQ0(0)
+      .setReadsMappedForwardStrand(1)
+      .build()
+    val genotype1 = ADAMGenotype.newBuilder()
+      .setPosition(0L)
+      .setSampleId("mySample1")
+      .setAllele("T")
+      .setReferenceAllele("A")
+      .setIsReference(true)
+      .setRmsMappingQuality(40)
+      .setRmsBaseQuality(30)
+      .setDepth(2)
+      .setReferenceId(1)
+      .setReferenceName("myRef")
+      .setGenotypeQuality(50)
+      .setReadsMappedMapQ0(0)
+      .setReadsMappedForwardStrand(1)
+      .build()
+
+    val gtSeq = Seq(genotype0, genotype1)
+
+    val vc = ADAMVariantContext.buildFromGenotypes(gtSeq)
+
+    assert(vc.position === 0L)
+    assert(vc.variants.length === 2L)
+  }
+
+  test("cannot build a variant context from variants at different sites") {
+    val genotype0 = ADAMGenotype.newBuilder()
+      .setPosition(0L)
+      .setSampleId("mySample0")
+      .setAllele("A")
+      .setReferenceAllele("A")
+      .setIsReference(true)
+      .setRmsMappingQuality(40)
+      .setRmsBaseQuality(30)
+      .setDepth(2)
+      .setReferenceId(1)
+      .setReferenceName("myRef")
+      .setGenotypeQuality(50)
+      .setReadsMappedMapQ0(0)
+      .setReadsMappedForwardStrand(1)
+      .build()
+    val genotype1 = ADAMGenotype.newBuilder()
+      .setPosition(1L)
+      .setSampleId("mySample1")
+      .setAllele("A")
+      .setReferenceAllele("A")
+      .setIsReference(true)
+      .setRmsMappingQuality(40)
+      .setRmsBaseQuality(30)
+      .setDepth(2)
+      .setReferenceId(1)
+      .setReferenceName("myRef")
+      .setGenotypeQuality(50)
+      .setReadsMappedMapQ0(0)
+      .setReadsMappedForwardStrand(1)
+      .build()
+
+    val gtSeq = Seq(genotype0, genotype1)
+
+    intercept[AssertionError] {
+      ADAMVariantContext.buildFromGenotypes(gtSeq)
+    }
+  }
+
 }


### PR DESCRIPTION
Provides a function for building aggregated variant context from genotype data. This is useful for joint variant callers, as it saves a join if data is already grouped by position.
