### PR TITLE
Add back in allele dosage for genotypes.

### DIFF
--- a/adam-core/src/test/scala/edu/berkeley/cs/amplab/adam/util/NormalizationUtilsSuite.scala
+++ b/adam-core/src/test/scala/edu/berkeley/cs/amplab/adam/util/NormalizationUtilsSuite.scala
@@ -66,7 +66,9 @@ class NormalizationUtilsSuite extends FunSuite {
 
     println(new_cigar)
     assert(new_cigar.toString == "10M10D10M")
-    assert(read.samtoolsCigar.getReadLength === new_cigar.getReadLength)
+    // TODO: the implicit for ADAMRecord->RichADAMRecord doesn't get
+    // called here for some reason.
+    assert(RichADAMRecord(read).samtoolsCigar.getReadLength === new_cigar.getReadLength)
   }
 
   test("shift an indel left by 0 in a cigar") {

--- a/adam-format/src/main/resources/avro/adam.avdl
+++ b/adam-format/src/main/resources/avro/adam.avdl
@@ -151,11 +151,22 @@ record ADAMContig {
   union { null, string } referenceURL = null;
 }
 
+enum VariantType {
+    SNP,
+    MNP,
+    Insertion,
+    Deletion,
+    Complex,
+    SV
+}
+
 record ADAMVariant {
   union { null, ADAMContig } contig = null;
   union { null, long }       position = null;
   string                     referenceAllele;
   string                     variantAllele;
+  // enum to describe type of variant called
+  union { null, VariantType } variantType = null;
 }
 
 enum ADAMGenotypeAllele {
@@ -226,6 +237,12 @@ record ADAMGenotype {
 
   // Phred-scaled. Always length 3 since we are not multiallelic.
   array<int>              genotypeLikelihoods = null; 
+
+  // Allele dosage
+  union { null, float }    expectedAlleleDosage = null;
+
+  // number of reads mapped at site on forward strand
+  union { null, int } readsMappedForwardStrand = null;
 
   // In the ADAM world we split multiallelic VCF lines into multiple
   // single-alternate records.  This bit is set if that happened for this


### PR DESCRIPTION
It was removed in the new schema but it's still a useful metric
Also, some more changes that Avocado needs, like number of reads that mapped on the forward strand.
