### PR TITLE
Adding Smith-Waterman and Knowns-Only consensus modes to indel realignment

### DIFF
--- a/adam-core/src/main/scala/edu/berkeley/cs/amplab/adam/algorithms/consensus/ConsensusGenerator.scala
+++ b/adam-core/src/main/scala/edu/berkeley/cs/amplab/adam/algorithms/consensus/ConsensusGenerator.scala
@@ -1,0 +1,51 @@
+/*
+ * Copyright (c) 2013-2014. Regents of the University of California
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package edu.berkeley.cs.amplab.adam.algorithms.consensus
+
+import edu.berkeley.cs.amplab.adam.algorithms.realignmenttarget.IndelRealignmentTarget
+import edu.berkeley.cs.amplab.adam.models.{Consensus, ReferenceRegion}
+import edu.berkeley.cs.amplab.adam.rich.RichADAMRecord
+import org.apache.spark.rdd.RDD
+
+abstract class ConsensusGenerator extends Serializable {
+
+  /**
+   * Generates targets to add to initial set of indel realignment targets, if additional
+   * targets are necessary.
+   *
+   * @return Returns an option which wraps an RDD of indel realignment targets.
+   */
+  def targetsToAdd(): Option[RDD[IndelRealignmentTarget]]
+
+  /**
+   * Performs any preprocessing specific to this consensus generation algorithm, e.g.,
+   * indel normalization.
+   *
+   * @param reads Reads to preprocess.
+   * @return Preprocessed reads.
+   */
+  def preprocessReadsForRealignment(reads: Seq[RichADAMRecord],
+                                    reference: String,
+                                    region: ReferenceRegion): Seq[RichADAMRecord]
+
+  /**
+   * For all reads in this region, generates the list of consensus sequences for realignment.
+   *
+   * @param reads Reads to generate consensus sequences from.
+   * @return Consensus sequences to use for realignment.
+   */
+  def findConsensus(reads: Seq[RichADAMRecord]): Seq[Consensus]
+}

--- a/adam-core/src/main/scala/edu/berkeley/cs/amplab/adam/algorithms/consensus/ConsensusGeneratorFromKnowns.scala
+++ b/adam-core/src/main/scala/edu/berkeley/cs/amplab/adam/algorithms/consensus/ConsensusGeneratorFromKnowns.scala
@@ -1,0 +1,81 @@
+/*
+ * Copyright (c) 2013-2014. Regents of the University of California
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package edu.berkeley.cs.amplab.adam.algorithms.consensus
+
+import edu.berkeley.cs.amplab.adam.avro.{ADAMContig, ADAMVariant}
+import edu.berkeley.cs.amplab.adam.rdd.AdamContext._
+import edu.berkeley.cs.amplab.adam.rdd.variation.ADAMVariationContext._
+import edu.berkeley.cs.amplab.adam.algorithms.realignmenttarget.IndelRealignmentTarget
+import edu.berkeley.cs.amplab.adam.models.{Consensus, 
+                                           IndelTable,
+                                           ADAMVariantContext, 
+                                           ReferenceRegion}
+import edu.berkeley.cs.amplab.adam.rich.RichADAMRecord
+import org.apache.spark.SparkContext
+import org.apache.spark.rdd.RDD
+
+class ConsensusGeneratorFromKnowns (file: String, sc: SparkContext) extends ConsensusGenerator {
+
+  val indelTable = sc.broadcast(IndelTable(file, sc))
+
+  /**
+   * Generates targets to add to initial set of indel realignment targets, if additional
+   * targets are necessary.
+   *
+   * @return Returns an option which wraps an RDD of indel realignment targets.
+   */
+  def targetsToAdd(): Option[RDD[IndelRealignmentTarget]] = {
+    val rdd: RDD[ADAMVariantContext] = sc.adamVCFLoad(file)
+
+    Some(rdd.map(_.variant.variant)
+      .filter(v => v.getReferenceAllele.length != v.getVariantAllele.length)
+      .map(v => ReferenceRegion(v.getContig.getContigId, v.getPosition, v.getPosition + v.getReferenceAllele.length))
+      .map(r => new IndelRealignmentTarget(Some(r), r)))
+  }
+
+  /**
+   * Performs any preprocessing specific to this consensus generation algorithm, e.g.,
+   * indel normalization.
+   *
+   * @param reads Reads to preprocess.
+   * @return Preprocessed reads.
+   */
+  def preprocessReadsForRealignment(reads: Seq[RichADAMRecord],
+                                    reference: String,
+                                    region: ReferenceRegion): Seq[RichADAMRecord] = {
+    reads
+  }
+
+  /**
+   * For all reads in this region, generates the list of consensus sequences for realignment.
+   *
+   * @param reads Reads to generate consensus sequences from.
+   * @return Consensus sequences to use for realignment.
+   */
+  def findConsensus(reads: Seq[RichADAMRecord]): List[Consensus] = {
+    val table = indelTable.value
+
+    // get region
+    val start = reads.map(_.record.getStart.toLong).reduce(_ min _)
+    val end = reads.flatMap(_.end).reduce(_ max _)
+    val refId = reads.head.record.getReferenceId
+
+    val region = ReferenceRegion(refId, start, end + 1)
+
+    // get reads
+    table.getIndelsInRegion(region).toList
+  }
+}

