### PR TITLE
Minor change, increase adam-cli usage width to 150 characters

### DIFF
--- a/adam-cli/src/main/scala/edu/berkeley/cs/amplab/adam/cli/Args4j.scala
+++ b/adam-cli/src/main/scala/edu/berkeley/cs/amplab/adam/cli/Args4j.scala
@@ -33,6 +33,7 @@ object Args4j {
   def apply[T <% Args4jBase : Manifest](args: Array[String]): T = {
     val args4j: T = manifest[T].erasure.asInstanceOf[Class[T]].newInstance()
     val parser = new CmdLineParser(args4j)
+    parser.setUsageWidth(150);
 
     def displayHelp(exitCode: Int = 0) = {
       parser.printUsage(System.out)


### PR DESCRIPTION
Most of my terminal windows are set wider than 60 characters, merge or close without as you wish.
