### PR TITLE
Refactored SequenceDictionary 

### DIFF
--- a/adam-cli/src/main/scala/edu/berkeley/cs/amplab/adam/cli/ListDict.scala
+++ b/adam-cli/src/main/scala/edu/berkeley/cs/amplab/adam/cli/ListDict.scala
@@ -46,7 +46,8 @@ class ListDict(protected val args: ListDictArgs) extends AdamSparkCommand[ListDi
     ParquetLogger.hadoopLoggerLevel(Level.SEVERE)
 
     val dict = sc.adamDictionaryLoad[ADAMRecord](args.inputPath)
-    dict.records.toList.sortBy(_.id).foreach {
+
+    dict.recordsIn.sortBy(_.id).foreach {
       rec: SequenceRecord =>
         println("%d\t%s\t%d".format(rec.id, rec.name, rec.length))
     }

--- a/adam-core/src/main/scala/edu/berkeley/cs/amplab/adam/rdd/GenomicRegionPartitioner.scala
+++ b/adam-core/src/main/scala/edu/berkeley/cs/amplab/adam/rdd/GenomicRegionPartitioner.scala
@@ -100,7 +100,7 @@ object GenomicRegionPartitioner {
   def apply(N: Int, lengths: Map[Int, Long]) = new GenomicRegionPartitioner(N, lengths)
 
   def extractLengthMap(seqDict: SequenceDictionary): Map[Int, Long] =
-    Map(seqDict.records.map(rec => (rec.id, rec.length)): _*)
+    Map(seqDict.records.toSeq.map(rec => (rec.id, rec.length)): _*)
 }
 
 

--- a/adam-core/src/test/scala/edu/berkeley/cs/amplab/adam/models/SequenceDictionarySuite.scala
+++ b/adam-core/src/test/scala/edu/berkeley/cs/amplab/adam/models/SequenceDictionarySuite.scala
@@ -160,7 +160,7 @@ class SequenceDictionarySuite extends FunSuite {
     assert(map(3) === 1)
   }
 
-  test("the additions + and += work correctly") {
+  test("the addition + works correctly") {
     val s1 = SequenceDictionary()
     val s2 = SequenceDictionary(record(1, "foo"))
     val s3 = SequenceDictionary(record(1, "foo"), record(2, "bar"))
@@ -168,18 +168,9 @@ class SequenceDictionarySuite extends FunSuite {
     assert(s1 + record(1, "foo") === s2)
     assert(s2 + record(1, "foo") === s2)
     assert(s2 + record(2, "bar") === s3)
-
-    s1 += record(1, "foo")
-    assert(s1 === s2)
-
-    s1 += record(1, "foo")
-    assert(s1 === s2)
-
-    s1 += record(2, "bar")
-    assert(s1 === s3)
   }
 
-  test("the append operations ++ and ++= work correctly") {
+  test("the append operation ++ works correctly") {
     val s1 = SequenceDictionary()
     val s2a = SequenceDictionary(record(1, "foo"))
     val s2b = SequenceDictionary(record(2, "bar"))
@@ -189,15 +180,6 @@ class SequenceDictionarySuite extends FunSuite {
     assert(s1 ++ s2a === s2a)
     assert(s1 ++ s2b === s2b)
     assert(s2a ++ s2b === s3)
-
-    s1 ++= s2a
-    assert(s1 === s2a)
-
-    s1 ++= s2b
-    assert(s1 === s3)
-
-    s1 ++= s3
-    assert(s1 === s3)
   }
 
   test("containsRefName works correctly") {


### PR DESCRIPTION
Refactored aggregation to eliminate replication between RDD extensions, and to improve speed. Additionally, refactored SequenceDictionary class to reduce GC overhead and to make class immutable. GC overhead was reduced by switching away from pointer based data structures to arrays. Additionally, eliminated "derived" sequences from inside of SequenceDictionary.
