### PR TITLE
Fix Scalariform issues and Maven warnings

### DIFF
--- a/adam-core/src/main/scala/org/bdgenomics/adam/util/BuildInformation.scala
+++ b/adam-core/src/main/scala/org/bdgenomics/adam/util/BuildInformation.scala
@@ -22,7 +22,7 @@ import java.util.Properties
 
 /**
  * A static object that gets the resource "git.properties" and renders the
- * build-information in different formats. The parsing is “lazy”, it parses
+ * build-information in different formats. The parsing is "lazy", it parses
  * the properties only the first time a function is called.
  */
 object BuildInformation {

--- a/adam-core/src/test/scala/org/bdgenomics/adam/rdd/ADAMContextSuite.scala
+++ b/adam-core/src/test/scala/org/bdgenomics/adam/rdd/ADAMContextSuite.scala
@@ -93,15 +93,15 @@ class ADAMContextSuite extends SparkFunSuite {
      * Create the following directory structure, in the temp file location:
      *
      * .
-     * ├── parent-dir/
-     *     ├── subDir1/
-     *     |   ├── match1/
-     *     |   └── match2/
-     *     └── subDir2/
-     *     |   ├── match3/
-     *     |   └── nomatch4/
-     *     ├── match5/
-     *     └── nomatch6/
+     * |__ parent-dir/
+     *     |__ subDir1/
+     *     |   |__ match1/
+     *     |   |__ match2/
+     *     |__ subDir2/
+     *     |   |__ match3/
+     *     |   |__ nomatch4/
+     *     |__ match5/
+     *     |__ nomatch6/
      */
 
     val tempDir = File.createTempFile("ADAMContextSuite", "").getParentFile

--- a/pom.xml
+++ b/pom.xml
@@ -4,6 +4,7 @@
         <groupId>org.sonatype.oss</groupId>
         <artifactId>oss-parent</artifactId>
         <version>7</version>
+        <relativePath></relativePath>
     </parent>
 
     <modelVersion>4.0.0</modelVersion>


### PR DESCRIPTION
We had some Unicode characters in our comments which were causing
Scalariform to throw an exception during processing.  Also, Maven
requires an empty "relativePath" attribute in the parent POM, otherwise
it was trying to resolve parent artifacts in some invalid location.

PS sorry to whoever wrote the cool unicode art for the directory tree that I had to rewrite using 8bit ascii.
