### PR TITLE
Modified pileup transforms to improve performance + to add options

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -37,6 +37,9 @@ Trunk (not yet released)
   * Transformed phred --> double calculation into a LUT, which improves performance. This change was introduced
     into the API in PR#65 and was a breaking change. This change was then propegated into BQSR by PR#71.
 
+  * Removed unnecessary count during pileup conversion; this count substantially increased the time it took to
+    do pileup conversion. This was introduced in PR#125 which came out of issue #121.
+
   IMPROVEMENTS
 
   * ISSUE 92: improved the representation of the types of 'optional' fields from the BAM, and their encoding
@@ -53,6 +56,11 @@ Trunk (not yet released)
     added by PR#91.
 
   * Various build improvements were added by PR#68 and PR#66.
+
+  * Added option to pileup transformations to set whether reads that are not at their primary alignment positions
+    should be converted into pileups. By default, we only convert reads at a primary mapping location. This
+    is does not introduce incompatible changes to the API, but changes the APIs functionality. This change was
+    introduced in PR#125 which came out of issue #121.
 
   BUG FIXES
 

--- a/adam-cli/src/main/scala/edu/berkeley/cs/amplab/adam/cli/Reads2Ref.scala
+++ b/adam-cli/src/main/scala/edu/berkeley/cs/amplab/adam/cli/Reads2Ref.scala
@@ -48,6 +48,9 @@ class Reads2RefArgs extends Args4jBase with ParquetArgs with SparkArgs {
 
   @option(name = "-aggregate", usage = "Aggregates data at each pileup position, to reduce storage cost.")
   var aggregate: Boolean = false
+
+  @option(name = "-allowNonPrimaryAlignments", usage = "Converts reads that are not at their primary alignment positions to pileups.")
+  var nonPrimary: Boolean = true
 }
 
 class Reads2Ref(protected val args: Reads2RefArgs) extends AdamSparkCommand[Reads2RefArgs] {
@@ -58,7 +61,7 @@ class Reads2Ref(protected val args: Reads2RefArgs) extends AdamSparkCommand[Read
 
     val readCount = reads.count()
 
-    val pileups: RDD[ADAMPileup] = reads.adamRecords2Pileup()
+    val pileups: RDD[ADAMPileup] = reads.adamRecords2Pileup(args.nonPrimary)
 
     val pileupCount = pileups.count()
 

--- a/adam-core/src/main/scala/edu/berkeley/cs/amplab/adam/algorithms/realignmenttarget/RealignmentTargetFinder.scala
+++ b/adam-core/src/main/scala/edu/berkeley/cs/amplab/adam/algorithms/realignmenttarget/RealignmentTargetFinder.scala
@@ -79,7 +79,7 @@ class RealignmentTargetFinder extends Serializable with Logging {
   def findTargets (reads: RDD[ADAMRecord]) : TreeSet[IndelRealignmentTarget] = {
 
     // generate pileups from reads
-    val rods: RDD[Seq[ADAMPileup]] = reads.adamRecords2Pileup()
+    val rods: RDD[Seq[ADAMPileup]] = reads.adamRecords2Pileup(true)
       .groupBy(_.getPosition).map(_._2)
 
     def createTreeSet(target : IndelRealignmentTarget) : TreeSet[IndelRealignmentTarget] = {

--- a/adam-core/src/main/scala/edu/berkeley/cs/amplab/adam/rdd/AdamRDDFunctions.scala
+++ b/adam-core/src/main/scala/edu/berkeley/cs/amplab/adam/rdd/AdamRDDFunctions.scala
@@ -58,8 +58,6 @@ class AdamRDDFunctions[T <% SpecificRecord : Manifest](rdd: RDD[T]) extends Seri
 }
 
 class AdamRecordRDDFunctions(rdd: RDD[ADAMRecord]) extends Serializable with Logging {
-  initLogging()
-
   def adamSortReadsByReferencePosition(): RDD[ADAMRecord] = {
     log.info("Sorting reads by reference position")
 
@@ -125,10 +123,12 @@ class AdamRecordRDDFunctions(rdd: RDD[ADAMRecord]) extends Serializable with Log
 
   /**
    * Groups all reads by reference position and returns a non-aggregated pileup RDD.
+   *
+   * @param secondaryAlignments Creates pileups for non-primary aligned reads. Default is false.
    * @return ADAMPileup without aggregation
    */
-  def adamRecords2Pileup(): RDD[ADAMPileup] = {
-    val helper = new Reads2PileupProcessor
+  def adamRecords2Pileup(secondaryAlignments: Boolean = false): RDD[ADAMPileup] = {
+    val helper = new Reads2PileupProcessor(secondaryAlignments)
     helper.process(rdd)
   }
 
@@ -138,10 +138,11 @@ class AdamRecordRDDFunctions(rdd: RDD[ADAMRecord]) extends Serializable with Log
    *
    * @param bucketSize Size in basepairs of buckets. Larger buckets take more time per
    * bucket to convert, but have lower skew. Default is 1000.
-   * 
+   * @param secondaryAlignments Creates rods for non-primary aligned reads. Default is false.
    * @return RDD of ADAMRods.
    */
-  def adamRecords2Rods (bucketSize: Int = 1000): RDD[ADAMRod] = {
+  def adamRecords2Rods (bucketSize: Int = 1000,
+                        secondaryAlignments: Boolean = false): RDD[ADAMRod] = {
     
     /**
      * Maps a read to one or two buckets. A read maps to a single bucket if both
@@ -170,7 +171,7 @@ class AdamRecordRDDFunctions(rdd: RDD[ADAMRecord]) extends Serializable with Log
 
     println ("Have reads in buckets.")
 
-    val pp = new Reads2PileupProcessor
+    val pp = new Reads2PileupProcessor(secondaryAlignments)
     
     /**
      * Converts all reads in a bucket into rods.
@@ -230,8 +231,6 @@ class AdamRecordRDDFunctions(rdd: RDD[ADAMRecord]) extends Serializable with Log
 }
 
 class AdamPileupRDDFunctions(rdd: RDD[ADAMPileup]) extends Serializable with Logging {
-  initLogging()
-
   /**
    * Aggregates pileup bases together.
    *
@@ -260,8 +259,6 @@ class AdamPileupRDDFunctions(rdd: RDD[ADAMPileup]) extends Serializable with Log
 }
 
 class AdamRodRDDFunctions(rdd: RDD[ADAMRod]) extends Serializable with Logging {
-  initLogging()
-
   /**
    * Given an RDD of rods, splits the rods up by the specific sample they correspond to.
    * Returns a flat RDD.

--- a/adam-core/src/test/scala/edu/berkeley/cs/amplab/adam/rdd/AdamRDDFunctionsSuite.scala
+++ b/adam-core/src/test/scala/edu/berkeley/cs/amplab/adam/rdd/AdamRDDFunctionsSuite.scala
@@ -237,6 +237,7 @@ class AdamRDDFunctionsSuite extends SparkFunSuite {
       .setMismatchingPositions("3")
       .setReadNegativeStrand(false)
       .setReadMapped(true)
+      .setPrimaryAlignment(true)
       .setQual("!#$")
       .build()
     val r1 = ADAMRecord.newBuilder
@@ -248,6 +249,7 @@ class AdamRDDFunctionsSuite extends SparkFunSuite {
       .setMismatchingPositions("2")
       .setReadNegativeStrand(false)
       .setReadMapped(true)
+      .setPrimaryAlignment(true)
       .setQual("%&")
       .build()
     val r2 = ADAMRecord.newBuilder
@@ -259,6 +261,7 @@ class AdamRDDFunctionsSuite extends SparkFunSuite {
       .setMismatchingPositions("1")
       .setReadNegativeStrand(false)
       .setReadMapped(true)
+      .setPrimaryAlignment(true)
       .setQual("%")
       .build()
     
@@ -289,6 +292,7 @@ class AdamRDDFunctionsSuite extends SparkFunSuite {
       .setMismatchingPositions("2")
       .setReadNegativeStrand(false)
       .setReadMapped(true)
+      .setPrimaryAlignment(true)
       .setQual("!#$")
       .build()
     val r1 = ADAMRecord.newBuilder
@@ -300,6 +304,7 @@ class AdamRDDFunctionsSuite extends SparkFunSuite {
       .setMismatchingPositions("1")
       .setReadNegativeStrand(false)
       .setReadMapped(true)
+      .setPrimaryAlignment(true)
       .setQual("%&")
       .build()
     val r2 = ADAMRecord.newBuilder
@@ -311,6 +316,7 @@ class AdamRDDFunctionsSuite extends SparkFunSuite {
       .setMismatchingPositions("1")
       .setReadNegativeStrand(false)
       .setReadMapped(true)
+      .setPrimaryAlignment(true)
       .setQual("%")
       .build()
     

--- a/adam-core/src/test/scala/edu/berkeley/cs/amplab/adam/rdd/PileupConversionSuite.scala
+++ b/adam-core/src/test/scala/edu/berkeley/cs/amplab/adam/rdd/PileupConversionSuite.scala
@@ -35,6 +35,7 @@ class PileupConversionSuite extends FunSuite {
       .setMismatchingPositions("5")
       .setQual(qualString)
       .setReadMapped(true)
+      .setPrimaryAlignment(true)
       .build()
 
     val converter = new Reads2PileupProcessor
@@ -70,6 +71,7 @@ class PileupConversionSuite extends FunSuite {
       .setMismatchingPositions("4A0")
       .setQual(qualString)
       .setReadMapped(true)
+      .setPrimaryAlignment(true)
       .build()
 
     val converter = new Reads2PileupProcessor


### PR DESCRIPTION
This change came up when working on #121:
- Removed two unnecessary count operations during pileup conversion that negatively impacted performance.
- Added a switch to all pileup conversions (both pileup and rod) to specify whether reads that are at non-primary mappings should be converted into pileups. By default, we only convert primary mappings.
