### PR TITLE
Parse annotations out of vcf files

### DIFF
--- a/adam-cli/src/main/scala/edu/berkeley/cs/amplab/adam/cli/AdamMain.scala
+++ b/adam-cli/src/main/scala/edu/berkeley/cs/amplab/adam/cli/AdamMain.scala
@@ -17,6 +17,7 @@ package edu.berkeley.cs.amplab.adam.cli
 
 import org.apache.spark.Logging
 import scala.Some
+import edu.berkeley.cs.amplab.adam.cli.VcfAnnotation2Adam
 
 object AdamMain extends Logging {
 
@@ -39,7 +40,9 @@ object AdamMain extends Logging {
     FindReads,
     Fasta2Adam,
     PluginExecutor,
-    BuildInformation)
+    BuildInformation,
+    VcfAnnotation2Adam
+  )
 
   private def printCommands() {
     println("\n")

--- a/adam-cli/src/main/scala/edu/berkeley/cs/amplab/adam/cli/VcfAnnotation2Adam.scala
+++ b/adam-cli/src/main/scala/edu/berkeley/cs/amplab/adam/cli/VcfAnnotation2Adam.scala
@@ -1,0 +1,75 @@
+/*
+* Copyright (c) 2014. Mount Sinai School of Medicine
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+package edu.berkeley.cs.amplab.adam.cli
+
+import org.apache.hadoop.mapreduce.Job
+import org.apache.spark.{Logging, SparkContext}
+import org.kohsuke.args4j.{Argument, Option => Args4jOption}
+import edu.berkeley.cs.amplab.adam.rdd.variation.ADAMVariationContext._
+import edu.berkeley.cs.amplab.adam.rdd.AdamContext._
+import edu.berkeley.cs.amplab.adam.avro._
+import org.apache.spark.rdd.RDD
+import org.apache.spark.SparkContext._
+import edu.berkeley.cs.amplab.adam.models.ADAMVariantContext
+import edu.berkeley.cs.amplab.adam.converters.VariantAnnotationConverter
+import edu.berkeley.cs.amplab.adam.rich.RichADAMVariant
+
+object VcfAnnotation2Adam extends AdamCommandCompanion {
+
+  val commandName = "anno2adam"
+  val commandDescription = "Convert a annotation file (in VCF format) to the corresponding ADAM format"
+
+  def apply(cmdLine: Array[String]) = {
+    new VcfAnnotation2Adam(Args4j[VcfAnnotation2AdamArgs](cmdLine))
+  }
+}
+
+class VcfAnnotation2AdamArgs extends Args4jBase with ParquetArgs with SparkArgs {
+  @Argument(required = true, metaVar = "VCF", usage = "The VCF file with annotations to convert", index = 0)
+  var vcfFile: String = _
+  @Argument(required = true, metaVar = "ADAM", usage = "Location to write ADAM Variant annotations data", index = 1)
+  var outputPath: String = null
+  @Args4jOption(required=false, name = "-current-db", usage = "Location of existing ADAM Variant annotations data")
+  var currentAnnotations: String = null
+}
+
+class VcfAnnotation2Adam(val args: VcfAnnotation2AdamArgs) extends AdamSparkCommand[VcfAnnotation2AdamArgs] with Logging {
+  val companion = VcfAnnotation2Adam
+
+  def run(sc: SparkContext, job: Job) {
+    log.info("Reading VCF file from %s".format(args.vcfFile))
+    val annotations : RDD[ADAMDatabaseVariantAnnotation] = sc.adamVCFAnnotationLoad(args.vcfFile)
+    log.info("Converted %d records".format(annotations.count))
+
+    if (args.currentAnnotations != null) {
+      val existingAnnotations : RDD[ADAMDatabaseVariantAnnotation] = sc.adamLoad(args.currentAnnotations)
+      val keyedAnnotations = existingAnnotations.keyBy(anno => new RichADAMVariant(anno.getVariant))
+      val joinedAnnotations = keyedAnnotations.join( annotations.keyBy(anno => new RichADAMVariant(anno.getVariant)))
+      val mergedAnnotations = joinedAnnotations.map( kv => VariantAnnotationConverter.mergeAnnotations( kv._2._1, kv._2._2 ))
+      mergedAnnotations.adamSave(args.outputPath, blockSize = args.blockSize, pageSize = args.pageSize,
+        compressCodec = args.compressionCodec, disableDictionaryEncoding = args.disableDictionary)
+    }
+    else {
+      annotations.adamSave(args.outputPath, blockSize = args.blockSize, pageSize = args.pageSize,
+        compressCodec = args.compressionCodec, disableDictionaryEncoding = args.disableDictionary)
+    }
+
+    log.info("Added %d annotation records".format(annotations.count()))
+
+  }
+
+}

--- a/adam-core/src/main/scala/edu/berkeley/cs/amplab/adam/converters/VariantAnnotationConverter.scala
+++ b/adam-core/src/main/scala/edu/berkeley/cs/amplab/adam/converters/VariantAnnotationConverter.scala
@@ -53,6 +53,30 @@ object VariantAnnotationConverter extends Serializable {
     val vcfKey: String = hdrLine.getID
   }
 
+  private val COSMIC_KEYS: List[AttrKey] = List(
+    AttrKey("geneSymbol", attrAsString _, new VCFInfoHeaderLine("GENE,", 1, VCFHeaderLineType.String,"Gene name")),
+    AttrKey("strand", attrAsString _, new VCFInfoHeaderLine("STRAND,", 1, VCFHeaderLineType.String,"Gene strand")),
+    AttrKey("cds", attrAsString _, new VCFInfoHeaderLine("CDS,", 1, VCFHeaderLineType.String,"CDS annotation")),
+    AttrKey("cnt", attrAsString _, new VCFInfoHeaderLine("CNT,", 1, VCFHeaderLineType.Integer,"How many samples have this mutation"))
+  )
+
+  private val DBNSFP_KEYS: List[AttrKey] = List(
+    AttrKey("phylop", attrAsFloat _,new VCFInfoHeaderLine("PHYLOP", 1, VCFHeaderLineType.Float,"PhyloP score. The larger the score, the more conserved the site.")),
+    AttrKey("siftPred", attrAsString _,new VCFInfoHeaderLine("SIFT_PRED", 1, VCFHeaderLineType.Character,"SIFT Prediction: D (damaging), T (tolerated)")),
+    AttrKey("siftScore", attrAsFloat _,new VCFInfoHeaderLine("SIFT_SCORE", 1, VCFHeaderLineType.Float,"SIFT Score")),
+    AttrKey("ancestralAllele", attrAsString _,new VCFInfoHeaderLine("AA", 1, VCFHeaderLineType.String,"Ancestral allele"))
+
+  )
+
+  private val CLINVAR_KEYS: List[AttrKey] = List(
+    AttrKey("dbSnpId", attrAsInt _, new VCFInfoHeaderLine("dbSNP ID", 1, VCFHeaderLineType.Integer, "dbSNP ID")),
+    AttrKey("geneSymbol", attrAsString _, new VCFInfoHeaderLine("GENEINFO", 1, VCFHeaderLineType.String, "Pairs each of gene symbol:gene id.  The gene symbol and id are delimited by a colon (:) and each pair is delimited by a vertical bar"))
+  )
+
+  private val OMIM_KEYS: List[AttrKey] = List(
+    AttrKey("omimId", attrAsString _, new VCFInfoHeaderLine("VAR", 1, VCFHeaderLineType.String, "MIM entry with variant mapped to rsID"))
+  )
+
   private val INFO_KEYS: Seq[AttrKey] = Seq(
     AttrKey("clippingRankSum", attrAsFloat _, new VCFInfoHeaderLine("ClippingRankSum", 1, VCFHeaderLineType.Float, "Z-score From Wilcoxon rank sum test of Alt vs. Ref number of hard clipped bases")),
     AttrKey("readDepth", attrAsInt _, VCFStandardHeaderLines.getInfoLine(VCFConstants.DEPTH_KEY)),
@@ -88,6 +112,10 @@ object VariantAnnotationConverter extends Serializable {
   lazy val VCF2VarCallAnnotations : Map[String,(Int,Object => Object)] = createFieldMap(INFO_KEYS,VariantCallingAnnotations.getClassSchema )
   lazy val VCF2GTAnnotations : Map[String,(Int,Object => Object)] = createFieldMap(FORMAT_KEYS, ADAMGenotype.getClassSchema)
 
+  private lazy val EXTERNAL_DATABASE_KEYS : Seq[AttrKey] =  OMIM_KEYS ::: CLINVAR_KEYS ::: DBNSFP_KEYS // ::: COSMIC_KEYS
+  lazy val VCF2DatabaseAnnotations : Map[String,(Int,Object => Object)] = createFieldMap(EXTERNAL_DATABASE_KEYS, ADAMDatabaseVariantAnnotation.getClassSchema)
+
+
   private def createFieldMap( keys : Seq[AttrKey], schema : Schema ) : Map[String,(Int,Object => Object)] = {
     keys.filter(_.attrConverter != null).map(
       field => {
@@ -111,9 +139,30 @@ object VariantAnnotationConverter extends Serializable {
     fillRecord(createFieldMap(keys, record.getSchema), vc, record)
   }
 
+  def convert(vc : VariantContext, annotation : ADAMDatabaseVariantAnnotation) : ADAMDatabaseVariantAnnotation  = {
+    fillRecord(VCF2DatabaseAnnotations, vc, annotation)
+  }
+
   def convert(vc : VariantContext, call : VariantCallingAnnotations) : VariantCallingAnnotations  = {
     fillRecord(VCF2VarCallAnnotations, vc, call)
   }
 
+  def mergeAnnotations(leftRecord : ADAMDatabaseVariantAnnotation, rightRecord : ADAMDatabaseVariantAnnotation) : ADAMDatabaseVariantAnnotation = {
+    val mergedAnnotation = ADAMDatabaseVariantAnnotation.newBuilder(leftRecord).build()
+    val numFields = ADAMDatabaseVariantAnnotation.getClassSchema.getFields.size
+
+    def insertField( fieldIdx : Int) =
+    {
+      val value = rightRecord.get(fieldIdx)
+      if (value != null)
+      {
+        mergedAnnotation.put(fieldIdx, value)
+      }
+    }
+    (0 until numFields).foreach(insertField(_))
+
+    mergedAnnotation
+
+  }
 
 }

--- a/adam-core/src/main/scala/edu/berkeley/cs/amplab/adam/projections/ADAMDatabaseVariantAnnotation.scala
+++ b/adam-core/src/main/scala/edu/berkeley/cs/amplab/adam/projections/ADAMDatabaseVariantAnnotation.scala
@@ -1,0 +1,66 @@
+/*
+ * Copyright (c) 2014. Mount Sinai School of Medicine
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+
+package edu.berkeley.cs.amplab.adam.projections
+
+import edu.berkeley.cs.amplab.adam.avro.ADAMDatabaseVariantAnnotation
+
+
+object ADAMDatabaseVariantAnnotationField extends FieldEnumeration(ADAMDatabaseVariantAnnotation.SCHEMA$) {
+
+  val  variant,
+
+  dbsnpId,
+
+  //domain information
+  hgvs,
+  geneSymbol,
+  ensemblGeneId,
+  ensemblTranscriptIds,
+
+  //clinical fields
+  omimId,
+  cosmicId,
+  clinvarId,
+  clinicalSignificance,
+
+  //conservation
+  gerpNr,
+  gerpRs,
+  phylop,
+  ancestralAllele,
+
+
+  //population statistics
+  thousandGenomesAlleleCount,
+  thousandGenomesAlleleFrequency,
+
+  //effect
+  referenceAminoAcid,
+  alternateAminoAcid,
+
+  //predicted effects
+  siftScore,
+  siftScoreConverted,
+  siftPred,
+
+  mutationTasterScore,
+  mutationTasterScoreConverted,
+  mutationTasterPred
+
+  = SchemaValue
+}

--- a/adam-core/src/main/scala/edu/berkeley/cs/amplab/adam/rdd/variation/ADAMVariationRDDFunctions.scala
+++ b/adam-core/src/main/scala/edu/berkeley/cs/amplab/adam/rdd/variation/ADAMVariationRDDFunctions.scala
@@ -47,7 +47,7 @@ class ADAMVariantContextRDDFunctions(rdd: RDD[ADAMVariantContext]) extends AdamS
     rdd.keyBy(_.variant)
       .leftOuterJoin(ann.keyBy(_.getVariant))
       .values
-      .map { case (v:ADAMVariantContext, a) => new ADAMVariantContext(v.variant, v.genotypes, a) }
+      .map { case (v:ADAMVariantContext, a) => ADAMVariantContext(v.variant, v.genotypes, a) }
 
   }
 

--- a/adam-core/src/main/scala/edu/berkeley/cs/amplab/adam/serialization/AdamKryoRegistrator.scala
+++ b/adam-core/src/main/scala/edu/berkeley/cs/amplab/adam/serialization/AdamKryoRegistrator.scala
@@ -19,15 +19,12 @@ import org.apache.avro.specific.{SpecificDatumWriter, SpecificDatumReader, Speci
 import com.esotericsoftware.kryo.{Kryo, Serializer}
 import com.esotericsoftware.kryo.io.{Input, Output}
 import org.apache.avro.io.{BinaryDecoder, DecoderFactory, BinaryEncoder, EncoderFactory}
-import edu.berkeley.cs.amplab.adam.avro.{ADAMGenotype, 
-                                         ADAMPileup, 
-                                         ADAMRecord, 
-                                         ADAMNucleotideContigFragment}
+import edu.berkeley.cs.amplab.adam.avro._
 import edu.berkeley.cs.amplab.adam.models._
 import it.unimi.dsi.fastutil.io.{FastByteArrayInputStream, FastByteArrayOutputStream}
 import org.apache.spark.serializer.KryoRegistrator
 import edu.berkeley.cs.amplab.adam.algorithms.realignmenttarget._
-import scala.collection.immutable.{TreeSet, NumericRange}
+import scala.collection.immutable.TreeSet
 
 case class InputStreamWithDecoder(size: Int) {
   val buffer = new Array[Byte](size)
@@ -70,10 +67,10 @@ class AdamKryoRegistrator extends KryoRegistrator {
     kryo.register(classOf[ADAMRecord], new AvroSerializer[ADAMRecord]())
     kryo.register(classOf[ADAMPileup], new AvroSerializer[ADAMPileup]())
     kryo.register(classOf[ADAMGenotype], new AvroSerializer[ADAMGenotype]())
-    kryo.register(classOf[ADAMNucleotideContigFragment], 
-                  new AvroSerializer[ADAMNucleotideContigFragment]())
-    kryo.register(classOf[ReferencePositionWithOrientation],
-                  new ReferencePositionWithOrientationSerializer)
+    kryo.register(classOf[ADAMVariant], new AvroSerializer[ADAMVariant]())
+    kryo.register(classOf[ADAMDatabaseVariantAnnotation], new AvroSerializer[ADAMDatabaseVariantAnnotation]())
+    kryo.register(classOf[ADAMNucleotideContigFragment], new AvroSerializer[ADAMNucleotideContigFragment]())
+    kryo.register(classOf[ReferencePositionWithOrientation], new ReferencePositionWithOrientationSerializer)
     kryo.register(classOf[ReferencePosition], new ReferencePositionSerializer)
     kryo.register(classOf[ReferencePositionPair], new ReferencePositionPairSerializer)
     kryo.register(classOf[SingleReadBucket], new SingleReadBucketSerializer)

--- a/adam-core/src/test/scala/edu/berkeley/cs/amplab/adam/rdd/variation/ADAMVariantContextRDDFunctionsSuite.scala
+++ b/adam-core/src/test/scala/edu/berkeley/cs/amplab/adam/rdd/variation/ADAMVariantContextRDDFunctionsSuite.scala
@@ -38,7 +38,7 @@ class ADAMVariantContextRDDFunctionsSuite extends SparkFunSuite {
 
     val a0 = ADAMDatabaseVariantAnnotation.newBuilder
       .setVariant(v0)
-      .setDbsnpId(5219)
+      .setDbSnpId(5219)
       .build
 
     val vda: RDD[ADAMDatabaseVariantAnnotation] = sc.parallelize(List(

--- a/adam-format/src/main/resources/avro/adam.avdl
+++ b/adam-format/src/main/resources/avro/adam.avdl
@@ -264,9 +264,52 @@ record ADAMGenotype {
   union { null, int }     phaseQuality = null;
 }
 
+record VariantEffect
+{
+  union { null, string} hgvs = null;
+  union { null, string } referenceAminoAcid = null;
+  union { null, string } alternateAminoAcid = null;
+  union {null, string} geneId = null;
+  union {null, string} transcriptId = null;
+}
+
 record ADAMDatabaseVariantAnnotation {
   union { null, ADAMVariant } variant;
-  union { null, int } dbsnpId = null;
+
+  union { null, int } dbSnpId = null;
+
+  //domain information
+  union {null, string} geneSymbol = null;
+
+  //clinical fields
+  union {null, string} omimId  = null;
+  union {null, string} cosmicId = null;
+  union {null, string} clinvarId  = null;
+  union {null, string} clinicalSignificance  = null;
+
+  //conservation
+  union { null, string } gerpNr  = null;
+  union { null, string } gerpRs  = null;
+  union { null, float } phylop  = null;
+  union { null, string } ancestralAllele  = null;
+
+  //population statistics
+  union {null, int} thousandGenomesAlleleCount = null;
+  union {null, float} thousandGenomesAlleleFrequency = null;
+
+  //effect
+  //TODO(arahuja): Parse into array
+  //array<VariantEffect> effects = null;
+
+  //predicted effects
+  union { null, float } siftScore = null;
+  union { null, float } siftScoreConverted = null;
+  union { null, string } siftPred = null;
+
+  union { null, float } mutationTasterScore = null;
+  union { null, float } mutationTasterScoreConverted = null;
+  union { null, string } mutationTasterPred = null;
+
 }
 
 }


### PR DESCRIPTION
This is a proposal to populate ADAMDatabaseVariantAnnotation by parsing out field in the INFO column of a VCF file.  This mostly extends on the existing vcf parsing to ADAMVariant to also parse additional fields and supports integrating new annotations to an existing set.

This adds some preliminary parsing for clinvar, omim, cosmic and dbnsfp

There are still many todos, for example adding more fields to be parsed and populated and generalizing the parsing to allow for anyone to set specific keys that they want to be parsed out, but I wanted to get some discussion around the format and this mega-schema of related variant fields.
