### PR TITLE
Helper scripts to run an ADAM Console.

### DIFF
--- a/scripts/adam-console.sh
+++ b/scripts/adam-console.sh
@@ -1,0 +1,8 @@
+#!/bin/bash
+
+DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+PROJECT_ROOT="$DIR/.."
+VERSION=$(grep "<version>" "$PROJECT_ROOT/pom.xml"  | head -2 | tail -1 | sed 's/ *<version>//g' | sed 's/<\/version>//g')
+ADAM_JAR=$PROJECT_ROOT/adam-cli/target/adam-$VERSION.jar
+
+SPARK_CLASSPATH=$ADAM_JAR spark-shell -i:$DIR/scala-console.scala

--- a/scripts/scala-console.scala
+++ b/scripts/scala-console.scala
@@ -1,0 +1,15 @@
+import org.bdgenomics.adam.avro.ADAMRecord
+import org.bdgenomics.adam.avro.ADAMNucleotideContigFragment
+import org.bdgenomics.adam.avro.ADAMPileup
+import org.bdgenomics.adam.avro.ADAMNestedPileup
+import org.bdgenomics.adam.avro.ADAMContig
+import org.bdgenomics.adam.avro.ADAMVariant
+import org.bdgenomics.adam.avro.VariantCallingAnnotations
+import org.bdgenomics.adam.avro.ADAMGenotype
+import org.bdgenomics.adam.avro.VariantEffect
+import org.bdgenomics.adam.avro.ADAMDatabaseVariantAnnotation
+import org.apache.spark.rdd.RDD
+import org.bdgenomics.adam.rdd.ADAMContext
+import org.bdgenomics.adam.rdd.ADAMContext._
+println("\nYou can call ADAMContext methods on sc")
+println("Load a file using: sc.adamLoad(\"<Path to file>\");")


### PR DESCRIPTION
The idea is to set up the SPARK_CLASSPATH to point to the latest ADAM
and run spark-shell with a helper file that imports common ADAM classes.
