### PR TITLE
Display Git commit info on command line

### DIFF
--- a/adam-cli/pom.xml
+++ b/adam-cli/pom.xml
@@ -87,7 +87,6 @@
                     </execution>
                 </executions>
             </plugin>
-
         </plugins>
     </build>
 

--- a/adam-cli/src/main/scala/edu/berkeley/cs/amplab/adam/cli/AdamMain.scala
+++ b/adam-cli/src/main/scala/edu/berkeley/cs/amplab/adam/cli/AdamMain.scala
@@ -38,7 +38,8 @@ object AdamMain extends Logging {
     Vcf2Adam,
     FindReads,
     Fasta2Adam,
-    PluginExecutor)
+    PluginExecutor,
+    BuildInformation)
 
   private def printCommands() {
     println("\n")

--- a/adam-cli/src/main/scala/edu/berkeley/cs/amplab/adam/cli/BuildInformation.scala
+++ b/adam-cli/src/main/scala/edu/berkeley/cs/amplab/adam/cli/BuildInformation.scala
@@ -1,0 +1,41 @@
+/*
+ * Copyright (c) 2014. Sebastien Mondet <seb@mondet.org>
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package edu.berkeley.cs.amplab.adam.cli
+
+import scala.collection.JavaConversions._
+import scala.Some
+import scala.collection.JavaConverters._
+
+
+object BuildInformation extends AdamCommandCompanion {
+  val commandName: String = "buildinfo"
+  val commandDescription: String = "Display build information (use this for bug reports)"
+
+  def apply(cmdLine: Array[String]): AdamCommand = {
+    new BuildInformation()
+  }
+}
+
+class BuildInformation() extends AdamCommand {
+  val companion = BuildInformation
+
+  def run() = {
+    val properties = edu.berkeley.cs.amplab.adam.core.util.BuildInformation.asString();
+    println("Build information:\n" + properties);
+  }
+
+
+}

--- a/adam-core/.gitignore
+++ b/adam-core/.gitignore
@@ -1,1 +1,2 @@
 dependency-reduced-pom.xml
+src/main/resources/git.properties

--- a/adam-core/pom.xml
+++ b/adam-core/pom.xml
@@ -55,6 +55,26 @@
                     </execution>
                 </executions>
             </plugin>
+            <plugin>
+                <groupId>pl.project13.maven</groupId>
+                <artifactId>git-commit-id-plugin</artifactId>
+                <version>2.1.9</version>
+                <executions>
+                    <execution> <goals> <goal>revision</goal> </goals> </execution>
+                </executions>
+                <configuration>
+                    <verbose>true</verbose>
+                    <generateGitPropertiesFile>true</generateGitPropertiesFile>
+                    <!-- <generateGitPropertiesFilename>adam-cli/src/main/resources/git.properties</generateGitPropertiesFilename> -->
+                    <generateGitPropertiesFilename>src/main/resources/git.properties</generateGitPropertiesFilename>
+                    <failOnNoGitDirectory>false</failOnNoGitDirectory>
+                    <excludeProperties>
+                        <!-- Avoid email addresses and names: -->
+                        <excludeProperty>git.commit.user.*</excludeProperty>
+                        <excludeProperty>git.build.user.*</excludeProperty>
+                    </excludeProperties>
+                </configuration>
+            </plugin>
         </plugins>
     </build>
 

--- a/adam-core/src/main/scala/edu/berkeley/cs/amplab/adam/util/BuildInformation.scala
+++ b/adam-core/src/main/scala/edu/berkeley/cs/amplab/adam/util/BuildInformation.scala
@@ -1,0 +1,50 @@
+/*
+ * Copyright (c) 2014. Sebastien Mondet <seb@mondet.org>
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package edu.berkeley.cs.amplab.adam.core.util
+
+import scala.collection.JavaConversions._
+import scala.Some
+import scala.collection.JavaConverters._
+import java.util.Properties
+
+/** A static object that gets the resource "git.properties" and renders the
+ * build-information in different formats. The parsing is “lazy”, it parses
+ * the properties only the first time a function is called. */
+object BuildInformation {
+
+  private var properties : scala.Option[scala.collection.mutable.Map[String,String]] = None
+
+  /** Return a scala mutable Map (property, value).  */
+  def asMap(): scala.collection.mutable.Map[String,String] = {
+    properties match {
+      case Some(inThere) => inThere
+      case None => {
+        val javaProperties = new Properties;
+        javaProperties.load(getClass().getClassLoader().getResourceAsStream("git.properties"));
+        properties = Some(javaProperties.asScala); 
+        javaProperties.asScala
+      }
+    }
+  }
+
+  /** Return a formatted human-readable string. */
+  def asString(): String = {
+    asMap().foldLeft(""){
+      case (prev_string, (key, value)) =>
+        prev_string + key + ": " + value + "\n"
+    }
+  }
+}


### PR DESCRIPTION
This is a first attempt at https://github.com/bigdatagenomics/adam/issues/41
(a “pick-me-up”).
To dump useful information while reporting bugs.

```
 $ java -jar adam-cli/target/adam-0.6.1-SNAPSHOT.jar buildinformation
Build information:
git.commit.id.abbrev: b476864
git.commit.message.full: Do code clean-up (BuildInformation)

git.commit.id: b476864265ee83660ea3cdb116241fb853720294
git.commit.message.short: Do code clean-up (BuildInformation)
git.commit.id.describe: adam-parent-0.6.0-69-gb476864
git.branch: git_properties
git.commit.time: 23.02.2014 @ 14:43:05 EST
git.remote.origin.url: git@github.com:bigdatagenomics/adam
git.build.time: 23.02.2014 @ 14:45:25 EST
```

It uses https://github.com/ktoso/maven-git-commit-id-plugin
