### PR TITLE
Add repartition parameter

### DIFF
--- a/adam-cli/src/main/scala/edu/berkeley/cs/amplab/adam/cli/SparkCommand.scala
+++ b/adam-cli/src/main/scala/edu/berkeley/cs/amplab/adam/cli/SparkCommand.scala
@@ -36,6 +36,10 @@ trait SparkArgs extends Args4jBase {
   var spark_kryo_buffer_size = 4
   @Args4jOption(required = false, name = "-spark_add_stats_listener", usage = "Register job stat reporter, which is useful for debug/profiling.")
   var spark_add_stats_listener = false
+  @Args4jOption(required = false, name = "-coalesce", usage = "Set the number of partitions written to the ADAM output directory")
+  var coalesce: Int = -1
+  @Args4jOption(required = false, name = "-repartition", usage = "Set the number of partitions to map data to")
+  var repartition: Int = -1
 }
 
 trait SparkCommand extends AdamCommand {


### PR DESCRIPTION
Coalesce doesn't currently perform as documented since all of the transformation operations happen after it so you never actually get the proper number of output partitions.

I added a repartition at the top of the job to remap the data to more or less partitions (this helps with increasing parallelism) and moved coalesce to the end to create the proper number of outputs (can it go after the sort?, not sure the expectations on output are after the sort)

Also, moved both parameters to SparkArgs as they are likely to be needed in other operations (i.e. reads2ref) There may be better defaults too, but since they both add some overhead they are off by default
