### PR TITLE
Add summarize_genotypes command

### DIFF
--- a/adam-cli/src/main/scala/edu/berkeley/cs/amplab/adam/cli/AdamMain.scala
+++ b/adam-cli/src/main/scala/edu/berkeley/cs/amplab/adam/cli/AdamMain.scala
@@ -41,8 +41,9 @@ object AdamMain extends Logging {
     Fasta2Adam,
     PluginExecutor,
     BuildInformation,
-    VcfAnnotation2Adam
-  )
+    VcfAnnotation2Adam,
+    SummarizeGenotypes,
+    BuildInformation)
 
   private def printCommands() {
     println("\n")

--- a/adam-cli/src/main/scala/edu/berkeley/cs/amplab/adam/cli/SummarizeGenotypes.scala
+++ b/adam-cli/src/main/scala/edu/berkeley/cs/amplab/adam/cli/SummarizeGenotypes.scala
@@ -1,0 +1,73 @@
+/*
+ * Copyright (c) 2014. Mount Sinai School of Medicine
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package edu.berkeley.cs.amplab.adam.cli
+
+import edu.berkeley.cs.amplab.adam.avro.ADAMGenotype
+import edu.berkeley.cs.amplab.adam.rdd.AdamContext._
+import edu.berkeley.cs.amplab.adam.rdd.{GenotypesSummary, GenotypesSummaryFormatting}
+import org.kohsuke.args4j
+import org.apache.spark.rdd.RDD
+import org.apache.spark.{Logging, SparkContext}
+import org.apache.hadoop.mapreduce.Job
+import org.apache.hadoop.fs.{Path, FileSystem}
+import org.apache.hadoop.conf.Configuration
+import java.io.{OutputStreamWriter, BufferedWriter}
+
+object SummarizeGenotypes extends AdamCommandCompanion {
+
+  val commandName = "summarize_genotypes"
+  val commandDescription = "Print statistics of genotypes and variants in an ADAM file"
+
+  def apply(cmdLine: Array[String]) = {
+    new SummarizeGenotypes(Args4j[SummarizeGenotypesArgs](cmdLine))
+  }
+}
+
+class SummarizeGenotypesArgs extends Args4jBase with ParquetArgs with SparkArgs {
+  @args4j.Argument(required = true, metaVar = "ADAM", usage = "The ADAM genotypes file to print stats for", index = 0)
+  var adamFile: String = _
+
+  @args4j.Option(required = false, name = "-format", usage = "Format: one of human, csv. Default: human.")
+  var format: String = "human"
+
+  @args4j.Option(required = false, name = "-out", usage = "Write output to the given file.")
+  var out: String = ""
+}
+
+class SummarizeGenotypes(val args: SummarizeGenotypesArgs) extends AdamSparkCommand[SummarizeGenotypesArgs] with Logging {
+  val companion = SummarizeGenotypes
+
+  def run(sc: SparkContext, job: Job) {
+    val adamGTs: RDD[ADAMGenotype] = sc.adamLoad(args.adamFile)
+    val stats = GenotypesSummary(adamGTs)
+    val result = args.format match {
+      case "human" => GenotypesSummaryFormatting.format_human_readable(stats)
+      case "csv" => GenotypesSummaryFormatting.format_csv(stats)
+      case _ => throw new IllegalArgumentException("Invalid -format: %s".format(args.format))
+    }
+    if (args.out.isEmpty) {
+      println(result)
+    } else {
+      val filesystem = FileSystem.get(new Configuration())
+      val path = new Path(args.out)
+      val writer = new BufferedWriter(new OutputStreamWriter(filesystem.create(path, true)))
+      writer.write(result)
+      writer.close()
+      println("Wrote: %s".format(args.out))
+    }
+  }
+}

--- a/adam-core/src/main/scala/edu/berkeley/cs/amplab/adam/converters/VariantContextConverter.scala
+++ b/adam-core/src/main/scala/edu/berkeley/cs/amplab/adam/converters/VariantContextConverter.scala
@@ -133,13 +133,12 @@ class VariantContextConverter(dict: Option[SequenceDictionary] = None) extends S
     }
 
     // VCF CHROM, POS, REF and ALT
-    val variant: ADAMVariant = ADAMVariant.newBuilder
+    ADAMVariant.newBuilder
       .setContig(contig.build)
       .setPosition(vc.getStart - 1 /* ADAM is 0-indexed */)
       .setReferenceAllele(vc.getReference.getBaseString)
       .setVariantAllele(vc.getAlternateAllele(0).getBaseString)
       .build
