### PR TITLE
Refactoring FASTA work to break contig sizes.

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,6 @@
 # ADAM #
 * ISSUE [161](https://github.com/bigdatagenomics/adam/pull/161): Added switches to spark context creation code
+* ISSUE [160](https://github.com/bigdatagenomics/adam/pull/160): Refactoring FASTA work to break contig sizes.
 * ISSUE [148](https://github.com/bigdatagenomics/adam/issues/148): Moving createSparkContext into core
 * ISSUE [83](https://github.com/bigdatagenomics/adam/issues/83): Add ability to perform a "region join" to RDDs of ADAMRecords
 * ISSUE [101](https://github.com/bigdatagenomics/adam/issues/101): Add ability to call 'plugins' from the command-line

--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -88,7 +88,10 @@ Trunk (not yet released)
 
   * ISSUE 103: Added a call to clearProperty('spark.driver.port') in the cleanup from a sparkTest, so that 
     we correctly clean up the test Spark workers and avoid errors about attempting to bind to a port that's
-	already in use.
+    already in use.
+
+  * ISSUE 109: Added code that splits very large assemblies into fragments. This improves a performance
+    bottleneck when running on machines with finite memory. This fix was added in PR#160.
 
   BREAKING CHANGES
 

--- a/adam-cli/src/main/scala/edu/berkeley/cs/amplab/adam/cli/Fasta2Adam.scala
+++ b/adam-cli/src/main/scala/edu/berkeley/cs/amplab/adam/cli/Fasta2Adam.scala
@@ -15,7 +15,7 @@
  */
 package edu.berkeley.cs.amplab.adam.cli
 
-import edu.berkeley.cs.amplab.adam.avro.{ADAMNucleotideContig, ADAMRecord}
+import edu.berkeley.cs.amplab.adam.avro.{ADAMNucleotideContigFragment, ADAMRecord}
 import edu.berkeley.cs.amplab.adam.converters.FastaConverter
 import edu.berkeley.cs.amplab.adam.rdd.AdamContext._
 import org.apache.hadoop.io.{LongWritable, Text}
@@ -43,6 +43,8 @@ class Fasta2AdamArgs extends Args4jBase with ParquetArgs with SparkArgs {
   var verbose: Boolean = false
   @Args4jOption(required = false, name = "-reads", usage = "Maps contig IDs to match contig IDs of reads.")
   var reads: String = ""
+  @Args4jOption(required = false, name = "-fragment_length", usage = "Sets maximum fragment length. Default value is 10,000. Values greater than 1e9 should be avoided.")
+  var fragmentLength: Long = 10000L
 }
 
 class Fasta2Adam(protected val args: Fasta2AdamArgs) extends AdamSparkCommand[Fasta2AdamArgs] with Logging {
@@ -58,7 +60,7 @@ class Fasta2Adam(protected val args: Fasta2AdamArgs) extends AdamSparkCommand[Fa
     val remapData = fastaData.map(kv => (kv._1.get.toInt, kv._2.toString.toString))
 
     log.info("Converting FASTA to ADAM.")
-    val adamFasta = FastaConverter(remapData)
+    val adamFasta = FastaConverter(remapData, args.fragmentLength)
 
     if (args.verbose) {
       println("FASTA contains:")

--- a/adam-cli/src/main/scala/edu/berkeley/cs/amplab/adam/cli/ListDict.scala
+++ b/adam-cli/src/main/scala/edu/berkeley/cs/amplab/adam/cli/ListDict.scala
@@ -46,7 +46,7 @@ class ListDict(protected val args: ListDictArgs) extends AdamSparkCommand[ListDi
     ParquetLogger.hadoopLoggerLevel(Level.SEVERE)
 
     val dict = sc.adamDictionaryLoad[ADAMRecord](args.inputPath)
-    dict.records.sortBy(_.id).foreach {
+    dict.records.toList.sortBy(_.id).foreach {
       rec: SequenceRecord =>
         println("%d\t%s\t%d".format(rec.id, rec.name, rec.length))
     }

--- a/adam-core/src/main/scala/edu/berkeley/cs/amplab/adam/models/SequenceDictionary.scala
+++ b/adam-core/src/main/scala/edu/berkeley/cs/amplab/adam/models/SequenceDictionary.scala
@@ -15,7 +15,7 @@
  */
 package edu.berkeley.cs.amplab.adam.models
 
-import edu.berkeley.cs.amplab.adam.avro.{ADAMContig, ADAMNucleotideContig, ADAMRecord}
+import edu.berkeley.cs.amplab.adam.avro.{ADAMRecord, ADAMNucleotideContigFragment, ADAMContig}
 import edu.berkeley.cs.amplab.adam.rdd.AdamContext._
 import net.sf.samtools.{SAMFileHeader, SAMFileReader, SAMSequenceRecord, SAMSequenceDictionary}
 import org.apache.avro.specific.SpecificRecord
@@ -422,8 +422,8 @@ object SequenceRecord {
    * @param ctg Contig to convert.
    * @return Contig expressed as a sequence record.
    */
-  def fromADAMContig (ctg: ADAMNucleotideContig): SequenceRecord = {
-    apply(ctg.getContigId, ctg.getContigName, ctg.getSequenceLength, ctg.getUrl)
+  def fromADAMContigFragment (ctg: ADAMNucleotideContigFragment): SequenceRecord = {
+    apply(ctg.getContigId, ctg.getContigName, ctg.getContigLength, ctg.getUrl)
   }
 
   /*

--- a/adam-core/src/main/scala/edu/berkeley/cs/amplab/adam/projections/ADAMNucleotideContigFragmentField.scala
+++ b/adam-core/src/main/scala/edu/berkeley/cs/amplab/adam/projections/ADAMNucleotideContigFragmentField.scala
@@ -16,7 +16,7 @@
 
 package edu.berkeley.cs.amplab.adam.projections
 
-import edu.berkeley.cs.amplab.adam.avro.ADAMNucleotideContig
+import edu.berkeley.cs.amplab.adam.avro.ADAMNucleotideContigFragment
 
 /**
  * This enumeration exist in order to reduce typo errors in the code. It needs to be kept
@@ -25,12 +25,15 @@ import edu.berkeley.cs.amplab.adam.avro.ADAMNucleotideContig
  * This enumeration is necessary because Parquet needs the field string names
  * for predicates and projections.
  */
-object ADAMNucleotideContigField extends FieldEnumeration(ADAMNucleotideContig.SCHEMA$) {
+object ADAMNucleotideContigFragmentField extends FieldEnumeration(ADAMNucleotideContigFragment.SCHEMA$) {
 
   val contigName,
   contigId,
   description,
-  sequence,
-  sequenceLength,
+  fragmentSequence,
+  contigLength,
+  fragmentNumber,
+  fragmentStartPosition,
+  numberOfFragmentsInContig,
   url = SchemaValue
 }

--- a/adam-core/src/main/scala/edu/berkeley/cs/amplab/adam/serialization/AdamKryoRegistrator.scala
+++ b/adam-core/src/main/scala/edu/berkeley/cs/amplab/adam/serialization/AdamKryoRegistrator.scala
@@ -19,7 +19,10 @@ import org.apache.avro.specific.{SpecificDatumWriter, SpecificDatumReader, Speci
 import com.esotericsoftware.kryo.{Kryo, Serializer}
 import com.esotericsoftware.kryo.io.{Input, Output}
 import org.apache.avro.io.{BinaryDecoder, DecoderFactory, BinaryEncoder, EncoderFactory}
-import edu.berkeley.cs.amplab.adam.avro.{ADAMGenotype, ADAMPileup, ADAMRecord, ADAMNucleotideContig}
+import edu.berkeley.cs.amplab.adam.avro.{ADAMGenotype, 
+                                         ADAMPileup, 
+                                         ADAMRecord, 
+                                         ADAMNucleotideContigFragment}
 import edu.berkeley.cs.amplab.adam.models._
 import it.unimi.dsi.fastutil.io.{FastByteArrayInputStream, FastByteArrayOutputStream}
 import org.apache.spark.serializer.KryoRegistrator
@@ -67,8 +70,10 @@ class AdamKryoRegistrator extends KryoRegistrator {
     kryo.register(classOf[ADAMRecord], new AvroSerializer[ADAMRecord]())
     kryo.register(classOf[ADAMPileup], new AvroSerializer[ADAMPileup]())
     kryo.register(classOf[ADAMGenotype], new AvroSerializer[ADAMGenotype]())
-    kryo.register(classOf[ADAMNucleotideContig], new AvroSerializer[ADAMNucleotideContig]())
-    kryo.register(classOf[ReferencePositionWithOrientation], new ReferencePositionWithOrientationSerializer)
+    kryo.register(classOf[ADAMNucleotideContigFragment], 
+                  new AvroSerializer[ADAMNucleotideContigFragment]())
+    kryo.register(classOf[ReferencePositionWithOrientation],
+                  new ReferencePositionWithOrientationSerializer)
     kryo.register(classOf[ReferencePosition], new ReferencePositionSerializer)
     kryo.register(classOf[ReferencePositionPair], new ReferencePositionPairSerializer)
     kryo.register(classOf[SingleReadBucket], new SingleReadBucketSerializer)

--- a/adam-core/src/test/scala/edu/berkeley/cs/amplab/adam/rdd/AdamRDDFunctionsSuite.scala
+++ b/adam-core/src/test/scala/edu/berkeley/cs/amplab/adam/rdd/AdamRDDFunctionsSuite.scala
@@ -15,15 +15,17 @@
  */
 package edu.berkeley.cs.amplab.adam.rdd
 
-
-import edu.berkeley.cs.amplab.adam.avro.{ADAMRecord, 
-                                         ADAMContig,
+import edu.berkeley.cs.amplab.adam.avro.{ADAMContig,
+                                         ADAMGenotype,
+                                         ADAMNucleotideContigFragment,
                                          ADAMPileup, 
-                                         Base, 
-                                         ADAMNucleotideContig, 
-                                         ADAMGenotype, 
-                                         ADAMVariant}
-import edu.berkeley.cs.amplab.adam.models.{ADAMVariantContext, SequenceRecord, SequenceDictionary}
+                                         ADAMVariant,
+                                         ADAMRecord,
+                                         Base}
+import edu.berkeley.cs.amplab.adam.models.{ADAMVariantContext,
+                                           ReferenceRegion,
+                                           SequenceDictionary, 
+                                           SequenceRecord}
 import edu.berkeley.cs.amplab.adam.util.SparkFunSuite
 import edu.berkeley.cs.amplab.adam.rdd.AdamContext._
 import edu.berkeley.cs.amplab.adam.rdd.variation.ADAMVariantContextRDDFunctions
@@ -344,15 +346,15 @@ class AdamRDDFunctionsSuite extends SparkFunSuite {
   sparkTest ("can remap contig ids") {
     val dict = SequenceDictionary(SequenceRecord(0, "chr0", 1000L, "http://bigdatagenomics.github.io/chr0.fa"),
                                   SequenceRecord(1, "chr1", 1000L, "http://bigdatagenomics.github.io/chr0.fa"))
-    val ctg0 = ADAMNucleotideContig.newBuilder()
+    val ctg0 = ADAMNucleotideContigFragment.newBuilder()
       .setContigName("chr0")
       .setContigId(1)
-      .setSequenceLength(1000L)
+      .setContigLength(1000L)
       .build()
-    val ctg1 = ADAMNucleotideContig.newBuilder()
+    val ctg1 = ADAMNucleotideContigFragment.newBuilder()
       .setContigName("chr1")
       .setContigId(2)
-      .setSequenceLength(1000L)
+      .setContigLength(1000L)
       .build()
 
     val rdd = sc.parallelize(List(ctg0, ctg1))
@@ -367,15 +369,15 @@ class AdamRDDFunctionsSuite extends SparkFunSuite {
   sparkTest ("can remap contig ids while filtering out contigs that aren't in dict") {
     val dict = SequenceDictionary(SequenceRecord(0, "chr0", 1000L, "http://bigdatagenomics.github.io/chr0.fa"),
                                   SequenceRecord(1, "chr1", 1000L, "http://bigdatagenomics.github.io/chr0.fa"))
-    val ctg0 = ADAMNucleotideContig.newBuilder()
+    val ctg0 = ADAMNucleotideContigFragment.newBuilder()
       .setContigName("chr0")
       .setContigId(1)
-      .setSequenceLength(1000L)
+      .setContigLength(1000L)
       .build()
-    val ctg1 = ADAMNucleotideContig.newBuilder()
+    val ctg1 = ADAMNucleotideContigFragment.newBuilder()
       .setContigName("chr2")
       .setContigId(2)
-      .setSequenceLength(1000L)
+      .setContigLength(1000L)
       .build()
 
     val rdd = sc.parallelize(List(ctg0, ctg1))
@@ -388,16 +390,16 @@ class AdamRDDFunctionsSuite extends SparkFunSuite {
   }
 
   sparkTest ("generate sequence dict from fasta") {
-    val ctg0 = ADAMNucleotideContig.newBuilder()
+    val ctg0 = ADAMNucleotideContigFragment.newBuilder()
       .setContigName("chr0")
       .setContigId(1)
-      .setSequenceLength(1000L)
+      .setContigLength(1000L)
       .setUrl("http://bigdatagenomics.github.io/chr0.fa")
       .build()
-    val ctg1 = ADAMNucleotideContig.newBuilder()
+    val ctg1 = ADAMNucleotideContigFragment.newBuilder()
       .setContigName("chr1")
       .setContigId(2)
-      .setSequenceLength(900L)
+      .setContigLength(900L)
       .build()
 
     val rdd = sc.parallelize(List(ctg0, ctg1))
@@ -544,6 +546,124 @@ class AdamRDDFunctionsSuite extends SparkFunSuite {
     assert(mapCounts("NM") === 200)
     assert(mapCounts("AS") === 200)
     assert(mapCounts("XS") === 200)
+  }
+
+  sparkTest("recover reference string from a single contig fragment") {
+    val sequence = "ACTGTAC"
+    val fragment = ADAMNucleotideContigFragment.newBuilder()
+      .setContigId(1)
+      .setContigName("chr1")
+      .setFragmentSequence(sequence)
+      .setContigLength(7L)
+      .setFragmentNumber(0)
+      .setFragmentStartPosition(0L)
+      .setNumberOfFragmentsInContig(1)
+      .build()
+    val region = ReferenceRegion(fragment).get
+
+    val rdd = sc.parallelize(List(fragment))
+    
+    assert(rdd.adamGetReferenceString(region) === "ACTGTAC")
+  }
+
+  sparkTest("recover trimmed reference string from a single contig fragment") {
+    val sequence = "ACTGTAC"
+    val fragment = ADAMNucleotideContigFragment.newBuilder()
+      .setContigId(1)
+      .setContigName("chr1")
+      .setFragmentSequence(sequence)
+      .setContigLength(7L)
+      .setFragmentNumber(0)
+      .setFragmentStartPosition(0L)
+      .setNumberOfFragmentsInContig(1)
+      .build()
+    val region = new ReferenceRegion(1, 1L, 6L)
+
+    val rdd = sc.parallelize(List(fragment))
+    
+    assert(rdd.adamGetReferenceString(region) === "CTGTA")
+  }
+
+  sparkTest("recover reference string from multiple contig fragments") {
+    val sequence = "ACTGTACTC"
+    val sequence0 = sequence.take(7) // ACTGTAC
+    val sequence1 = sequence.drop(3).take(5) // GTACT 
+    val sequence2 = sequence.takeRight(6).reverse // CTCATG
+    val fragment0 = ADAMNucleotideContigFragment.newBuilder()
+      .setContigId(1)
+      .setContigName("chr1")
+      .setFragmentSequence(sequence0)
+      .setContigLength(7L)
+      .setFragmentNumber(0)
+      .setFragmentStartPosition(0L)
+      .setNumberOfFragmentsInContig(1)
+      .build()
+    val fragment1 = ADAMNucleotideContigFragment.newBuilder()
+      .setContigId(2)
+      .setContigName("chr2")
+      .setFragmentSequence(sequence1)
+      .setContigLength(11L)
+      .setFragmentNumber(0)
+      .setFragmentStartPosition(0L)
+      .setNumberOfFragmentsInContig(2)
+      .build()
+    val fragment2 = ADAMNucleotideContigFragment.newBuilder()
+      .setContigId(2)
+      .setContigName("chr2")
+      .setFragmentSequence(sequence2)
+      .setContigLength(11L)
+      .setFragmentNumber(1)
+      .setFragmentStartPosition(5L)
+      .setNumberOfFragmentsInContig(2)
+      .build()
+    val region0 = ReferenceRegion(fragment0).get
+    val region1 = ReferenceRegion(fragment1).get.merge(ReferenceRegion(fragment2).get)
+
+    val rdd = sc.parallelize(List(fragment0, fragment1, fragment2))
+    
+    assert(rdd.adamGetReferenceString(region0) === "ACTGTAC")
+    assert(rdd.adamGetReferenceString(region1) === "GTACTCTCATG")
+  }
+
+  sparkTest("recover trimmed reference string from multiple contig fragments") {
+    val sequence = "ACTGTACTC"
+    val sequence0 = sequence.take(7) // ACTGTAC
+    val sequence1 = sequence.drop(3).take(5) // GTACT 
+    val sequence2 = sequence.takeRight(6).reverse // CTCATG
+    val fragment0 = ADAMNucleotideContigFragment.newBuilder()
+      .setContigId(1)
+      .setContigName("chr1")
+      .setFragmentSequence(sequence0)
+      .setContigLength(7L)
+      .setFragmentNumber(0)
+      .setFragmentStartPosition(0L)
+      .setNumberOfFragmentsInContig(1)
+      .build()
+    val fragment1 = ADAMNucleotideContigFragment.newBuilder()
+      .setContigId(2)
+      .setContigName("chr2")
+      .setFragmentSequence(sequence1)
+      .setContigLength(11L)
+      .setFragmentNumber(0)
+      .setFragmentStartPosition(0L)
+      .setNumberOfFragmentsInContig(2)
+      .build()
+    val fragment2 = ADAMNucleotideContigFragment.newBuilder()
+      .setContigId(2)
+      .setContigName("chr2")
+      .setFragmentSequence(sequence2)
+      .setContigLength(11L)
+      .setFragmentNumber(1)
+      .setFragmentStartPosition(5L)
+      .setNumberOfFragmentsInContig(2)
+      .build()
+    val region0 = new ReferenceRegion(1, 1L, 6L)
+    val region1 = new ReferenceRegion(2, 3L, 9L)
+
+    val rdd = sc.parallelize(List(fragment0, fragment1, fragment2))
+    
+    assert(rdd.adamGetReferenceString(region0) === "CTGTA")
+    assert(rdd.adamGetReferenceString(region1) === "CTCTCA")
   }
 
 }

--- a/adam-format/src/main/resources/avro/adam.avdl
+++ b/adam-format/src/main/resources/avro/adam.avdl
@@ -88,13 +88,19 @@ enum Base {
     D  // not C
 }
 
-record ADAMNucleotideContig {
+record ADAMNucleotideContigFragment {
+    // stores a contig of nucleotides; this may be a reference chromosome, may be an
+    // assembly, may be a BAC. very long contigs (>1Mbp) need to be split into fragments.
+    // it seems that they are too long to load in a single go.
     union { null, string } contigName = null;
     union { null, int } contigId = null;
     union { null, string } description = null;
-    array<Base> sequence = [];
-    union { null, long } sequenceLength = null;
-    union { null, string } url = null;
+    union { null, string } url = null; 
+    union { null, string } fragmentSequence = null; // sequence of bases in this fragment
+    union { null, long } contigLength = null; // length of the total contig (all fragments)
+    union { null, int } fragmentNumber = null; // ordered number for this fragment
+    union { null, long } fragmentStartPosition = null; // position of first base of fragment in contig
+    union { null, int } numberOfFragmentsInContig = null; // total number of fragments in contig
 }
 
 record ADAMPileup {


### PR DESCRIPTION
This change fixes #109. Specifically, on FASTA import, assemblies that were too long (>800kbp) would cause things to go a bit wonky. To resolve this, we break a single contig up into contig fragments. Additionally, this PR adds a few utility functions for manipulating contigs.

As a note, I've held off on editing the CHANGES.txt/md until there is consensus on which one we are sticking with.
