### PR TITLE
Update maven-surefire-plugin dependency version to 2.17, also create an ...

### DIFF
--- a/adam-core/pom.xml
+++ b/adam-core/pom.xml
@@ -46,7 +46,6 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-jar-plugin</artifactId>
-                <version>2.4</version>
                 <executions>
                     <execution>
                         <goals>
@@ -58,7 +57,6 @@
             <plugin>
                 <groupId>pl.project13.maven</groupId>
                 <artifactId>git-commit-id-plugin</artifactId>
-                <version>2.1.9</version>
                 <executions>
                     <execution>
                         <goals>

--- a/pom.xml
+++ b/pom.xml
@@ -162,12 +162,17 @@
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-surefire-plugin</artifactId>
-                    <version>2.16</version>
+                    <version>2.17</version>
                 </plugin>
                 <plugin>
                     <groupId>org.scalatest</groupId>
                     <artifactId>scalatest-maven-plugin</artifactId>
                     <version>1.0-RC2</version>
+                </plugin>
+                <plugin>
+                    <groupId>pl.project13.maven</groupId>
+                    <artifactId>git-commit-id-plugin</artifactId>
+                    <version>2.1.9</version>
                 </plugin>
             </plugins>
         </pluginManagement>


### PR DESCRIPTION
...entry in pluginManagement for git-commit-id-plugin.

See

[ANN] Apache Maven Surefire Plugin 2.17 Released
http://mail-archives.apache.org/mod_mbox/maven-announce/201403.mbox/%3CCAK2FUK2HMOUVwnhdPN02XCmPrNV1SsquL==OsJ96c3Jk=CMKZQ@mail.gmail.com%3E
