### PR TITLE
Added switches to spark context creation code

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,4 +1,5 @@
 # ADAM #
+* ISSUE [161](https://github.com/bigdatagenomics/adam/pull/161): Added switches to spark context creation code
 * ISSUE [148](https://github.com/bigdatagenomics/adam/issues/148): Moving createSparkContext into core
 * ISSUE [83](https://github.com/bigdatagenomics/adam/issues/83): Add ability to perform a "region join" to RDDs of ADAMRecords
 * ISSUE [101](https://github.com/bigdatagenomics/adam/issues/101): Add ability to call 'plugins' from the command-line

--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -67,6 +67,10 @@ Trunk (not yet released)
     is does not introduce incompatible changes to the API, but changes the APIs functionality. This change was
     introduced in PR#125 which came out of issue #121.
 
+  * Added switches to AdamContext creation code to allow for configuration of Kryo buffer size, and to allow
+    registration of job statistics listener for profiling. This change was introduced in PR#161 which came out
+    of issue #149.
+
   BUG FIXES
 
   * Fixed issues where VCF header was not being written correctly. This prevented variant calls from being

--- a/adam-cli/src/main/scala/edu/berkeley/cs/amplab/adam/cli/SparkCommand.scala
+++ b/adam-cli/src/main/scala/edu/berkeley/cs/amplab/adam/cli/SparkCommand.scala
@@ -32,6 +32,10 @@ trait SparkArgs extends Args4jBase {
   var spark_jars = new util.ArrayList[String]()
   @Args4jOption(required = false, name = "-spark_env", metaVar = "KEY=VALUE", usage = "Add Spark environment variable")
   var spark_env_vars = new util.ArrayList[String]()
+  @Args4jOption(required = false, name = "-spark_kryo_buffer_size", usage = "Set the size of the buffer used for serialization in MB. Default size is 4MB.")
+  var spark_kryo_buffer_size = 4
+  @Args4jOption(required = false, name = "-spark_add_stats_listener", usage = "Register job stat reporter, which is useful for debug/profiling.")
+  var spark_add_stats_listener = false
 }
 
 trait SparkCommand extends AdamCommand {
@@ -42,7 +46,9 @@ trait SparkCommand extends AdamCommand {
       args.spark_master,
       args.spark_home,
       args.spark_jars,
-      args.spark_env_vars)
+      args.spark_env_vars,
+      args.spark_add_stats_listener,
+      args.spark_kryo_buffer_size)
   }
 
 }

--- a/adam-core/src/main/scala/edu/berkeley/cs/amplab/adam/serialization/AdamKryoProperties.scala
+++ b/adam-core/src/main/scala/edu/berkeley/cs/amplab/adam/serialization/AdamKryoProperties.scala
@@ -18,10 +18,15 @@ package edu.berkeley.cs.amplab.adam.serialization
 
 object AdamKryoProperties {
 
-  def setupContextProperties() = {
+  /**
+   * Sets up serialization properties for ADAM.
+   *
+   * @param kryoBufferSize Buffer size in MB to allocate for object serialization. Default is 4MB.
+   */
+  def setupContextProperties(kryoBufferSize: Int = 4) = {
     System.setProperty("spark.serializer", "org.apache.spark.serializer.KryoSerializer")
     System.setProperty("spark.kryo.registrator", "edu.berkeley.cs.amplab.adam.serialization.AdamKryoRegistrator")
-    System.setProperty("spark.kryoserializer.buffer.mb", "4")
+    System.setProperty("spark.kryoserializer.buffer.mb", kryoBufferSize.toString)
     System.setProperty("spark.kryo.referenceTracking", "false")
   }
 }


### PR DESCRIPTION
Adds the following switches to the spark context creation code:
- A switch to allow for configuring the size of the Spark Kryo buffer. This is necessary for indel realignment on larger datasets.
- A switch to add a logger that prints debug text after every stage. This debug text contains information about data movement inside of the command that is being run, and is useful for performance analysis/profiling.

This addresses #149.