-    variant
   }
 
   private def extractVariantDatabaseAnnotation(variant : ADAMVariant, vc : VariantContext) : ADAMDatabaseVariantAnnotation = {

--- a/adam-core/src/main/scala/edu/berkeley/cs/amplab/adam/rdd/GenotypesSummary.scala
+++ b/adam-core/src/main/scala/edu/berkeley/cs/amplab/adam/rdd/GenotypesSummary.scala
@@ -1,0 +1,316 @@
+/*
+ * Copyright (c) 2014. Mount Sinai School of Medicine
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package edu.berkeley.cs.amplab.adam.rdd
+
+import edu.berkeley.cs.amplab.adam.avro.{ADAMGenotypeAllele, ADAMGenotype}
+import edu.berkeley.cs.amplab.adam.rdd.GenotypesSummary.StatisticsMap
+import edu.berkeley.cs.amplab.adam.rich.RichADAMVariant._
+import org.apache.spark.rdd.RDD
+import scala.collection.JavaConverters._
+import scala.collection.immutable.Map
+import scala.collection.mutable
+import edu.berkeley.cs.amplab.adam.rdd.GenotypesSummaryCounts.ReferenceAndAlternate
+
+/**
+ * Simple counts of various properties across a set of genotypes.
+ *
+ * Note: for counts of variants, both homozygous and heterozygous
+ * count as 1 (i.e. homozygous alternate is NOT counted as 2).
+ * This seems to be the most common convention.
+ *
+ * @param genotypesCounts Counts of genotypes: map from list of ADAMGenotypeAllele (of size ploidy) -> count
+ * @param singleNucleotideVariantCounts Map from ReferenceAndAlternate -> count
+ *                                      where ReferenceAndAlternate is a single base variant.
+ * @param multipleNucleotideVariantCount Count of multiple nucleotide variants (e.g.: AA -> TG)
+ * @param insertionCount Count of insertions
+ * @param deletionCount Count of deletions
+ * @param readCount Sum of read depths for all genotypes with a called variant
+ * @param phasedCount Number of genotypes with phasing information
+ *
+ */
+case class GenotypesSummaryCounts(
+  genotypesCounts: GenotypesSummaryCounts.GenotypeAlleleCounts,
+  singleNucleotideVariantCounts: GenotypesSummaryCounts.VariantCounts,
+  multipleNucleotideVariantCount: Long,
+  insertionCount: Long,
+  deletionCount: Long,
+  readCount: Option[Long],
+  phasedCount: Long) {
+
+  lazy val genotypesCount: Long = genotypesCounts.values.sum
+  lazy val variantGenotypesCount: Long =
+    genotypesCounts.keys.filter(_.contains(ADAMGenotypeAllele.Alt)).map(genotypesCounts(_)).sum
+  lazy val singleNucleotideVariantCount: Long = singleNucleotideVariantCounts.values.sum
+  lazy val transitionCount: Long = GenotypesSummaryCounts.transitions.map(singleNucleotideVariantCounts).sum
+  lazy val transversionCount: Long = GenotypesSummaryCounts.transversions.map(singleNucleotideVariantCounts).sum
+  lazy val noCallCount: Long = genotypesCounts.count(_._1.contains(ADAMGenotypeAllele.NoCall))
+  lazy val averageReadDepthAtVariants =
+    if (variantGenotypesCount == 0) None
+    else for (readCount1 <- readCount) yield readCount1.toDouble / variantGenotypesCount.toDouble
+  lazy val withDefaultZeroCounts = GenotypesSummaryCounts(
+      genotypesCounts.withDefaultValue(0.toLong),
+      singleNucleotideVariantCounts.withDefaultValue(0.toLong),
+      multipleNucleotideVariantCount,
+      insertionCount,
+      deletionCount,
+      readCount,
+      phasedCount)
+
+  def combine(that: GenotypesSummaryCounts): GenotypesSummaryCounts = {
+    def combine_counts[A](map1: Map[A, Long], map2: Map[A, Long]): Map[A, Long] = {
+      val keys: Set[A] = map1.keySet.union(map2.keySet)
+      val pairs = keys.map(k => (k -> (map1.getOrElse(k, 0.toLong) + map2.getOrElse(k, 0.toLong))))
+      pairs.toMap
+    }
+    GenotypesSummaryCounts(
+      combine_counts(genotypesCounts, that.genotypesCounts),
+      combine_counts(singleNucleotideVariantCounts, that.singleNucleotideVariantCounts),
+      multipleNucleotideVariantCount + that.multipleNucleotideVariantCount,
+      insertionCount + that.insertionCount,
+      deletionCount + that.deletionCount,
+      for (readCount1 <- readCount; readcount2 <- that.readCount) yield readCount1 + readcount2,
+      phasedCount + that.phasedCount
+    )
+  }
+}
+object GenotypesSummaryCounts {
+  case class ReferenceAndAlternate(reference: String, alternate: String)
+
+  type GenotypeAlleleCounts =  Map[List[ADAMGenotypeAllele], Long]
+  type VariantCounts = Map[ReferenceAndAlternate, Long]
+
+  val simpleNucleotides = List("A", "C", "T", "G")
+
+  val transitions = List(
+    ReferenceAndAlternate("A", "G"),
+    ReferenceAndAlternate("G", "A"),
+    ReferenceAndAlternate("C", "T"),
+    ReferenceAndAlternate("T", "C"))
+
+  val transversions = List(
+    ReferenceAndAlternate("A", "C"),
+    ReferenceAndAlternate("C", "A"),
+    ReferenceAndAlternate("A", "T"),
+    ReferenceAndAlternate("T", "A"),
+    ReferenceAndAlternate("G", "C"),
+    ReferenceAndAlternate("C", "G"),
+    ReferenceAndAlternate("G", "T"),
+    ReferenceAndAlternate("T", "G"))
+
+  /**
+   * Factory for an empty GenotypesSummaryCounts.
+   */
+  def apply(): GenotypesSummaryCounts =
+    GenotypesSummaryCounts(
+      Map(),
+      Map(),
+      0,  // Multiple nucleotide variants
+      0,  // Insertion count
+      0,  // Deletion count
+      Some(0),  // Read count
+      0)  // Phased count
+
+  def apply(counts: GenotypesSummaryCounts) {
+    assert(false)
+  }
+
+  /**
+   * Factory for a GenotypesSummaryCounts that counts a single ADAMGenotype.
+   */
+  def apply(genotype: ADAMGenotype): GenotypesSummaryCounts = {
+    val variant = genotype.getVariant
+    val ref_and_alt = ReferenceAndAlternate(variant.getReferenceAllele.toString, variant.getVariantAllele.toString)
+
+    // We always count our genotype. The other counts are set to 1 only if we have a variant genotype.
+    val isVariant = genotype.getAlleles.contains(ADAMGenotypeAllele.Alt)
+    val genotypeAlleleCounts = Map(genotype.getAlleles.asScala.toList -> 1.toLong)
+    val variantCounts = (
+      if (isVariant && variant.isSingleNucleotideVariant) Map(ref_and_alt -> 1.toLong)
+      else Map(): VariantCounts)
+
+    val readDepth = (
+      if (genotype.getReadDepth == null) None
+      else if (isVariant) Some(genotype.getReadDepth.toLong)
+      else Some(0.toLong))
+
+    GenotypesSummaryCounts(
+      genotypeAlleleCounts,
+      variantCounts,
+      if (isVariant && variant.isMultipleNucleotideVariant) 1 else 0,
+      if (isVariant && variant.isInsertion) 1 else 0,
+      if (isVariant && variant.isDeletion) 1 else 0,
+      readDepth,
+      if (isVariant && genotype.getIsPhased != null && genotype.getIsPhased) 1 else 0)
+  }
+}
+
+/**
+ * Summary statistics for a set of genotypes.
+ * @param perSampleStatistics A map from sample id -> GenotypesSummaryCounts for that sample
+ * @param singletonCount Number of variants that are called in exactly one sample.
+ * @param distinctVariantCount Number of distinct variants that are called at least once.
+ *
+ */
+case class GenotypesSummary(
+  perSampleStatistics: StatisticsMap,
+  singletonCount: Long,
+  distinctVariantCount: Long) {
+  lazy val aggregateStatistics =
+    perSampleStatistics.values.foldLeft(GenotypesSummaryCounts())(_.combine(_)).withDefaultZeroCounts
+}
+object GenotypesSummary {
+  type StatisticsMap = Map[String, GenotypesSummaryCounts]
+
+  /**
+   * Factory for a GenotypesSummary given an RDD of ADAMGenotype.
+   */
+  def apply(rdd: RDD[ADAMGenotype]) : GenotypesSummary = {
+    def combineStatisticsMap(stats1: StatisticsMap, stats2: StatisticsMap): StatisticsMap = {
+      stats1.keySet.union(stats2.keySet).map(sample => {
+        (stats1.get(sample), stats2.get(sample)) match {
+          case (Some(statsA), Some(statsB)) => sample -> statsA.combine(statsB)
+          case (Some(stats), None) => sample -> stats
+          case (None, Some(stats)) => sample -> stats
+          case (None, None) => throw new AssertionError("Unreachable")
+        }
+      }).toMap
+    }
+    val perSampleStatistics: StatisticsMap = rdd
+      .map(genotype => Map(genotype.getSampleId.toString -> GenotypesSummaryCounts(genotype)))
+      .fold(Map(): StatisticsMap)(combineStatisticsMap(_, _))
+      .map({case (sample: String, stats: GenotypesSummaryCounts) => sample -> stats.withDefaultZeroCounts}).toMap
+    val variantCounts =
+      rdd.filter(_.getAlleles.contains(ADAMGenotypeAllele.Alt)).map(genotype => {
+        val variant = genotype.getVariant
+        (variant.getContig, variant.getPosition, variant.getReferenceAllele, variant.getVariantAllele)
+      }).countByValue
+    val singletonCount = variantCounts.count(_._2 == 1)
+    val distinctVariantsCount = variantCounts.size
+    GenotypesSummary(perSampleStatistics, singletonCount, distinctVariantsCount)
+  }
+}
+/**
+ * Functions for converting a GenotypesSummary object to various text formats.
+ */
+object GenotypesSummaryFormatting {
+  def format_csv(summary: GenotypesSummary): String = {
+
+    val genotypeAlleles = sortedGenotypeAlleles(summary.aggregateStatistics)
+
+    def format_statistics(stats: GenotypesSummaryCounts): Seq[String] = {
+      val row = mutable.MutableList[String]()
+      row += stats.genotypesCount.toString
+      row += stats.variantGenotypesCount.toString
+      row += stats.insertionCount.toString
+      row += stats.deletionCount.toString
+      row += stats.singleNucleotideVariantCount.toString
+      row += stats.transitionCount.toString
+      row += stats.transversionCount.toString
+      row += (stats.transitionCount.toDouble / stats.transversionCount.toDouble).toString
+      row ++= genotypeAlleles.map(stats.genotypesCounts(_).toString) // Genotype counts
+      row ++= allSNVs.map(stats.singleNucleotideVariantCounts(_).toString) // SNV counts
+      row
+    }
+
+    val basicHeader = List(
+      "Sample", "Genotypes", "Variant Genotypes", "Insertions", "Deletions", "SNVs", "Transitions", "Transversions", "Ti / Tv")
+    val genotypesHeader = genotypeAlleles.map(genotypeAllelesToString(_))
+    val snvsHeader = allSNVs.map(snv => "%s>%s".format(snv.reference, snv.alternate))
+
+    val result = new mutable.StringBuilder
+    result ++= "# " + (basicHeader ++ genotypesHeader ++ snvsHeader).mkString(", ") + "\n"
+
+    for ((sample, stats) <- summary.perSampleStatistics) {
+      val row = mutable.MutableList(sample)
+      row ++= format_statistics(stats)
+      result ++= row.mkString(", ") + "\n"
+    }
+    val final_row = List("Aggregated") ++ format_statistics(summary.aggregateStatistics)
+    result ++= final_row.mkString(", ") + "\n"
+    result.toString
+  }
+
+  def format_human_readable(summary: GenotypesSummary): String = {
+    def format_statistics(stats: GenotypesSummaryCounts, result: mutable.StringBuilder) = {
+      result ++= "\tVariant Genotypes: %d / %d = %1.3f%%\n".format(
+        stats.variantGenotypesCount,
+        stats.genotypesCount,
+        stats.variantGenotypesCount.toDouble * 100.0 / stats.genotypesCount)
+
+      for (genotype <- sortedGenotypeAlleles(summary.aggregateStatistics)) {
+        val count = stats.genotypesCounts(genotype)
+        result ++= "\t%20s: %9d = %1.3f%%\n".format(
+          genotypeAllelesToString(genotype),
+          count,
+          count.toDouble * 100.0 / stats.genotypesCount.toDouble)
+      }
+      result ++= "\tInsertions: %d\n".format(stats.insertionCount)
+      result ++= "\tDeletions: %d\n".format(stats.deletionCount)
+      result ++= "\tMultiple nucleotide variants: %d\n".format(stats.multipleNucleotideVariantCount)
+      result ++= "\tSingle nucleotide variants: %d\n".format(stats.singleNucleotideVariantCount)
+      result ++= "\t\tTransitions / transversions: %4d / %4d = %1.3f\n".format(
+        stats.transitionCount,
+        stats.transversionCount,
+        stats.transitionCount.toDouble / stats.transversionCount.toDouble)
+      var from, to = 0
+      for (snv <- allSNVs) {
+        result ++= "\t\t%s>%s %9d\n".format(snv.reference, snv.alternate, stats.singleNucleotideVariantCounts(snv))
+      }
+      result ++= "\tAverage read depth at called variants: %s\n".format(stats.averageReadDepthAtVariants match {
+        case Some(depth) => "%1.1f".format(depth)
+        case None => "[no variant calls, or read depth missing for one or more variant calls]"
+      })
+      result ++= "\tPhased genotypes: %d / %d = %1.3f%%\n".format(
+        stats.phasedCount,
+        stats.genotypesCount,
+        stats.phasedCount.toDouble * 100 / stats.genotypesCount
+      )
+    }
+
+    val result = new mutable.StringBuilder
+    for (sample <- summary.perSampleStatistics.keySet.toList.sorted) {
+      result ++= "Sample: %s\n".format(sample)
+      format_statistics(summary.perSampleStatistics(sample), result)
+      result ++= "\n"
+    }
+    result ++= "\nSummary\n"
+    result ++= "\tSamples: %d\n".format(summary.perSampleStatistics.size)
+    result ++= "\tDistinct variants: %d\n".format(summary.distinctVariantCount)
+    result ++= "\tVariants found only in a single sample: %d = %1.3f%%\n".format(
+      summary.singletonCount,
+      summary.singletonCount.toDouble * 100.0 / summary.distinctVariantCount)
+    format_statistics(summary.aggregateStatistics, result)
+    result.toString
+  }
+
+  private def sortedGenotypeAlleles(stats: GenotypesSummaryCounts): Seq[List[ADAMGenotypeAllele]] = {
+    def genotypeSortOrder(genotype: List[ADAMGenotypeAllele]): Int = genotype.map({
+      case ADAMGenotypeAllele.Ref => 0
+      case ADAMGenotypeAllele.Alt => 1
+      case ADAMGenotypeAllele.NoCall => 10  // arbitrary large number so any genotype with a NoCall sorts last.
+    }).sum
+    stats.genotypesCounts.keySet.toList.sortBy(genotypeSortOrder(_))
+  }
+
+  private def genotypeAllelesToString(alleles: List[ADAMGenotypeAllele]): String =
+    alleles.map(_.toString).mkString("-")
+
+  lazy val allSNVs: Seq[ReferenceAndAlternate] =
+    for (from <- GenotypesSummaryCounts.simpleNucleotides;
+         to <- GenotypesSummaryCounts.simpleNucleotides;
+         if (from != to)) yield GenotypesSummaryCounts.ReferenceAndAlternate(from, to)
+
+}

--- a/adam-core/src/main/scala/edu/berkeley/cs/amplab/adam/rich/RichADAMVariant.scala
+++ b/adam-core/src/main/scala/edu/berkeley/cs/amplab/adam/rich/RichADAMVariant.scala
@@ -45,4 +45,17 @@ class RichADAMVariant(val variant: ADAMVariant) {
     }
     case _ => false
   }
