### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,7 +56,8 @@ You will need to have [Maven](http://maven.apache.org/) installed in order to bu
 ```
 $ git clone git@github.com:bigdatagenomics/adam.git
 $ cd adam
-$ mvn clean package
+$ export "MAVEN_OPTS=-Xmx512m -XX:MaxPermSize=128m"
+$ mvn clean package -DskipTests
 ...
 [INFO] ------------------------------------------------------------------------
 [INFO] BUILD SUCCESS


### PR DESCRIPTION
To improve the experience for users trying to build ADAM from source, I think it's worth explicitly adding the command to up the PermGen size and to turn off running tests, which should reduce the number of emails to the mailing list about failing builds and allow the new user to get moving with the jar file sooner rather than later.

Feel free to discard if you think either change does more harm than good.
