### PR TITLE
Encoding tag types in the ADAMRecord attributes, adding the 'tags' command

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -23,6 +23,10 @@ Trunk (not yet released)
 
   IMPROVEMENTS
 
+  * ISSUE 92: improved the representation of the types of 'optional' fields from the BAM, and their encoding
+    in the 'attributes' field of ADAMRecord.  This encoding now includes the type, and should no longer be 
+	lossy, therefore making it possible to write code to re-export a BAM from the ADAM file in the future.
+
   BUG FIXES
 
   * Fixed issues where VCF header was not being written correctly. This prevented variant calls from being

--- a/adam-cli/src/main/scala/edu/berkeley/cs/amplab/adam/cli/AdamMain.scala
+++ b/adam-cli/src/main/scala/edu/berkeley/cs/amplab/adam/cli/AdamMain.scala
@@ -21,6 +21,7 @@ import scala.Some
 object AdamMain extends Logging {
 
   private val commands = List(Transform,
+    PrintTags,
     FlagStat,
     Reads2Ref,
     MpileupCommand,

--- a/adam-cli/src/main/scala/edu/berkeley/cs/amplab/adam/cli/PrintTags.scala
+++ b/adam-cli/src/main/scala/edu/berkeley/cs/amplab/adam/cli/PrintTags.scala
@@ -1,0 +1,91 @@
+/**
+ * Copyright 2014 Genome Bridge LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package edu.berkeley.cs.amplab.adam.cli
+
+import edu.berkeley.cs.amplab.adam.util.ParquetLogger
+import edu.berkeley.cs.amplab.adam.rdd.AdamContext._
+import org.kohsuke.args4j.{Option, Argument}
+import org.apache.spark.SparkContext
+import org.apache.hadoop.mapreduce.Job
+import java.util.logging.Level
+import edu.berkeley.cs.amplab.adam.avro.ADAMRecord
+import edu.berkeley.cs.amplab.adam.projections.{Projection, ADAMRecordField}
+import org.apache.spark.rdd.RDD
+import ADAMRecordField._
+
+
+/**
+ * Reads in the tagStrings field of every record, and prints out the set of unique
+ * tags found in those fields along with the number of records that have each particular
+ * tag.
+ */
+object PrintTags extends AdamCommandCompanion {
+  val commandName: String = "print_tags"
+  val commandDescription: String = "Prints the values and counts of all tags in a set of records"
+
+  def apply(cmdLine: Array[String]): AdamCommand = {
+    new PrintTags(Args4j[PrintTagsArgs](cmdLine))
+  }
+}
+
+class PrintTagsArgs extends Args4jBase with SparkArgs with ParquetArgs {
+  @Argument(required = true, metaVar = "INPUT", usage = "The ADAM file to scan for tags", index = 0)
+  val inputPath: String = null
+
+  @Option(required = false, name = "-list",
+    usage = "When value is set to <N>, also lists the first N attribute fields for ADAMRecords in the input")
+  var list :String = null
+
+  @Option(required = false, name = "-count",
+    usage = "comma-separated list of tag names; for each tag listed, we print the distinct values and their counts")
+  var count :String = null
+
+}
+
+class PrintTags(protected val args: PrintTagsArgs) extends AdamSparkCommand[PrintTagsArgs] {
+  val companion: AdamCommandCompanion = PrintTags
+
+  def run(sc: SparkContext, job: Job): Unit = {
+
+    // Quiet parquet logging...
+    ParquetLogger.hadoopLoggerLevel(Level.SEVERE)
+
+    val toCount = if(args.count != null) args.count.split(",").toSet else Set()
+
+    val proj = Projection(attributes, primaryAlignment, readMapped, readPaired, failedVendorQualityChecks)
+    val rdd : RDD[ADAMRecord] = sc.adamLoad(args.inputPath, projection=Some(proj))
+    val filtered = rdd.filter(rec => !rec.getFailedVendorQualityChecks)
+
+    if(args.list != null) {
+      val count = args.list.toInt
+      filtered.take(count).map(_.getAttributes).foreach(println)
+    }
+
+    val tagCounts = filtered.adamCharacterizeTags().collect()
+    for( (tag, count) <- tagCounts ) {
+      println("%3s\t%d".format(tag, count))
+      if(toCount.contains(tag)) {
+        val countMap = filtered.adamCharacterizeTagValues(tag)
+        for( (value, valueCount) <- countMap ) {
+          println("\t%10d\t%s".format(valueCount, value.toString))
+        }
+      }
+    }
+
+    println("Total: %d".format(filtered.count()))
+  }
+
+}

--- a/adam-core/src/main/scala/edu/berkeley/cs/amplab/adam/converters/SAMRecordConverter.scala
+++ b/adam-core/src/main/scala/edu/berkeley/cs/amplab/adam/converters/SAMRecordConverter.scala
@@ -19,7 +19,8 @@ import net.sf.samtools.{SAMReadGroupRecord, SAMRecord}
 
 import edu.berkeley.cs.amplab.adam.avro.ADAMRecord
 import scala.collection.JavaConverters._
-import edu.berkeley.cs.amplab.adam.models.{RecordGroupDictionary, SequenceDictionary}
+import edu.berkeley.cs.amplab.adam.models.{Attribute, RecordGroupDictionary, SequenceDictionary}
+import edu.berkeley.cs.amplab.adam.util.AttributeUtils
 
 class SAMRecordConverter extends Serializable {
   def convert(samRecord: SAMRecord, dict: SequenceDictionary, readGroups: RecordGroupDictionary): ADAMRecord = {
@@ -107,16 +108,16 @@ class SAMRecordConverter extends Serializable {
     }
 
     if (samRecord.getAttributes != null) {
-      var attrs = List[String]()
+      var tags = List[Attribute]()
       samRecord.getAttributes.asScala.foreach {
         attr =>
           if (attr.tag == "MD") {
             builder.setMismatchingPositions(attr.value.toString)
           } else {
-            attrs ::= attr.tag + "=" + attr.value
+            tags ::= AttributeUtils.convertSAMTagAndValue(attr)
           }
       }
-      builder.setAttributes(attrs.mkString("\t"))
+      builder.setAttributes(tags.mkString("\t"))
     }
 
     val recordGroup: SAMReadGroupRecord = samRecord.getReadGroup

--- a/adam-core/src/main/scala/edu/berkeley/cs/amplab/adam/models/Attribute.scala
+++ b/adam-core/src/main/scala/edu/berkeley/cs/amplab/adam/models/Attribute.scala
@@ -1,0 +1,48 @@
+/**
+ * Copyright 2014 Genome Bridge LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package edu.berkeley.cs.amplab.adam.models
+
+/**
+ * A wrapper around the attrTuple (key) and value pair.  Includes the attrTuple-type explicitly, rather than
+ * embedding the corresponding information in the type of 'value', because otherwise it'd be difficult
+ * to extract the correct type for Byte and NumericSequence values.
+ *
+ * Roughly analogous to Picards SAMTagAndValue.
+ *
+ * @param tag The string key associated with this pair.
+ * @param tagType An enumerated value representing the type of the 'value' parameter.
+ * @param value The 'value' half of the pair.
+ */
+case class Attribute(tag: String, tagType : TagType.Value, value : Any) {
+  override def toString : String = "%s:%s:%s".format(tag, tagType, value.toString)
+}
+
+object TagType extends Enumeration {
+
+  class TypeVal(val abbreviation : String) extends Val(nextId, abbreviation) {
+    override def toString() : String = abbreviation
+  }
+  def TypeValue(abbreviation : String) : Val = new TypeVal(abbreviation)
+
+  // These String values come from the SAM file format spec: http://samtools.sourceforge.net/SAMv1.pdf
+  val Character = TypeValue("A")
+  val Integer = TypeValue("i")
+  val Float = TypeValue("f")
+  val String = TypeValue("Z")
+  val ByteSequence = TypeValue("H")
+  val NumericSequence = TypeValue("B")
+
+}

--- a/adam-core/src/main/scala/edu/berkeley/cs/amplab/adam/rich/RichADAMRecord.scala
+++ b/adam-core/src/main/scala/edu/berkeley/cs/amplab/adam/rich/RichADAMRecord.scala
@@ -17,9 +17,11 @@ package edu.berkeley.cs.amplab.adam.rich
 
 import edu.berkeley.cs.amplab.adam.avro.ADAMRecord
 import net.sf.samtools.{CigarElement, CigarOperator, Cigar, TextCigarCodec}
-import edu.berkeley.cs.amplab.adam.util.MdTag
 import edu.berkeley.cs.amplab.adam.rdd.AdamContext._
-import edu.berkeley.cs.amplab.adam.util.MdTag
+import edu.berkeley.cs.amplab.adam.util._
+import scala.Some
+import scala.concurrent.JavaConversions._
+import edu.berkeley.cs.amplab.adam.models.Attribute
 
 object RichADAMRecord {
   val CIGAR_CODEC: TextCigarCodec = TextCigarCodec.getSingleton
@@ -39,6 +41,9 @@ class RichADAMRecord(val record: ADAMRecord) {
 
   // Returns the quality scores as a list of bytes
   lazy val qualityScores: Array[Byte] = record.getQual.toString.toCharArray.map(q => (q - 33).toByte)
+
+  // Parse the tags ("key:type:value" triples)
+  lazy val tags: Seq[Attribute] = AttributeUtils.parseAttributes(record.getAttributes.toString)
 
   // Parses the readname to Illumina optics information
   lazy val illuminaOptics: Option[IlluminaOptics] = {

--- a/adam-core/src/main/scala/edu/berkeley/cs/amplab/adam/util/AttributeUtils.scala
+++ b/adam-core/src/main/scala/edu/berkeley/cs/amplab/adam/util/AttributeUtils.scala
@@ -1,0 +1,103 @@
+/*
+ * Copyright 2014 Genome Bridge LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package edu.berkeley.cs.amplab.adam.util
+
+import net.sf.samtools.SAMRecord.SAMTagAndValue
+import edu.berkeley.cs.amplab.adam.models.{TagType, Attribute}
+
+/**
+ * AttributeUtils is a utility object for parsing optional fields from a BAM file, or
+ * the attributes column from an ADAM file.
+ *
+ */
+object AttributeUtils {
+
+  val attrRegex = RegExp("([^:]{2}):([AifZHB]):(.*)")
+
+  def convertSAMTagAndValue(attr : SAMTagAndValue) : Attribute = {
+    attr.value match {
+      case x : java.lang.Integer => Attribute(attr.tag, TagType.Integer, attr.value.asInstanceOf[Int])
+      case x : java.lang.Character => Attribute(attr.tag, TagType.Character, attr.value.asInstanceOf[Char])
+      case x : java.lang.Float => Attribute(attr.tag, TagType.Float, attr.value.asInstanceOf[Float])
+      case x : java.lang.String => Attribute(attr.tag, TagType.String, attr.value.asInstanceOf[String])
+      case Array(_*) => Attribute(attr.tag, TagType.ByteSequence, attr.value.asInstanceOf[Array[java.lang.Byte]])
+      // It appears from the code, that 'H' is encoded as a String as well? I'm not sure
+      // how to pull that out here.
+    }
+  }
+
+  /**
+   * Parses a tab-separated string of attributes (tag:type:value) into a Seq of Attribute values.
+   * @param tagStrings The String to be parsed
+   * @return The parsed Attributes
+   */
+  def parseAttributes(tagStrings: String): Seq[Attribute] =
+    tagStrings.split("\t").filter(_.length > 0).map(parseAttribute)
+
+  /**
+   * Extract the Attribute value from the corresponding String fragment stored in the
+   * ADAMRecord.attributes field.
+   *
+   * @param encoded A three-part ':'-separated string, containing [attrTuple]:[type]:[value]
+   * @return An Attribute value which has the three, extracted and correctly-typed parts of the encoded argument.
+   * @throws IllegalArgumentException if the encoded string doesn't conform to the required regular
+   *         expression ([A-Z]{2}:[AifZHB]:[^\t^]+)
+   */
+  def parseAttribute(encoded : String) : Attribute = {
+    attrRegex.matches(encoded) match {
+      case Some(m) => createAttribute(m.group(1), m.group(2), m.group(3))
+      case None =>
+        throw new IllegalArgumentException(
+          "attribute string \"%s\" doesn't match format attrTuple:type:value".format(encoded))
+    }
+  }
+
+  private def createAttribute(attrTuple: (String,String,String)): Attribute = {
+    val tagName = attrTuple._1
+    val tagTypeString = attrTuple._2
+    val valueStr = attrTuple._3
+
+    // partial match, but these letters should be (per the SAM file format spec)
+    // the only legal values of the tagTypeString anyway.
+    val tagType = tagTypeString match {
+      case "A" => TagType.Character
+      case "i" => TagType.Integer
+      case "f" => TagType.Float
+      case "Z" => TagType.String
+      case "H" => TagType.ByteSequence
+      case "B" => TagType.NumericSequence
+    }
+
+    Attribute(tagName, tagType, typedStringToValue(tagType, valueStr))
+  }
+
+  private def typedStringToValue(tagType : TagType.Value, valueStr : String) : Any = {
+    tagType match {
+      case TagType.Character => valueStr(0)
+      case TagType.Integer => Integer.valueOf(valueStr)
+      case TagType.Float => java.lang.Float.valueOf(valueStr)
+      case TagType.String => valueStr
+      case TagType.ByteSequence => valueStr.map(c => java.lang.Byte.valueOf(""+c))
+      case TagType.NumericSequence => valueStr.split(",").map(c => {
+        if (c.contains(".")) java.lang.Float.valueOf(c)
+        else Integer.valueOf(c)
+      })
+    }
+  }
+}
+
+
+

--- a/adam-core/src/main/scala/edu/berkeley/cs/amplab/adam/util/MapTools.scala
+++ b/adam-core/src/main/scala/edu/berkeley/cs/amplab/adam/util/MapTools.scala
@@ -1,0 +1,51 @@
+/*
+ * Copyright 2014 Genome Bridge LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package edu.berkeley.cs.amplab.adam.util
+
+object MapTools {
+
+  /**
+   * Takes two "count maps" (i.e. Map values that contain numeric counts as the values of the keys),
+   * and does a point-wise add.  For example,
+   *
+   *   add(Map("A"->1, "B"->1), Map("B"->1, "C"->1))
+   *
+   * should be equal to
+   *
+   *   Map("A"->1, "B"->2, "C"->1)
+   *
+   * The operation should be commutative, although it contains a "filter" step on the second addend
+   * (in the current implementation), so if the two maps are of wildly different sizes, you might
+   * want to make the larger map the first argument.
+   *
+   * @param map1 Left addend
+   * @param map2 Right addend
+   * @param ops
+   * @tparam KeyType
+   * @tparam NumberType
+   * @return
+   */
+  def add[KeyType,NumberType](map1 : Map[KeyType,NumberType],
+                              map2 : Map[KeyType,NumberType])
+                             (implicit ops : Numeric[NumberType]) : Map[KeyType,NumberType] = {
+
+    (map1.keys ++ map2.keys.filter(!map1.contains(_))).map {
+      (key : KeyType) =>
+        (key, ops.plus(map1.getOrElse(key, ops.zero), map2.getOrElse(key, ops.zero)))
+    }.toMap
+  }
+
+}

--- a/adam-core/src/main/scala/edu/berkeley/cs/amplab/adam/util/RegExp.scala
+++ b/adam-core/src/main/scala/edu/berkeley/cs/amplab/adam/util/RegExp.scala
@@ -1,0 +1,51 @@
+/*
+ * Copyright 2014 Genome Bridge LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package edu.berkeley.cs.amplab.adam.util
+
+import java.util.regex._
+
+object RegExp {
+  def apply(pattern : String) : RegExp = new RegExp(pattern)
+}
+
+/**
+ * Wraps the java Pattern class, to allow for easier regular expression matching
+ * (including making the matches/finds methods return Option[Matcher], so that we can
+ * flatMap a set of strings with these methods).
+ *
+ * @param patternString The Pattern-compatiable regular expression to be compiled and used for matching.
+ */
+class RegExp(val patternString : String) {
+  val pattern = Pattern.compile(patternString)
+
+  def matches(tgt : String) : Option[Matcher] = {
+    val m = pattern.matcher(tgt)
+    if(m.matches()) {
+      Some(m)
+    } else {
+      None
+    }
+  }
+
+  def find(tgt : String, idx : Int = 0) : Option[Matcher] = {
+    val m = pattern.matcher(tgt)
+    if(m.find(idx)) {
+      Some(m)
+    } else {
+      None
+    }
+  }
+}

--- a/adam-core/src/test/scala/edu/berkeley/cs/amplab/adam/rich/RichADAMRecordSuite.scala
+++ b/adam-core/src/test/scala/edu/berkeley/cs/amplab/adam/rich/RichADAMRecordSuite.scala
@@ -18,6 +18,7 @@ package edu.berkeley.cs.amplab.adam.rich
 import org.scalatest.FunSuite
 import edu.berkeley.cs.amplab.adam.avro.ADAMRecord
 import RichADAMRecord._
+import edu.berkeley.cs.amplab.adam.models.{TagType, Attribute}
 
 class RichADAMRecordSuite extends FunSuite {
 
@@ -72,6 +73,13 @@ class RichADAMRecordSuite extends FunSuite {
     assert( softClippedRead.referencePositions(0) == Some(90L))
 
 
+  }
+
+  test("tags contains optional fields") {
+    val rec = ADAMRecord.newBuilder().setAttributes("XX:i:3\tYY:Z:foo").build()
+    assert(rec.tags.size === 2)
+    assert(rec.tags(0) === Attribute("XX", TagType.Integer, 3))
+    assert(rec.tags(1) === Attribute("YY", TagType.String, "foo"))
   }
 
   test("Reference Positions") {

--- a/adam-core/src/test/scala/edu/berkeley/cs/amplab/adam/util/AttributeUtilsSuite.scala
+++ b/adam-core/src/test/scala/edu/berkeley/cs/amplab/adam/util/AttributeUtilsSuite.scala
@@ -1,0 +1,72 @@
+/**
+ * Copyright 2014 Genome Bridge LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package edu.berkeley.cs.amplab.adam.util
+
+import org.scalatest._
+import net.sf.samtools.SAMRecord.SAMTagAndValue
+import edu.berkeley.cs.amplab.adam.models.{Attribute, TagType}
+
+class AttributeUtilsSuite extends FunSuite {
+
+  import AttributeUtils._
+
+  test("parseTags returns a reasonable set of tagStrings") {
+    val tags = parseAttributes("XT:i:3\tXU:Z:foo,bar")
+
+    assert(tags.size === 2)
+
+    assert(tags.head.tag === "XT")
+    assert(tags.head.tagType === TagType.Integer)
+    assert(tags.head.value === 3)
+
+    assert(tags(1).tag === "XU")
+    assert(tags(1).tagType === TagType.String)
+    assert(tags(1).value === "foo,bar")
+  }
+
+  test("empty string is parsed as zero tagStrings") {
+    assert(parseAttributes("") === Seq[Attribute]())
+  }
+
+  test("incorrectly formatted tag throws an exception") {
+    intercept[IllegalArgumentException] {
+      assert(parseAttributes("XT:i") === Seq[Attribute]())
+    }
+  }
+
+  test("string tag with a ':' in it is correctly parsed") {
+    val string = "foo:bar"
+    val tags = parseAttributes("XX:Z:%s".format(string))
+
+    assert(tags.size === 1)
+    assert(tags.head.value === string)
+  }
+}
+
+class AttributeSuite extends FunSuite {
+
+  import AttributeUtils._
+
+  test("test SAMTagAndValue parsing") {
+    assert(convertSAMTagAndValue(new SAMTagAndValue("XY", 3)) === Attribute("XY", TagType.Integer, 3))
+    assert(convertSAMTagAndValue(new SAMTagAndValue("XY", "foo")) === Attribute("XY", TagType.String, "foo"))
+    assert(convertSAMTagAndValue(new SAMTagAndValue("XY", 3.0f)) === Attribute("XY", TagType.Float, 3.0f))
+    assert(convertSAMTagAndValue(new SAMTagAndValue("XY", 'a')) === Attribute("XY", TagType.Character, 'a'))
+
+    val byteArray : Array[java.lang.Byte] = Seq(java.lang.Byte.valueOf("0"), java.lang.Byte.valueOf("1")).toArray
+    assert(convertSAMTagAndValue(new SAMTagAndValue("XY", byteArray))=== Attribute("XY", TagType.ByteSequence, byteArray))
+  }
+}

--- a/adam-core/src/test/scala/edu/berkeley/cs/amplab/adam/util/MapToolsSuite.scala
+++ b/adam-core/src/test/scala/edu/berkeley/cs/amplab/adam/util/MapToolsSuite.scala
@@ -1,0 +1,56 @@
+/**
+ * Copyright 2014 Genome Bridge LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package edu.berkeley.cs.amplab.adam.util
+
+import org.scalatest._
+
+class MapToolsSuite extends FunSuite {
+
+  test("add two nonzero integer maps") {
+
+    val m1 = Map(55 -> 2, 23 -> 1)
+    val m2 = Map(55 -> 1, 17 -> 10)
+
+    val sum = MapTools.add(m1, m2)
+
+    assert(sum.size === 3)
+    assert(sum(55) === 3)
+    assert(sum(23) === 1)
+    assert(sum(17) === 10)
+  }
+
+  test("add two nonzero float maps") {
+    val m1 = Map(55 -> 2.0f, 23 -> 1.1f)
+    val m2 = Map(55 -> 1.8f, 17 -> 10.2f)
+
+    val sum = MapTools.add(m1, m2)
+
+    assert(sum.size === 3)
+    assert(sum(55) === 2.0f + 1.8f)
+    assert(sum(23) === 1.1f)
+    assert(sum(17) === 10.2f)
+  }
+
+  test("adding an empty map is the identity") {
+    val m1 = Map(55 -> 2, 23 -> 1)
+    val m2 = Map[Int,Int]()
+
+    val sum = MapTools.add(m1, m2)
+
+    assert(sum === m1)
+  }
+
+}

--- a/adam-core/src/test/scala/edu/berkeley/cs/amplab/adam/util/RegExpSuite.scala
+++ b/adam-core/src/test/scala/edu/berkeley/cs/amplab/adam/util/RegExpSuite.scala
@@ -1,0 +1,35 @@
+/**
+ * Copyright 2014 Genome Bridge LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package edu.berkeley.cs.amplab.adam.util
+
+import org.scalatest._
+
+class RegExpSuite extends FunSuite {
+
+  test("matches returns Some(matcher) when a complete match is found") {
+    val re = RegExp("foo(?:a|b)bar")
+    assert(re.matches("fooabar").isDefined)
+    assert(!re.matches("foocbar").isDefined)
+    assert(!re.matches("afooabar").isDefined)
+  }
+
+  test("find returns Some(matcher) when a partial match is found") {
+    val re = RegExp("foo(?:a|b)bar")
+    assert(re.find("fooabar").isDefined)
+    assert(!re.find("foocbar").isDefined)
+    assert(re.find("afooabar").isDefined)
+  }
+}


### PR DESCRIPTION
This commit fixes issue https://github.com/bigdatagenomics/adam/issues/92

The old style of encoding the "optional fields" from the SAM/BAM was to store
them as key=value pairs in the ADAMRecord.attributes string. However, this
loses information about the _type_ of the tag/value, which is necessary if
we want to reconstruct the original value type (for example, for re-exporting
BAM files from ADAM files).

This update is non-backwards-compatible, changing the format of the attributes
field to tag:type:value and introducing a new Attribute class for parsing and
handling these values.  It also adds functions to AdamRDDFunctions to allow for
filtering and subsetting of reads based on their tags, or to count the number of
distinct tags or tag-values across a set of reads.
