### PR TITLE
FastaConverter Refactor

### DIFF
--- a/adam-cli/src/main/scala/org/bdgenomics/adam/cli/Fasta2ADAM.scala
+++ b/adam-cli/src/main/scala/org/bdgenomics/adam/cli/Fasta2ADAM.scala
@@ -52,16 +52,7 @@ class Fasta2ADAM(protected val args: Fasta2ADAMArgs) extends ADAMSparkCommand[Fa
 
   def run(sc: SparkContext, job: Job) {
     log.info("Loading FASTA data from disk.")
-    val fastaData: RDD[(LongWritable, Text)] = sc.newAPIHadoopFile(args.fastaFile,
-      classOf[TextInputFormat],
-      classOf[LongWritable],
-      classOf[Text])
-
-    val remapData = fastaData.map(kv => (kv._1.get.toInt, kv._2.toString.toString))
-
-    log.info("Converting FASTA to ADAM.")
-    val adamFasta = FastaConverter(remapData, args.fragmentLength)
-
+    val adamFasta = sc.adamSequenceLoad(args.fastaFile, args.fragmentLength)
     if (args.verbose) {
       println("FASTA contains:")
       println(adamFasta.adamGetSequenceDictionary())


### PR DESCRIPTION
- Bug in FastaConverter where it would incorrectly identify the header line with an associated sequence (see broken test case on older code (https://github.com/hammerlab/adam/compare/fasta-branch?expand=1)
- General cleanup, splitting out into functions for readability
- Added adamSequenceLoad to load either fasta or adam sequences