+
+  def isSingleNucleotideVariant() = {
+    variant.getReferenceAllele.length == 1 && variant.getVariantAllele.length == 1
+  }
+  
+  def isMultipleNucleotideVariant() = {
+    !isSingleNucleotideVariant && variant.getReferenceAllele.length == variant.getVariantAllele.length
+  }
+
+  def isInsertion() = variant.getReferenceAllele.length < variant.getVariantAllele.length
+
+  def isDeletion() = variant.getReferenceAllele.length > variant.getVariantAllele.length
+
 }

--- a/adam-core/src/test/scala/edu/berkeley/cs/amplab/adam/rdd/GenotypesSummarySuite.scala
+++ b/adam-core/src/test/scala/edu/berkeley/cs/amplab/adam/rdd/GenotypesSummarySuite.scala
@@ -1,0 +1,163 @@
+/*
+ * Copyright (c) 2014. Mount Sinai School of Medicine
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package edu.berkeley.cs.amplab.adam.rdd
+
+import edu.berkeley.cs.amplab.adam.avro._
+import edu.berkeley.cs.amplab.adam.rdd.AdamContext._
+import edu.berkeley.cs.amplab.adam.rdd.GenotypesSummaryCounts.ReferenceAndAlternate
+import edu.berkeley.cs.amplab.adam.util.SparkFunSuite
+
+class GenotypesSummarySuite extends SparkFunSuite {
+  private val contig = ADAMContig.newBuilder()
+    .setContigId(1)
+    .setContigName("abc")
+    .setContigLength(100)
+    .build
+
+  private def homRef = List(ADAMGenotypeAllele.Ref, ADAMGenotypeAllele.Ref)
+  private def het = List(ADAMGenotypeAllele.Alt, ADAMGenotypeAllele.Ref)
+  private def homAlt = List(ADAMGenotypeAllele.Alt, ADAMGenotypeAllele.Alt)
+  private def noCall = List(ADAMGenotypeAllele.NoCall, ADAMGenotypeAllele.NoCall)
+
+  private def variant(reference: String, alternate: String, position: Int): ADAMVariant = {
+    ADAMVariant.newBuilder()
+      .setContig(contig)
+      .setPosition(position)
+      .setReferenceAllele(reference)
+      .setVariantAllele(alternate)
+      .build
+  }
+
+  private def genotype(sample: String, variant: ADAMVariant, alleles: List[ADAMGenotypeAllele]) = {
+    ADAMGenotype.newBuilder()
+      .setSampleId(sample)
+      .setVariant(variant)
+      .setAlleles(alleles)
+  }
+
+  private def summarize(genotypes: Seq[ADAMGenotype]): GenotypesSummary = {
+    val rdd = sc.parallelize(genotypes)
+    GenotypesSummary(rdd)
+  }
+
+  sparkTest("simple genotypes summary") {
+    val genotypes = List(
+      genotype("alice", variant("A", "TT", 2), het).build,
+      genotype("alice", variant("G", "A", 4), het).build,
+      genotype("alice", variant("G", "C", 1), homRef).build,
+      genotype("alice", variant("G", "T", 0), homAlt).build,
+      genotype("alice", variant("GGG", "T", 7), het).build,
+      genotype("alice", variant("T", "AA", 9), het).build,
+      genotype("alice", variant("TT", "AA", 12), het).build,
+      genotype("bob", variant("A", "TT", 2), het).build,
+      genotype("bob", variant("A", "T", 3), het).build,
+      genotype("bob", variant("A", "T", 9), het).build,
+      genotype("bob", variant("T", "C", 4), het).setIsPhased(true).build,
+      genotype("bob", variant("T", "A", 7), homRef).build,
+      genotype("bob", variant("T", "G", 8), homAlt).build,
+      genotype("bob", variant("T", "G", 12), noCall).build,
+      genotype("empty", variant("T", "G", 12), noCall).build
+    )
+
+    val stats = summarize(genotypes)
+    assert(stats.perSampleStatistics.size == 3)
+
+    assert(stats.perSampleStatistics("empty").singleNucleotideVariantCount == 0)
+    assert(stats.perSampleStatistics("empty").singleNucleotideVariantCounts(ReferenceAndAlternate("A", "T")) == 0)
+    assert(stats.perSampleStatistics("empty").singleNucleotideVariantCounts(ReferenceAndAlternate("T", "C")) == 0)
+    assert(stats.perSampleStatistics("empty").singleNucleotideVariantCounts(ReferenceAndAlternate("T", "C")) == 0)
+    assert(stats.perSampleStatistics("empty").singleNucleotideVariantCounts(ReferenceAndAlternate("T", "G")) == 0)
+    assert(stats.perSampleStatistics("empty").singleNucleotideVariantCounts(ReferenceAndAlternate("C", "T")) == 0)
+    assert(stats.perSampleStatistics("empty").insertionCount == 0)
+    assert(stats.perSampleStatistics("empty").noCallCount == 1)
+    assert(stats.perSampleStatistics("empty").phasedCount == 0)
+
+    assert(stats.perSampleStatistics("alice").singleNucleotideVariantCount == 2)
+    assert(stats.perSampleStatistics("alice").singleNucleotideVariantCounts(ReferenceAndAlternate("G", "A")) == 1)
+    assert(stats.perSampleStatistics("alice").singleNucleotideVariantCounts(ReferenceAndAlternate("G", "C")) == 0)
+    assert(stats.perSampleStatistics("alice").singleNucleotideVariantCounts(ReferenceAndAlternate("G", "T")) == 1)
+    assert(stats.perSampleStatistics("alice").singleNucleotideVariantCounts(ReferenceAndAlternate("A", "T")) == 0)
+    assert(stats.perSampleStatistics("alice").deletionCount == 1)
+    assert(stats.perSampleStatistics("alice").insertionCount == 2)
+    assert(stats.perSampleStatistics("alice").multipleNucleotideVariantCount == 1)
+    assert(stats.perSampleStatistics("alice").phasedCount == 0)
+    assert(stats.perSampleStatistics("alice").noCallCount == 0)
+    assert(stats.perSampleStatistics("bob").singleNucleotideVariantCount == 4)
+    assert(stats.perSampleStatistics("bob").singleNucleotideVariantCounts(ReferenceAndAlternate("A", "T")) == 2)
+    assert(stats.perSampleStatistics("bob").singleNucleotideVariantCounts(ReferenceAndAlternate("T", "C")) == 1)
+    assert(stats.perSampleStatistics("bob").singleNucleotideVariantCounts(ReferenceAndAlternate("T", "C")) == 1)
+    assert(stats.perSampleStatistics("bob").singleNucleotideVariantCounts(ReferenceAndAlternate("T", "G")) == 1)
+    assert(stats.perSampleStatistics("bob").singleNucleotideVariantCounts(ReferenceAndAlternate("C", "T")) == 0)
+    assert(stats.perSampleStatistics("bob").insertionCount == 1)
+    assert(stats.perSampleStatistics("bob").noCallCount == 1)
+    assert(stats.perSampleStatistics("bob").phasedCount == 1)
+
+    assert(stats.aggregateStatistics.singleNucleotideVariantCount == 6)
+    assert(stats.aggregateStatistics.singleNucleotideVariantCounts(ReferenceAndAlternate("G", "A")) == 1)
+    assert(stats.aggregateStatistics.singleNucleotideVariantCounts(ReferenceAndAlternate("G", "C")) == 0)
+    assert(stats.aggregateStatistics.singleNucleotideVariantCounts(ReferenceAndAlternate("G", "T")) == 1)
+    assert(stats.aggregateStatistics.singleNucleotideVariantCounts(ReferenceAndAlternate("A", "T")) == 2)
+    assert(stats.aggregateStatistics.singleNucleotideVariantCounts(ReferenceAndAlternate("T", "C")) == 1)
+    assert(stats.aggregateStatistics.singleNucleotideVariantCounts(ReferenceAndAlternate("T", "G")) == 1)
+    assert(stats.aggregateStatistics.insertionCount == 3)
+    assert(stats.aggregateStatistics.deletionCount == 1)
+    assert(stats.aggregateStatistics.multipleNucleotideVariantCount == 1)
+
+    assert(stats.singletonCount == 9)
+    assert(stats.distinctVariantCount == 10)
+
+    // Test that the formatting functions do not throw.
+    GenotypesSummaryFormatting.format_csv(stats)
+    GenotypesSummaryFormatting.format_human_readable(stats)
+  }
+
+  sparkTest("empty genotypes summary") {
+    val genotypes = List(
+      genotype("empty", variant("T", "G", 12), noCall).build
+    )
+
+    val stats = summarize(genotypes)
+
+    assert(stats.perSampleStatistics.size == 1)
+    assert(stats.perSampleStatistics("empty").singleNucleotideVariantCount == 0)
+    assert(stats.perSampleStatistics("empty").singleNucleotideVariantCounts(ReferenceAndAlternate("A", "T")) == 0)
+    assert(stats.perSampleStatistics("empty").singleNucleotideVariantCounts(ReferenceAndAlternate("T", "C")) == 0)
+    assert(stats.perSampleStatistics("empty").singleNucleotideVariantCounts(ReferenceAndAlternate("T", "C")) == 0)
+    assert(stats.perSampleStatistics("empty").singleNucleotideVariantCounts(ReferenceAndAlternate("T", "G")) == 0)
+    assert(stats.perSampleStatistics("empty").singleNucleotideVariantCounts(ReferenceAndAlternate("C", "T")) == 0)
+    assert(stats.perSampleStatistics("empty").insertionCount == 0)
+    assert(stats.perSampleStatistics("empty").noCallCount == 1)
+    assert(stats.perSampleStatistics("empty").phasedCount == 0)
+
+    assert(stats.aggregateStatistics.singleNucleotideVariantCount == 0)
+    assert(stats.aggregateStatistics.singleNucleotideVariantCounts(ReferenceAndAlternate("G", "A")) == 0)
+    assert(stats.aggregateStatistics.singleNucleotideVariantCounts(ReferenceAndAlternate("G", "C")) == 0)
+    assert(stats.aggregateStatistics.singleNucleotideVariantCounts(ReferenceAndAlternate("G", "T")) == 0)
+    assert(stats.aggregateStatistics.singleNucleotideVariantCounts(ReferenceAndAlternate("A", "T")) == 0)
+    assert(stats.aggregateStatistics.singleNucleotideVariantCounts(ReferenceAndAlternate("T", "C")) == 0)
+    assert(stats.aggregateStatistics.singleNucleotideVariantCounts(ReferenceAndAlternate("T", "G")) == 0)
+    assert(stats.aggregateStatistics.insertionCount == 0)
+    assert(stats.aggregateStatistics.deletionCount == 0)
+    assert(stats.aggregateStatistics.multipleNucleotideVariantCount == 0)
+
+    assert(stats.singletonCount == 0)
+    assert(stats.distinctVariantCount == 0)
+
+    // Test that the formatting functions do not throw.
+    GenotypesSummaryFormatting.format_csv(stats)
+    GenotypesSummaryFormatting.format_human_readable(stats)
+  }
+}

--- a/adam-format/src/main/resources/avro/adam.avdl
+++ b/adam-format/src/main/resources/avro/adam.avdl
@@ -151,22 +151,11 @@ record ADAMContig {
   union { null, string } referenceURL = null;
 }
 
-enum VariantType {
-    SNP,
-    MNP,
-    Insertion,
-    Deletion,
-    Complex,
-    SV
-}
-
 record ADAMVariant {
   union { null, ADAMContig } contig = null;
   union { null, long }       position = null;
   string                     referenceAllele;
   string                     variantAllele;
-  // enum to describe type of variant called
-  union { null, VariantType } variantType = null;
 }
 
 enum ADAMGenotypeAllele {


### PR DESCRIPTION
Adds the summarize_genotypes command described in #172 (closes #172). This command gives basic stats on a collection of ADAMGenotype records. Also adds methods to compute the type of a variant (SNV, insertion, deletion, etc.) in RichADAMVariant, which closes #174, and cleans up the no longer used VariantType enum in adam.avdl.
