### PR TITLE
Fix ReferenceRegion from ADAMRecord

### DIFF
--- a/adam-core/src/main/scala/org/bdgenomics/adam/models/ReferenceRegion.scala
+++ b/adam-core/src/main/scala/org/bdgenomics/adam/models/ReferenceRegion.scala
@@ -34,7 +34,7 @@ object ReferenceRegion {
    */
   def apply(record: ADAMRecord): Option[ReferenceRegion] = {
     if (record.getReadMapped) {
-      Some(ReferenceRegion(record.getContig.getContigName, record.getStart, RichADAMRecord(record).end.get + 1))
+      Some(ReferenceRegion(record.getContig.getContigName, record.getStart, RichADAMRecord(record).end.get))
     } else {
       None
     }

--- a/adam-core/src/main/scala/org/bdgenomics/adam/rich/RichADAMRecord.scala
+++ b/adam-core/src/main/scala/org/bdgenomics/adam/rich/RichADAMRecord.scala
@@ -74,7 +74,7 @@ class RichADAMRecord(val record: ADAMRecord) {
       el.getOperator == CigarOperator.HARD_CLIP
   }
 
-  // Returns the end position if the read is mapped, None otherwise
+  // Returns the exclusive end position if the read is mapped, None otherwise
   lazy val end: Option[Long] = {
     if (record.getReadMapped) {
       Some(samtoolsCigar.getCigarElements

--- a/adam-core/src/test/scala/org/bdgenomics/adam/models/ReferenceRegionSuite.scala
+++ b/adam-core/src/test/scala/org/bdgenomics/adam/models/ReferenceRegionSuite.scala
@@ -142,6 +142,8 @@ class ReferenceRegionSuite extends FunSuite {
     assert(ReferenceRegion(read).isDefined)
     assert(ReferenceRegion(read).get.contains(point("chr1", 1L)))
     assert(ReferenceRegion(read).get.contains(point("chr1", 5L)))
+
+    assert(ReferenceRegion(read).get.contains(point("chr1", 6L)) == false)
   }
 
   test("validate that adjacent regions can be merged") {


### PR DESCRIPTION
ReferenceRegion from ADAMRecord currently treats the end as inclusive and therefore creates a region that is one base too long.
