### PR TITLE
Change Some to Option to check for unmapped reads

### DIFF
--- a/adam-core/src/main/scala/org/bdgenomics/adam/models/ReferencePosition.scala
+++ b/adam-core/src/main/scala/org/bdgenomics/adam/models/ReferencePosition.scala
@@ -20,7 +20,6 @@ import org.bdgenomics.adam.avro.{ ADAMRecord, ADAMGenotype, ADAMVariant, ADAMPil
 import org.bdgenomics.adam.rdd.ADAMContext._
 import com.esotericsoftware.kryo.{ Kryo, Serializer }
 import com.esotericsoftware.kryo.io.{ Input, Output }
-import Ordering.Option
 
 object ReferencePositionWithOrientation {
 
@@ -80,9 +79,9 @@ object ReferencePosition {
    * @return True if read is mapped and has a valid position, else false.
    */
   def mappedPositionCheck(record: ADAMRecord): Boolean = {
-    val contig = Some(record.getContig)
-    val start = Some(record.getStart)
-    record.getReadMapped && (contig.isDefined && Some(contig.get.getContigName).isDefined) && start.isDefined
+    val contig = Option(record.getContig)
+    val start = Option(record.getStart)
+    record.getReadMapped && (contig.isDefined && Option(contig.get.getContigName).isDefined) && start.isDefined
   }
 
   /**

--- a/adam-core/src/test/scala/org/bdgenomics/adam/models/ReferencePositionSuite.scala
+++ b/adam-core/src/test/scala/org/bdgenomics/adam/models/ReferencePositionSuite.scala
@@ -51,6 +51,49 @@ class ReferencePositionSuite extends FunSuite {
     assert(refPosOpt.isEmpty)
   }
 
+  test("create reference position from mapped read but contig not specified") {
+    val read = ADAMRecord.newBuilder()
+      .setReadMapped(true)
+      .setStart(1L)
+      .build()
+
+    val refPosOpt = ReferencePosition(read)
+
+    assert(refPosOpt.isEmpty)
+  }
+
+  test("create reference position from mapped read but contig is underspecified") {
+    val contig = ADAMContig.newBuilder
+      // contigName is NOT set
+      //.setContigName("chr1")
+      .build
+
+    val read = ADAMRecord.newBuilder()
+      .setReadMapped(true)
+      .setStart(1L)
+      .setContig(contig)
+      .build()
+
+    val refPosOpt = ReferencePosition(read)
+
+    assert(refPosOpt.isEmpty)
+  }
+
+  test("create reference position from mapped read but start not specified") {
+    val contig = ADAMContig.newBuilder
+      .setContigName("chr1")
+      .build
+
+    val read = ADAMRecord.newBuilder()
+      .setReadMapped(true)
+      .setContig(contig)
+      .build()
+
+    val refPosOpt = ReferencePosition(read)
+
+    assert(refPosOpt.isEmpty)
+  }
+
   test("create reference position from pileup") {
     val contig = ADAMContig.newBuilder
       .setContigName("chr2")


### PR DESCRIPTION
The current implementation of mappedPositionCheck throws a NullPointerException if the contig, start, position or contigname are defined.  Instead it will now return None as the reference position
