### PR TITLE
Added the port erasure to SparkFunSuite's cleanup.

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -66,6 +66,10 @@ Trunk (not yet released)
     fail for some datasets. This was addressed in PR#56. This change was propegated more widely across the
     API by PR#48.
 
+  * ISSUE 103: Added a call to clearProperty('spark.driver.port') in the cleanup from a sparkTest, so that 
+    we correctly clean up the test Spark workers and avoid errors about attempting to bind to a port that's
+	already in use.
+
   BREAKING CHANGES
 
   * ADAMFasta was changed to ADAMNucleotideContig, and internal field types and names were changed in PR #79.

--- a/adam-core/src/test/scala/edu/berkeley/cs/amplab/adam/util/SparkFunSuite.scala
+++ b/adam-core/src/test/scala/edu/berkeley/cs/amplab/adam/util/SparkFunSuite.scala
@@ -26,6 +26,7 @@ object SparkTest extends org.scalatest.Tag("edu.berkeley.cs.amplab.util.SparkFun
 trait SparkFunSuite extends FunSuite with BeforeAndAfter {
 
   val sparkPortProperty = "spark.driver.port"
+
   var sc: SparkContext = _
   var maybeLevels: Option[Map[String, Level]] = None
 
@@ -40,6 +41,7 @@ trait SparkFunSuite extends FunSuite with BeforeAndAfter {
       System.setProperty(sparkPortProperty, s.getLocalPort.toString)
       // Allow Spark to take the port we just discovered
       s.close()
+
       // Create a spark context
       new SparkContext("local[4]", sparkName)
     }
@@ -49,6 +51,14 @@ trait SparkFunSuite extends FunSuite with BeforeAndAfter {
     // Stop the context
     sc.stop()
     sc = null
+
+    // See notes at:
+    // http://blog.quantifind.com/posts/spark-unit-test/
+    // That post calls for clearing 'spark.master.port', but this thread
+    // https://groups.google.com/forum/#!topic/spark-users/MeVzgoJXm8I
+    // suggests that the property was renamed 'spark.driver.port'
+    System.clearProperty(sparkPortProperty)
+
     maybeLevels match {
       case None =>
       case Some(levels) =>


### PR DESCRIPTION
Fixes ISSUE #103

We've been getting intermittent errors, with respect to Spark being unable to bind to a port,
in the context of repeated unit tests.  This apparently is a known problem, see the thread here:
  http://blog.quantifind.com/posts/spark-unit-test/
and the follow-up from Matei here:
  https://groups.google.com/forum/#!topic/spark-users/MeVzgoJXm8I

The upshot is that we need to clearProperty('spark.driver.port') when we shut down our sparkContext
after a sparkTest.