--- a/adam-core/src/main/scala/edu/berkeley/cs/amplab/adam/algorithms/consensus/ConsensusGeneratorFromReads.scala
+++ b/adam-core/src/main/scala/edu/berkeley/cs/amplab/adam/algorithms/consensus/ConsensusGeneratorFromReads.scala
@@ -1,0 +1,85 @@
+/*
+ * Copyright (c) 2013-2014. Regents of the University of California
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package edu.berkeley.cs.amplab.adam.algorithms.consensus
+
+import edu.berkeley.cs.amplab.adam.algorithms.realignmenttarget.IndelRealignmentTarget
+import edu.berkeley.cs.amplab.adam.avro.ADAMRecord
+import edu.berkeley.cs.amplab.adam.models.{Consensus, ReferenceRegion, ReferencePosition}
+import edu.berkeley.cs.amplab.adam.rich.RichADAMRecord
+import edu.berkeley.cs.amplab.adam.rich.RichADAMRecord._
+import edu.berkeley.cs.amplab.adam.rich.RichCigar
+import edu.berkeley.cs.amplab.adam.rich.RichCigar._
+import edu.berkeley.cs.amplab.adam.util.MdTag
+import edu.berkeley.cs.amplab.adam.util.ImplicitJavaConversions
+import edu.berkeley.cs.amplab.adam.util.ImplicitJavaConversions._
+import edu.berkeley.cs.amplab.adam.util.NormalizationUtils._
+import net.sf.samtools.{Cigar, CigarOperator, CigarElement}
+import org.apache.spark.rdd.RDD
+
+class ConsensusGeneratorFromReads extends ConsensusGenerator {
+
+  /**
+   * No targets to add if generating consensus targets from reads.
+   *
+   * @return Returns a None.
+   */
+  def targetsToAdd(): Option[RDD[IndelRealignmentTarget]] = None
+
+  /**
+   * Performs read preprocessing by normalizing indels for all reads that have evidence of one
+   * indel.
+   *
+   * @param reads Reads to process.
+   * @return Reads with indels normalized if they contain a single indel.
+   */
+  def preprocessReadsForRealignment(reads: Seq[RichADAMRecord],
+                                    reference: String,
+                                    region: ReferenceRegion): Seq[RichADAMRecord] = {
+    reads.map(r => {
+      // if there are two alignment blocks (sequence matches) then there is a single indel in the read
+      if (r.samtoolsCigar.numAlignmentBlocks == 2) {
+        // left align this indel and update the mdtag
+        val cigar = leftAlignIndel(r)
+        val mdTag = MdTag.moveAlignment(r, cigar)
+        
+        val newRead: RichADAMRecord = ADAMRecord.newBuilder(r)
+          .setCigar(cigar.toString)
+          .setMismatchingPositions(mdTag.toString)
+          .build()
+
+        newRead
+      } else {
+        r
+      }
+    })
+  }
+
+  /**
+   * Generates concensus sequences from reads with indels.
+   */
+  def findConsensus(reads : Seq[RichADAMRecord]): Seq[Consensus] = {
+    reads.filter(r => r.mdTag.isDefined)
+      .flatMap(r => {
+        // try to generate a consensus alignment - if a consensus exists, add it to our
+        // list of consensuses to test
+        Consensus.generateAlternateConsensus(r.getSequence, 
+                                             ReferencePosition(r.getReferenceId, 
+                                                               r.getStart),
+                                             r.samtoolsCigar)
+      }).distinct
+  }
+
+}

--- a/adam-core/src/main/scala/edu/berkeley/cs/amplab/adam/algorithms/consensus/ConsensusGeneratorFromSmithWaterman.scala
+++ b/adam-core/src/main/scala/edu/berkeley/cs/amplab/adam/algorithms/consensus/ConsensusGeneratorFromSmithWaterman.scala
@@ -1,0 +1,73 @@
+/*
+ * Copyright (c) 2013-2014. Regents of the University of California
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package edu.berkeley.cs.amplab.adam.algorithms.consensus
+
+import edu.berkeley.cs.amplab.adam.algorithms.smithwaterman.SmithWatermanConstantGapScoring
+import edu.berkeley.cs.amplab.adam.avro.ADAMRecord
+import edu.berkeley.cs.amplab.adam.models.{Consensus, ReferenceRegion}
+import edu.berkeley.cs.amplab.adam.rich.RichADAMRecord
+import edu.berkeley.cs.amplab.adam.rich.RichADAMRecord._
+import edu.berkeley.cs.amplab.adam.rich.RichCigar._
+import edu.berkeley.cs.amplab.adam.util.MdTag
+import net.sf.samtools.Cigar
+
+class ConsensusGeneratorFromSmithWaterman (wMatch: Double,
+                                           wMismatch: Double,
+                                           wInsert: Double,
+                                           wDelete: Double) extends ConsensusGeneratorFromReads {
+
+  /**
+   * Attempts realignment of all reads using Smith-Waterman. Accepts all realignments that have one
+   * or fewer indels.
+   *
+   * @param reads Reads to process.
+   * @return Reads with indels normalized if they contain a single indel.
+   */
+  override def preprocessReadsForRealignment(reads: Seq[RichADAMRecord],
+                                             reference: String,
+                                             region: ReferenceRegion): Seq[RichADAMRecord] = {
+    val rds: Seq[RichADAMRecord] = reads.map(r => {
+      
+      val sw = new SmithWatermanConstantGapScoring(r.record.getSequence.toString,
+                                                   reference,
+                                                   wMatch,
+                                                   wMismatch,
+                                                   wInsert,
+                                                   wDelete)
+      println("for " + r.record.getReadName + " sw to " + sw.xStart + " with " + sw.cigarX)
+
+      // if we realign with fewer than three alignment blocks, then take the new alignment
+      if (sw.cigarX.numAlignmentBlocks <= 2) {
+        val mdTag = MdTag(r.record.getSequence.toString, 
+                          reference.drop(sw.xStart), 
+                          sw.cigarX, 
+                          region.start)
+
+        val newRead: RichADAMRecord = ADAMRecord.newBuilder(r)
+          .setStart(sw.xStart + region.start)
+          .setCigar(sw.cigarX.toString)
+          .setMismatchingPositions(mdTag.toString)
+          .build()
+
+        newRead
+      } else {
+        r
+      }
+    })
+
+    super.preprocessReadsForRealignment(rds, reference, region)
+  }
+}

--- a/adam-core/src/main/scala/edu/berkeley/cs/amplab/adam/algorithms/smithwaterman/SmithWaterman.scala
+++ b/adam-core/src/main/scala/edu/berkeley/cs/amplab/adam/algorithms/smithwaterman/SmithWaterman.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2013. Regents of the University of California
+ * Copyright (c) 2013-2014. Regents of the University of California
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,19 +16,168 @@
 
 package edu.berkeley.cs.amplab.adam.algorithms.smithwaterman
 
-import net.sf.samtools.Cigar
+import net.sf.samtools.{Cigar, TextCigarCodec}
+import scala.annotation.tailrec
 
-abstract class SmithWaterman (xSequence: String, ySequence: String) {
-  
-  var max = 0.0
-  var maxX = 0
-  var maxY = 0
+private[smithwaterman] object SmithWaterman {
+  val CIGAR_CODEC: TextCigarCodec = TextCigarCodec.getSingleton
+}
 
-  lazy val scoringMatrix = buildScoringMatrix
-  lazy val (cigarX, cigarY, alignmentX, alignmentY) = trackback 
+abstract class SmithWaterman (xSequence: String, ySequence: String) extends Serializable {
 
-  def buildScoringMatrix (): Array[Array[Double]]
+  lazy val (scoringMatrix, moveMatrix) = buildScoringMatrix
+  lazy val (cigarX, cigarY, xStart, yStart) = trackback(scoringMatrix, moveMatrix)
 
-  protected def trackback (): (Cigar, Cigar, String, String)
+  /**
+   * Builds Smith-Waterman scoring matrix.
+   *
+   * @returns 2D array of doubles, along with move direction at each point.
+   *
+   * @note To work with the move function, expected move directions are:
+   *
+   * * I: move in I coordinate
+   * * J: move in J coordinate
+   * * B: move in both I and J
+   * * T: terminate move
+   * 
+   * @see move
+   */
+  private[smithwaterman] def buildScoringMatrix (): (Array[Array[Double]], Array[Array[Char]])
+
+  /**
+   * Finds coordinates of a matrix with highest value.
+   *
+   * @param matrix Matrix to score.
+   * @return Tuple of (i, j) coordinates.
+   */
+  private[smithwaterman] final def maxCoordinates (matrix: Array[Array[Double]]): (Int, Int) = {
+    def maxInCol(col: Array[Double]): (Double, Int) = {
+      def takeMax(a: (Double, Int), b: (Double, Int)): (Double, Int) = {
+        if (a._1 > b._1) {
+          a
+        } else {
+          b
+        }
+      }
+
+      val c: Array[(Double, Int)] = col.zipWithIndex
+      
+      c.reduce(takeMax)
+    }
+
+    def maxCol(cols: Array[(Double, Int)]): (Int, Int) = {
+      def takeMax(a: (Double, Int, Int), b: (Double, Int, Int)): (Double, Int, Int) = {
+        if (a._1 > b._1) {
+          a
+        } else {
+          b
+        }
+      }
+
+      val c: Array[((Double, Int), Int)] = cols.zipWithIndex
+        
+      val m: (Double, Int, Int) = c.map(kv => (kv._1._1, kv._1._2, kv._2))
+        .reduce(takeMax)
+      
+      (m._2, m._3)
+    }
+
+    maxCol(matrix.map(maxInCol))
+  }
+
+  /**
+   * Converts a reversed non-numeric CIGAR into a normal CIGAR.
+   *
+   * @note A reversed non-numeric CIGAR is a CIGAR where each alignment block
+   * has length = 1, and the alignment block ordering goes from end-to-beginning. E.g.,
+   * the equivalent of the CIGAR 4M2D1M would be MDDMMMM.
+   *
+   * @param nnc Reversed non-numeric CIGAR.
+   * @return A normal CIGAR.
+   */
+  private[smithwaterman] def cigarFromRNNCigar(nnc: String): String = {
+
+    @tailrec def buildCigar(last: Char, runCount: Int, nnc: String, cigar: String): String = {
+      if (nnc.length == 0) {
+        (runCount.toString + last) + cigar
+      } else {
+        val (next, nrc, nc) = if (nnc.head == last) {
+          (last, runCount + 1, cigar)
+        } else {
+          (nnc.head, 1, (runCount.toString + last) + cigar)
+        }
+        
+        buildCigar(next, nrc, nnc.drop(1), nc)
+      }
+    }
+
+    buildCigar(nnc.head, 1, nnc.drop(1), "")
+  }
+
+  /**
+   * Recursive function to do backtrack.
+   *
+   * @param matrix Matrix to track back upon.
+   * @param i Current position in x sequence.
+   * @param j Current position in y sequence.
+   * @param cX Current reversed non-numeric CIGAR for the X sequence.
+   * @param cY Current reversed non-numeric CIGAR for the Y sequence.
+   * @return Returns the alignment CIGAR for the X and Y sequences, along with start indices.
+   * 
+   * @note To work with the move function, expected move directions are:
+   *
+   * * I: move in I coordinate
+   * * J: move in J coordinate
+   * * B: move in both I and J
+   * * T: terminate move
+   * 
+   * @see buildScoringMatrix
+   */
+  @tailrec private[smithwaterman] final def move (matrix: Array[Array[Char]],
+                                            i: Int, 
+                                            j: Int, 
+                                            cX: String, 
+                                            cY: String): (String, String, Int, Int) = {
+    if (matrix(i)(j) == 'T') {
+      // return if told to terminate
+      (cigarFromRNNCigar(cX), cigarFromRNNCigar(cY), i, j)
+    } else {
+      // find next move
+      val (in, jn, cXn, cYn) = if (matrix(i)(j) == 'B') {
+        (i - 1, j - 1, cX + "M", cY + "M")
+      } else if (matrix(i)(j) == 'J' ) {
+        (i - 1, j, cX + "I", cY + "D")
+      } else {
+        (i, j - 1, cX + "D", cY + "I")
+      }
+      
+      // recurse
+      move(matrix, in, jn, cXn, cYn)
+    }
+  }
+
+  /**
+   * Runs trackback on scoring matrix.
+   *
+   * @param scoreMatrix Scored matrix to track back on.
+   * @param moveMatrix Move matrix to track back on.
+   * @returns Tuple of Cigar for X, Y.
+   */
+  private[smithwaterman] def trackback (scoreMatrix: Array[Array[Double]],
+                                        moveMatrix: Array[Array[Char]]): (Cigar, Cigar, Int, Int) = {
+    assert(scoreMatrix.length == xSequence.length + 1)
+    assert(scoreMatrix.forall(_.length == ySequence.length + 1))
+    assert(moveMatrix.length == xSequence.length + 1)
+    assert(moveMatrix.forall(_.length == ySequence.length + 1))
+
+    // get the position of the max scored box - start trackback here
+    val (sx, sy) = maxCoordinates(scoreMatrix)
+
+    // run trackback
+    val (cX, cY, xI, yI) = move(moveMatrix, sy, sx, "", "")
+
+    // get cigars and return
+    (SmithWaterman.CIGAR_CODEC.decode(cX), SmithWaterman.CIGAR_CODEC.decode(cY), xI, yI)
+  }
 
 }

--- a/adam-core/src/main/scala/edu/berkeley/cs/amplab/adam/algorithms/smithwaterman/SmithWatermanConstantGapScoring.scala
+++ b/adam-core/src/main/scala/edu/berkeley/cs/amplab/adam/algorithms/smithwaterman/SmithWatermanConstantGapScoring.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2013. Regents of the University of California
+ * Copyright (c) 2013-2014. Regents of the University of California
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -19,11 +19,11 @@ package edu.berkeley.cs.amplab.adam.algorithms.smithwaterman
 object SmithWatermanConstantGapScoring {
 
   protected def constantGapFn (wMatch: Double, wDelete: Double, wInsert: Double, wMismatch: Double)(x: Int, y: Int, i: Char, j: Char): Double = {
-    if (x == y) {
+    if (i == j) {
       wMatch
-    } else if (x == '_') {
+    } else if (i == '_') {
       wDelete
-    } else if (y == '_') {
+    } else if (j == '_') {
       wInsert
     } else {
       wMismatch
@@ -32,11 +32,11 @@ object SmithWatermanConstantGapScoring {
   
 }
 
-abstract class SmithWatermanConstantGapScoring (xSequence: String,
+class SmithWatermanConstantGapScoring (xSequence: String,
 				       ySequence: String,
 				       wMatch: Double,
 				       wMismatch: Double,
 				       wInsert: Double,
 				       wDelete: Double)
-    extends SmithWatermanGapScoringFromFn (xSequence, ySequence, SmithWatermanConstantGapScoring.constantGapFn(wMatch,wMismatch,wInsert,wDelete)) {
+    extends SmithWatermanGapScoringFromFn (xSequence, ySequence, SmithWatermanConstantGapScoring.constantGapFn(wMatch,wInsert,wDelete,wMismatch)) {
 }

--- a/adam-core/src/main/scala/edu/berkeley/cs/amplab/adam/models/IndelTable.scala
+++ b/adam-core/src/main/scala/edu/berkeley/cs/amplab/adam/models/IndelTable.scala
@@ -1,0 +1,91 @@
+/*
+ * Copyright (c) 2014. Regents of the University of California
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package edu.berkeley.cs.amplab.adam.models
+
+import edu.berkeley.cs.amplab.adam.avro.{ADAMContig, ADAMVariant}
+import edu.berkeley.cs.amplab.adam.rdd.AdamContext._
+import edu.berkeley.cs.amplab.adam.rdd.variation.ADAMVariationContext._
+import org.apache.spark.{Logging, SparkContext}
+import org.apache.spark.SparkContext._
+import org.apache.spark.rdd.RDD
+
+class IndelTable (private val table: Map[Int, Seq[Consensus]]) extends Serializable with Logging {
+  log.info("Indel table has %s contigs and %s entries".format(table.size, 
+                                                              table.values.map(_.size).sum))
+
+  /**
+   * Returns all known indels within the given reference region. If none are known, returns an empty Seq.
+   *
+   * @param region Region to look for known indels.
+   * @return Returns a sequence of consensuses.
+   */
+  def getIndelsInRegion(region: ReferenceRegion): Seq[Consensus] = {
+    if (table.contains(region.refId)) {
+      val bucket = table(region.refId)
+      
+      bucket.filter(_.index.overlaps(region))
+    } else {
+      Seq()
+    }
+  }
+}
+
+object IndelTable {
+
+  /**
+   * Creates an indel table from a file containing known indels.
+   *
+   * @param knownIndelsFile Path to file with known indels.
+   * @param sc SparkContext to use for loading.
+   * @return Returns a table with the known indels populated.
+   */
+  def apply(knownIndelsFile: String, sc: SparkContext): IndelTable = {
+    val rdd: RDD[ADAMVariantContext] = sc.adamVCFLoad(knownIndelsFile)
+    apply(rdd.map(_.variant.variant))
+  }
+
+  /**
+   * Creates an indel table from an RDD containing known variants.
+   *
+   * @param variants RDD of variants.
+   * @return Returns a table with known indels populated.
+   */
+  def apply(variants: RDD[ADAMVariant]): IndelTable = {
+    val consensus: Map[Int, Seq[Consensus]] = variants.filter(v => v.getReferenceAllele.length != v.getVariantAllele.length)
+      .map(v => {
+        val refId: Int = v.getContig.getContigId
+        val consensus = if (v.getReferenceAllele.length > v.getVariantAllele.length) {
+          // deletion
+          val deletionLength = v.getReferenceAllele.length - v.getVariantAllele.length
+          val start = v.getPosition + v.getVariantAllele.length
+          
+          Consensus("", ReferenceRegion(refId, start, start + deletionLength))
+        } else {
+          // insertion
+          val insertionLength = v.getVariantAllele.length - v.getReferenceAllele.length
+          val start = v.getPosition + v.getReferenceAllele.length
+          
+          Consensus(v.getVariantAllele.toString.drop(v.getReferenceAllele.length), ReferenceRegion(refId, start, start + 1))
+        }
+
+        (refId, consensus)
+      }).groupByKey()
+        .collect
+        .toMap
+
+    new IndelTable(consensus)
+  }
+}

--- a/adam-core/src/main/scala/edu/berkeley/cs/amplab/adam/rdd/AdamRDDFunctions.scala
+++ b/adam-core/src/main/scala/edu/berkeley/cs/amplab/adam/rdd/AdamRDDFunctions.scala
@@ -15,6 +15,7 @@
  */
 package edu.berkeley.cs.amplab.adam.rdd
 
+import edu.berkeley.cs.amplab.adam.algorithms.consensus.{ConsensusGenerator, ConsensusGeneratorFromReads}
 import edu.berkeley.cs.amplab.adam.avro.{ADAMPileup, 
                                          ADAMRecord, 
                                          ADAMNucleotideContigFragment,
@@ -196,12 +197,13 @@ class AdamRecordRDDFunctions(rdd: RDD[ADAMRecord]) extends AdamSequenceDictionar
    *
    * @return Returns an RDD of mapped reads which have been realigned.
    */
-  def adamRealignIndels(isSorted: Boolean = false,
+  def adamRealignIndels(consensusModel: ConsensusGenerator = new ConsensusGeneratorFromReads,
+                        isSorted: Boolean = false,
                         maxIndelSize: Int = 500,
                         maxConsensusNumber: Int = 30,
                         lodThreshold: Double = 5.0,
                         maxTargetSize: Int = 3000): RDD[ADAMRecord] = {
-    RealignIndels(rdd, isSorted, maxIndelSize, maxConsensusNumber, lodThreshold)
+    RealignIndels(rdd, consensusModel, isSorted, maxIndelSize, maxConsensusNumber, lodThreshold)
   }
 
   // Returns a tuple of (failedQualityMetrics, passedQualityMetrics)

--- a/adam-core/src/test/scala/edu/berkeley/cs/amplab/adam/algorithms/consensus/ConsensusGeneratorFromReadsSuite.scala
+++ b/adam-core/src/test/scala/edu/berkeley/cs/amplab/adam/algorithms/consensus/ConsensusGeneratorFromReadsSuite.scala
@@ -1,0 +1,43 @@
+/*
+ * Copyright (c) 2014. Regents of the University of California
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package edu.berkeley.cs.amplab.adam.algorithms.consensus
+
+import edu.berkeley.cs.amplab.adam.util.SparkFunSuite
+import edu.berkeley.cs.amplab.adam.rdd.AdamContext._
+import org.apache.spark.rdd.RDD
+import edu.berkeley.cs.amplab.adam.avro.ADAMRecord
+import parquet.filter.UnboundRecordFilter
+import edu.berkeley.cs.amplab.adam.models.Consensus
+import edu.berkeley.cs.amplab.adam.rich.RichADAMRecord
+
+class ConsensusGeneratorFromReadsSuite extends SparkFunSuite {
+
+  val cg = new ConsensusGeneratorFromReads
+
+  def artificial_reads: RDD[ADAMRecord] = {
+    val path = ClassLoader.getSystemClassLoader.getResource("artificial.sam").getFile
+    sc.adamLoad[ADAMRecord, UnboundRecordFilter](path)
+  }
+
+  sparkTest("checking search for consensus list for artitifical reads") {
+    val consensus = cg.findConsensus(artificial_reads.map(new RichADAMRecord(_))
+      .collect()
+      .toSeq)
+    
+    assert(consensus.length === 2)
+  }
+}
+

--- a/adam-core/src/test/scala/edu/berkeley/cs/amplab/adam/algorithms/smithwaterman/SmithWatermanSuite.scala
+++ b/adam-core/src/test/scala/edu/berkeley/cs/amplab/adam/algorithms/smithwaterman/SmithWatermanSuite.scala
@@ -1,0 +1,239 @@
+/*
+ * Copyright (c) 2014. Regents of the University of California
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package edu.berkeley.cs.amplab.adam.algorithms.smithwaterman
+
+import org.scalatest.FunSuite
+import scala.math.abs
+
+class SmithWatermanSuite extends FunSuite {
+
+  val epsilon = 1e-6
+  def fpEquals(a: Double, b: Double): Boolean = {
+    abs(a - b) < epsilon
+  }
+
+  test("gather max position from simple scoring matrix") {
+    val c0 = Array(0.0, 0.0, 0.0, 0.0, 0.0)
+    val c1 = Array(0.0, 1.0, 1.0, 1.0, 1.0)
+    val c2 = Array(0.0, 1.0, 2.0, 2.0, 2.0)
+    val c3 = Array(0.0, 1.0, 2.0, 3.0, 3.0)
+    val c4 = Array(0.0, 1.0, 2.0, 3.0, 4.0)
+    val matrix = Array(c0, c1, c2, c3, c4)
+    
+    val sw = new SmithWatermanConstantGapScoring("AAAA", "AAAA", 1.0, 0.0, -1.0, -1.0)
+
+    val max = sw.maxCoordinates(matrix)
+    assert(max._1 === 4)
+    assert(max._2 === 4)
+  }
+
+  test("gather max position from irregular scoring matrix") {
+    //             _    A    C    G    T
+    val c0 = Array(0.0, 0.0, 0.0, 0.0, 0.0) // _
+    val c1 = Array(0.0, 1.0, 1.0, 1.0, 1.0) // A
+    val c2 = Array(0.0, 0.0, 2.0, 1.0, 1.0) // C
+    val c3 = Array(0.0, 1.0, 1.0, 2.0, 1.0) // A
+    val c4 = Array(0.0, 0.0, 1.0, 1.0, 3.0) // T
+    val c5 = Array(0.0, 0.0, 0.0, 0.0, 2.0) // G
+    val c6 = Array(0.0, 1.0, 0.0, 0.0, 1.0) // A
+    val matrix = Array(c0, c1, c2, c3, c4, c5, c6)
+    
+    val sw = new SmithWatermanConstantGapScoring("ACGT", "ACATGA", 1.0, 0.0, -1.0, -1.0)
+
+    val max = sw.maxCoordinates(matrix)
+    assert(max._1 === 4)
+    assert(max._2 === 4)
+  }
+
+  test("gather max position from irregular scoring matrix with deletions") {
+    //             _    A    C    G    A
+    val c0 = Array(0.0, 0.0, 0.0, 0.0, 0.0) // _
+    val c1 = Array(0.0, 1.0, 1.0, 1.0, 1.0) // A
+    val c2 = Array(0.0, 0.5, 2.0, 1.0, 1.0) // C
+    val c3 = Array(0.0, 1.0, 1.5, 2.0, 1.5) // A
+    val c4 = Array(0.0, 0.5, 1.0, 1.5, 2.0) // T
+    val c5 = Array(0.0, 0.5, 0.5, 2.0, 1.5) // G
+    val c6 = Array(0.0, 1.0, 0.5, 1.5, 3.0) // A
+    val matrix = Array(c0, c1, c2, c3, c4, c5, c6)
+    
+    val sw = new SmithWatermanConstantGapScoring("ACGA", "ACATGA", 1.0, 0.0, -0.5, -0.5)
+
+    val max = sw.maxCoordinates(matrix)
+    assert(max._1 === 4)
+    assert(max._2 === 6)
+  }  
+
+  test("score simple alignment with constant gap") {
+    val c0 = Array(0.0, 0.0, 0.0, 0.0, 0.0)
+    val c1 = Array(0.0, 1.0, 1.0, 1.0, 1.0)
+    val c2 = Array(0.0, 1.0, 2.0, 2.0, 2.0)
+    val c3 = Array(0.0, 1.0, 2.0, 3.0, 3.0)
+    val c4 = Array(0.0, 1.0, 2.0, 3.0, 4.0)
+    val matrix = Array(c0, c1, c2, c3, c4)
+    
+    val sw = new SmithWatermanConstantGapScoring("AAAA", "AAAA", 1.0, 0.0, -1.0, -1.0)
+
+    val (swMatrix, _) = sw.buildScoringMatrix()
+    for (j <- 0 to 4) {
+      for (i <- 0 to 4) {
+        assert(fpEquals(swMatrix(i)(j), matrix(i)(j)))
+      }
+    }
+  }
+
+  test("score irregular scoring matrix") {
+    //             _    A    C    G    T
+    val c0 = Array(0.0, 0.0, 0.0, 0.0, 0.0) // _
+    val c1 = Array(0.0, 1.0, 0.0, 0.0, 0.0) // A
+    val c2 = Array(0.0, 0.0, 2.0, 1.0, 0.0) // C
+    val c3 = Array(0.0, 1.0, 1.0, 2.0, 1.0) // A
+    val c4 = Array(0.0, 0.0, 1.0, 1.0, 3.0) // T
+    val c5 = Array(0.0, 0.0, 0.0, 2.0, 2.0) // G
+    val c6 = Array(0.0, 1.0, 0.0, 1.0, 2.0) // A
+    val matrix = Array(c0, c1, c2, c3, c4, c5, c6)
+    
+    val sw = new SmithWatermanConstantGapScoring("ACATGA", "ACGT", 1.0, 0.0, -1.0, -1.0)
+
+    val (swMatrix, _) = sw.buildScoringMatrix()
+    for (i <- 0 to 6) {
+      for (j <- 0 to 4) {
+        assert(fpEquals(swMatrix(i)(j), matrix(i)(j)))
+      }
+    }
+  }
+
+  test("score irregular scoring matrix with indel") {
+    //             _    A    C    G    A
+    val c0 = Array(0.0, 0.0, 0.0, 0.0, 0.0) // _
+    val c1 = Array(0.0, 1.0, 0.5, 0.0, 1.0) // A
+    val c2 = Array(0.0, 0.5, 2.0, 1.5, 1.0) // C
+    val c3 = Array(0.0, 1.0, 1.5, 2.0, 2.5) // A
+    val c4 = Array(0.0, 0.5, 1.0, 1.5, 2.0) // T
+    val c5 = Array(0.0, 0.0, 0.5, 2.0, 1.5) // G
+    val c6 = Array(0.0, 1.0, 0.5, 1.5, 3.0) // A
+    val matrix = Array(c0, c1, c2, c3, c4, c5, c6)
+    
+    val sw = new SmithWatermanConstantGapScoring("ACATGA", "ACGA", 1.0, 0.0, -0.5, -0.5)
+
+    val (swMatrix, _) = sw.buildScoringMatrix()
+    for (i <- 0 to 6) {
+      for (j <- 0 to 4) {
+        assert(fpEquals(swMatrix(i)(j), matrix(i)(j)))
+      }
+    }
+  }
+
+  val swh = new SmithWatermanConstantGapScoring("", "", 0.0, 0.0, 0.0, 0.0)
+
+  test("can unroll cigars correctly") {
+    assert(swh.cigarFromRNNCigar("MDDMMMM")  === "4M2D1M")
+    assert(swh.cigarFromRNNCigar("MMMIIMM")  === "2M2I3M")
+    assert(swh.cigarFromRNNCigar("MMMMMMMM") === "8M")
+  }
+
+  test("execute simple trackback") {
+    val c0 = Array('T', 'T', 'T', 'T', 'T')
+    val c1 = Array('T', 'B', 'B', 'B', 'B')
+    val c2 = Array('T', 'B', 'B', 'B', 'B')
+    val c3 = Array('T', 'B', 'B', 'B', 'B')
+    val c4 = Array('T', 'B', 'B', 'B', 'B')
+    val matrix = Array(c0, c1, c2, c3, c4)
+    
+    val (cx, cy, _, _) = swh.move(matrix, 4, 4, "", "")
+
+    assert(cx === "4M")
+    assert(cy === "4M")
+  }
+
+  test("execute trackback with indel") {
+    //             _    A    C    G    A
+    val c0 = Array('T', 'T', 'T', 'T', 'T') // _
+    val c1 = Array('T', 'B', 'J', 'T', 'B') // A
+    val c2 = Array('T', 'I', 'B', 'B', 'B') // C
+    val c3 = Array('T', 'B', 'J', 'I', 'B') // A
+    val c4 = Array('T', 'I', 'J', 'B', 'B') // T
+    val c5 = Array('T', 'T', 'I', 'B', 'B') // G
+    val c6 = Array('T', 'B', 'J', 'B', 'B') // A
+    val matrix = Array(c0, c1, c2, c3, c4, c5, c6)
+    
+    val (cx, cy, _, _) = swh.move(matrix, 6, 4, "", "")
+
+    assert(cx === "2M2I2M")
+    assert(cy === "2M2D2M")
+  }
+
+  test("run end to end smith waterman for simple reads") {
+    val sw = new SmithWatermanConstantGapScoring("AAAA", "AAAA", 1.0, 0.0, -1.0, -1.0)
+
+    assert(sw.cigarX.toString === "4M")
+    assert(sw.cigarY.toString === "4M")
+  }
+
+  test("run end to end smith waterman for short sequences with indel") {
+    val sw = new SmithWatermanConstantGapScoring("ACATGA", "ACGA", 1.0, 0.0, -0.333, -0.333)
+
+    assert(sw.cigarX.toString === "2M2I2M")
+    assert(sw.cigarY.toString === "2M2D2M")
+  }
+
+  test("run end to end smith waterman for longer sequences with snp") {
+    // ATTAGACTACTTAATATACAGATTTACCCCAATAGA
+    // ATTAGACTACTTAATATACAGAATTACCCCAATAGA
+    val sw = new SmithWatermanConstantGapScoring("ATTAGACTACTTAATATACAGATTTACCCCAATAGA", 
+                                                 "ATTAGACTACTTAATATACAGAATTACCCCAATAGA",
+                                                 1.0, 0.0, -0.333, -0.333)
+
+    assert(sw.cigarX.toString === "36M")
+    assert(sw.cigarY.toString === "36M")
+  }
+
+  test("run end to end smith waterman for longer sequences with short indel") {
+    // ATTAGACTACTTAATATACAGATTTACCCCAATAGA
+    // ATTAGACTACTTAATATACAGA__TACCCCAATAGA
+    val sw = new SmithWatermanConstantGapScoring("ATTAGACTACTTAATATACAGATTTACCCCAATAGA", 
+                                                 "ATTAGACTACTTAATATACAGATACCCCAATAGA",
+                                                 1.0, 0.0, -0.333, -0.333)
+
+    assert(sw.cigarX.toString === "22M2I12M")
+    assert(sw.cigarY.toString === "22M2D12M")
+  }
+
+  test("run end to end smith waterman for shorter sequence in longer sequence") {
+    // ATTAGACTACTTAATATACAGATTTACCCCAATAGA
+    //         ACTTAATATACAGATTTACC
+    val sw = new SmithWatermanConstantGapScoring("ATTAGACTACTTAATATACAGATTTACCCCAATAGA", 
+                                                 "ACTTAATATACAGATTTACC",
+                                                 1.0, 0.0, -0.333, -0.333)
+
+    assert(sw.cigarX.toString === "20M")
+    assert(sw.cigarY.toString === "20M")
+    assert(sw.xStart === 8)
+  }
+
+  test("run end to end smith waterman for shorter sequence in longer sequence, with indel") {
+    // ATTAGACTACTTAATATACAGATTTACCCCAATAGA
+    //         ACTTAATAT__AGATTTACC
+    val sw = new SmithWatermanConstantGapScoring("ATTAGACTACTTAATATACAGATTTACCCCAATAGA", 
+                                                 "ACTTAATATAGATTTACC",
+                                                 1.0, 0.0, -0.333, -0.333)
+
+    assert(sw.cigarX.toString === "9M2I9M")
+    assert(sw.cigarY.toString === "9M2D9M")
+    assert(sw.xStart === 8)
+  }
+
+}

--- a/adam-core/src/test/scala/edu/berkeley/cs/amplab/adam/models/ConsensusSuite.scala
+++ b/adam-core/src/test/scala/edu/berkeley/cs/amplab/adam/models/ConsensusSuite.scala
@@ -22,7 +22,7 @@ import net.sf.samtools.{Cigar, TextCigarCodec}
 class ConsensusSuite extends FunSuite {
 
   test ("test the insertion of a consensus insertion into a reference") {   
-    val c = Consensus("TCGA", 10L to 10L)
+    val c = Consensus("TCGA", ReferenceRegion(0, 10L, 11L))
     
     val ref = "AAAAAAAAAA"
     
@@ -32,7 +32,7 @@ class ConsensusSuite extends FunSuite {
   }
 
   test ("test the insertion of a consensus deletion into a reference") {   
-    val c = Consensus("", 10L to 15L)
+    val c = Consensus("", ReferenceRegion(0, 10L, 16L))
     
     val ref = "AAAAATTTTT"
     
@@ -43,7 +43,7 @@ class ConsensusSuite extends FunSuite {
 
   test ("inserting empty consensus returns the reference") {
     val ref = "AAAAAAAAAAAAA"
-    val c = new Consensus ("", 0L to 0L)
+    val c = new Consensus ("", ReferenceRegion(0, 0L, 1L))
 
     val co = c.insertIntoReference(ref, 0, ref.length)
 

--- a/adam-core/src/test/scala/edu/berkeley/cs/amplab/adam/models/IndelTableSuite.scala
+++ b/adam-core/src/test/scala/edu/berkeley/cs/amplab/adam/models/IndelTableSuite.scala
@@ -1,0 +1,81 @@
+/*
+ * Copyright (c) 2014. Regents of the University of California
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package edu.berkeley.cs.amplab.adam.models
+
+import edu.berkeley.cs.amplab.adam.avro.{ADAMContig, ADAMVariant}
+import edu.berkeley.cs.amplab.adam.util.SparkFunSuite
+
+class IndelTableSuite extends SparkFunSuite {
+
+  // indel table containing a 1 bp deletion at chr1, pos 1000
+  val indelTable = new IndelTable(Map(1 -> Seq(Consensus("", ReferenceRegion(1, 1000L, 1002L)))))
+
+  test ("check for indels in a region with known indels") {
+    assert(indelTable.getIndelsInRegion(ReferenceRegion(1, 0L, 2000L)).length === 1)
+  }
+
+  test ("check for indels in a contig that doesn't exist") {
+    assert(indelTable.getIndelsInRegion(ReferenceRegion(0, 0L, 0L)).length === 0)
+  }
+
+  test ("check for indels in a region without known indels") {
+    assert(indelTable.getIndelsInRegion(ReferenceRegion(1, 1002L, 1005L)).length === 0)
+  }
+
+  sparkTest("build indel table from rdd of variants") {
+    val ctg1 = ADAMContig.newBuilder()
+      .setContigId(1)
+      .setContigName("chr1")
+      .build()
+    val ctg2 = ADAMContig.newBuilder()
+      .setContigId(2)
+      .setContigName("chr2")
+      .build()
+    val ins = ADAMVariant.newBuilder()
+      .setContig(ctg1)
+      .setPosition(1000L)
+      .setReferenceAllele("A")
+      .setVariantAllele("ATT")
+      .build()
+    val del = ADAMVariant.newBuilder()
+      .setContig(ctg2)
+      .setPosition(50L)
+      .setReferenceAllele("ACAT")
+      .setVariantAllele("A")
+      .build()
+
+    val rdd = sc.parallelize(Seq(ins, del))
+
+    val table = IndelTable(rdd)
+
+    // check insert
+    val insT = table.getIndelsInRegion(ReferenceRegion(1, 1000L, 1010L))
+    assert(insT.length === 1)
+    assert(insT.head.consensus === "TT")
+    assert(insT.head.index.refId === 1)
+    assert(insT.head.index.start === 1001)
+    assert(insT.head.index.end === 1002)
+
+    // check delete
+    val delT = table.getIndelsInRegion(ReferenceRegion(2, 40L, 60L))
+    assert(delT.length === 1)
+    assert(delT.head.consensus === "")
+    assert(delT.head.index.refId === 2)
+    assert(delT.head.index.start === 51)
+    assert(delT.head.index.end === 54)
+  }
+
+}

--- a/adam-core/src/test/scala/edu/berkeley/cs/amplab/adam/util/MdTagSuite.scala
+++ b/adam-core/src/test/scala/edu/berkeley/cs/amplab/adam/util/MdTagSuite.scala
@@ -24,6 +24,8 @@ import edu.berkeley.cs.amplab.adam.rich.RichADAMRecord._
 
 class MdTagSuite extends FunSuite {
 
+  val CIGAR_CODEC: TextCigarCodec = TextCigarCodec.getSingleton
+
   test("null md tag") {
     MdTag(null, 0L)
   }
@@ -224,8 +226,6 @@ class MdTagSuite extends FunSuite {
       .setMismatchingPositions("27G0G0^GGGGGGGGAA8G0G0G0G0G0G0G0G0G0G13")
       .build()
 
-    val CIGAR_CODEC: TextCigarCodec = TextCigarCodec.getSingleton
-      
     val newCigar = CIGAR_CODEC.decode("27M10D33M")
 
     val newTag = MdTag.moveAlignment(read, newCigar)
@@ -242,8 +242,6 @@ class MdTagSuite extends FunSuite {
       .setMismatchingPositions("27G0G0^GGGGGGGGAA8G0G0G0G0G0G0G0G0G0G13")
       .build()
 
-    val CIGAR_CODEC: TextCigarCodec = TextCigarCodec.getSingleton
-      
     val newCigar = CIGAR_CODEC.decode("60M")
 
     val newTag = MdTag.moveAlignment(read, newCigar, "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA", 100L)
@@ -262,8 +260,6 @@ class MdTagSuite extends FunSuite {
       .setMismatchingPositions("27G0G0^GGGGGGGGAA8G0G0G0G0G0G0G0G0G0G13")
       .build()
 
-    val CIGAR_CODEC: TextCigarCodec = TextCigarCodec.getSingleton
-      
     val newCigar = CIGAR_CODEC.decode("60M")
 
     val newTag = MdTag.moveAlignment(read, newCigar, "GGAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA", 100L)
@@ -282,8 +278,6 @@ class MdTagSuite extends FunSuite {
       .setMismatchingPositions("27G0G0^GGGGGGGGAA8G0G0G0G0G0G0G0G0G0G13")
       .build()
 
-    val CIGAR_CODEC: TextCigarCodec = TextCigarCodec.getSingleton
-      
     val newCigar = CIGAR_CODEC.decode("10M10D50M")
 
     val newTag = MdTag.moveAlignment(read, newCigar, "AAAAAAAAAAGGGGGGGGGGAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA", 100L)
@@ -301,8 +295,6 @@ class MdTagSuite extends FunSuite {
       .setStart(7)
       .setMismatchingPositions("27G0G0^GGGGGGGGAA8G0G0G0G0G0G0G0G0G0G13")
       .build()
-
-    val CIGAR_CODEC: TextCigarCodec = TextCigarCodec.getSingleton
       
     val newCigar = CIGAR_CODEC.decode("10I50M")
 
@@ -311,6 +303,56 @@ class MdTagSuite extends FunSuite {
     assert(newTag.toString === "50")
     assert(newTag.start() === 100L)
     assert(newTag.end() === 149L)
+  }
+
+  test("create new md tag from read vs. reference, perfect match") {
+    val read = "ACCATAGA"
+    val reference = "ACCATAGA"
+    val cigar = CIGAR_CODEC.decode("8M")
+    val start = 0L
+
+    val tag = MdTag(read, reference, cigar, start)
+
+    assert(tag.toString === "8")
+  }
+
+  test("create new md tag from read vs. reference, perfect alignment match, 1 mismatch") {
+    val read = "ACCATAGA"
+    val reference = "ACAATAGA"
+    val cigar = CIGAR_CODEC.decode("8M")
+    val start = 0L
+
+    val tag = MdTag(read, reference, cigar, start)
+
+    assert(tag.toString === "2A5")
+    assert(tag.start === 0L)
+    assert(tag.end === 7L)
+  }
+
+  test("create new md tag from read vs. reference, alignment with deletion") {
+    val read = "ACCATAGA"
+    val reference = "ACCATTTAGA"
+    val cigar = CIGAR_CODEC.decode("5M2D3M")
+    val start = 5L
+
+    val tag = MdTag(read, reference, cigar, start)
+
+    assert(tag.toString === "5^TT3")
+    assert(tag.start === 5L)
+    assert(tag.end === 14L)
+  }
+
+  test("create new md tag from read vs. reference, alignment with insert") {
+    val read = "ACCCATAGA"
+    val reference = "ACCATAGA"
+    val cigar = CIGAR_CODEC.decode("3M1I5M")
+    val start = 10L
+
+    val tag = MdTag(read, reference, cigar, start)
+
+    assert(tag.toString === "8")
+    assert(tag.start === 10L)
+    assert(tag.end === 17L)
   }
 
 }


### PR DESCRIPTION
This commit modifies the following:
- Fleshes out and tests our constant gap penalty Smith-Waterman implementation
- Refactors indel realignment to separate consensus generation from the realignment process
- Adds Smith-Waterman and Knowns-only consensus generation modes

This PR is against the indel realigner topic branch. After this merges, I plan to squash that branch down, and do some sort of rebase/merge against our refactored master. There are several things outstanding:
- More end-to-end verification
- Unit tests for the Smith-Waterman consensus generation mode that are separate from the Smith-Waterman implementation
