### PR TITLE
Build up reference information during cigar processing

### DIFF
--- a/adam-core/src/main/scala/org/bdgenomics/adam/models/ReferenceRegion.scala
+++ b/adam-core/src/main/scala/org/bdgenomics/adam/models/ReferenceRegion.scala
@@ -17,10 +17,9 @@ package org.bdgenomics.adam.models
 
 import com.esotericsoftware.kryo.{ Kryo, Serializer }
 import com.esotericsoftware.kryo.io.{ Input, Output }
-import org.bdgenomics.adam.avro.{ ADAMRecord, ADAMNucleotideContigFragment, Base }
+import org.bdgenomics.adam.avro.{ ADAMRecord, ADAMNucleotideContigFragment }
 import org.bdgenomics.adam.rdd.ADAMContext._
 import org.bdgenomics.adam.rich.RichADAMRecord
-import org.bdgenomics.adam.rich.RichADAMRecord._
 import scala.math.{ min, max }
 
 object ReferenceRegion {

--- a/adam-core/src/main/scala/org/bdgenomics/adam/models/SnpTable.scala
+++ b/adam-core/src/main/scala/org/bdgenomics/adam/models/SnpTable.scala
@@ -1,12 +1,9 @@
 package org.bdgenomics.adam.models
 
-import org.bdgenomics.adam.avro.{ ADAMContig, ADAMVariant, ADAMRecord }
-import org.bdgenomics.adam.rdd.ADAMContext._
-import org.bdgenomics.adam.rich.{ RichADAMVariant, DecadentRead, ReferenceLocation }
+import org.bdgenomics.adam.rich.RichADAMVariant
 import org.bdgenomics.adam.rich.DecadentRead._
 import org.apache.spark.Logging
 import org.apache.spark.rdd.RDD
-import org.apache.spark.SparkContext._
 import scala.collection.immutable._
 import scala.collection.mutable
 import java.io.File
@@ -18,15 +15,15 @@ class SnpTable(private val table: Map[String, Set[Long]]) extends Serializable w
    * Is there a known SNP at the reference location of this Residue?
    */
   def isMasked(residue: Residue): Boolean =
-    contains(residue.referenceLocation)
+    contains(residue.referencePosition)
 
   /**
    * Is there a known SNP at the given reference location?
    */
-  def contains(location: ReferenceLocation): Boolean = {
-    val bucket = table.get(location.contig)
-    if (bucket.isEmpty) unknownContigWarning(location.contig)
-    bucket.map(_.contains(location.offset)).getOrElse(false)
+  def contains(location: ReferencePosition): Boolean = {
+    val bucket = table.get(location.referenceName)
+    if (bucket.isEmpty) unknownContigWarning(location.referenceName)
+    bucket.map(_.contains(location.pos)).getOrElse(false)
   }
 
   private val unknownContigs = new mutable.HashSet[String]

--- a/adam-core/src/main/scala/org/bdgenomics/adam/rich/ReferenceSequenceContext.scala
+++ b/adam-core/src/main/scala/org/bdgenomics/adam/rich/ReferenceSequenceContext.scala
@@ -1,0 +1,26 @@
+/*
+ * Copyright (c) 2014. Mount Sinai School of Medicine
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.bdgenomics.adam.rich
+
+import org.bdgenomics.adam.models.ReferencePosition
+import net.sf.samtools.CigarElement
+
+/**
+ * Represents information on the reference relative to a particular residue
+ */
+
+private[rich] case class ReferenceSequenceContext(pos: Option[ReferencePosition], referenceBase: Option[Char], cigarElement: CigarElement, cigarElementOffset: Int)

--- a/adam-core/src/main/scala/org/bdgenomics/adam/util/MdTag.scala
+++ b/adam-core/src/main/scala/org/bdgenomics/adam/util/MdTag.scala
@@ -20,6 +20,8 @@ import scala.collection.immutable.NumericRange
 import scala.util.matching.Regex
 import net.sf.samtools.{ Cigar, CigarOperator, CigarElement }
 import org.bdgenomics.adam.avro.ADAMRecord
+import org.bdgenomics.adam.models.ReferencePosition
+
 //import org.bdgenomics.adam.util.ImplicitJavaConversions._
 import org.bdgenomics.adam.rdd.ADAMContext._
 import org.bdgenomics.adam.rich.RichADAMRecord
@@ -246,6 +248,10 @@ class MdTag(
    */
   def isMatch(pos: Long): Boolean = {
     matches.exists(_.contains(pos))
+  }
+
+  def isMatch(pos: ReferencePosition): Boolean = {
+    matches.exists(_.contains(pos.pos))
   }
 
   /**

--- a/adam-core/src/test/scala/org/bdgenomics/adam/rich/DecadentReadSuite.scala
+++ b/adam-core/src/test/scala/org/bdgenomics/adam/rich/DecadentReadSuite.scala
@@ -1,0 +1,69 @@
+/*
+* Copyright (c) 2014. Mount Sinai School of Medicine
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+package org.bdgenomics.adam.rich
+
+import org.scalatest.FunSuite
+import org.bdgenomics.adam.avro.{ ADAMContig, ADAMRecord }
+import org.bdgenomics.adam.models.ReferencePosition
+
+class DecadentReadSuite extends FunSuite {
+
+  test("reference position of decadent read") {
+    val contig = ADAMContig.newBuilder
+      .setContigName("chr1")
+      .build
+
+    val hardClippedRead = RichADAMRecord(ADAMRecord
+      .newBuilder()
+      .setReadMapped(true)
+      .setStart(1000)
+      .setContig(contig)
+      .setMismatchingPositions("10")
+      .setSequence("AACCTTGGC")
+      .setQual("FFFFFFFFF")
+      .setCigar("9M1H").build())
+
+    val record = DecadentRead(hardClippedRead)
+    assert(record.residues.size === 9)
+
+    val residueSeq = record.residues
+    assert(residueSeq.head.referencePosition === ReferencePosition("chr1", 1000))
+  }
+
+  test("reference position of decadent read with insertions") {
+    val contig = ADAMContig.newBuilder
+      .setContigName("chr1")
+      .build
+
+    val hardClippedRead = RichADAMRecord(ADAMRecord
+      .newBuilder()
+      .setReadMapped(true)
+      .setStart(1000)
+      .setContig(contig)
+      .setMismatchingPositions("1TT10")
+      .setSequence("ATTGGGGGGGGGG")
+      .setQual("FFFFFFFFFFFFF")
+      .setCigar("1M2I10M").build())
+
+    val record = DecadentRead(hardClippedRead)
+    assert(record.residues.size === 13)
+
+    val residueSeq = record.residues
+    assert(residueSeq.head.referencePosition === ReferencePosition("chr1", 1000))
+  }
+
+}


### PR DESCRIPTION
This PR is to track more reference information during the cigar processing.

Currently, RichADAMRecord parses the Cigar string to extract the reference position (as a Long).
This:
- Also captures the reference base, cigar element, and cigar offset (which will allow for us to not reparse the cigar string when building pileups)
- Change reference position to be an instance of ReferencePosition (and changes the overlaps function to check other ReferencePosition ensuring a contigName check (resolving #113))

Also, this removes ReferenceLocation in favor of ReferencePosition as they had duplicate functionality

Noted issues:
- This has overlaps with #230 slightly 
- This still uses the current Cigar processing from samtools, there was some talk of removing this dependency
- DecadentRead vs RichAdamRecord do we want to merge or distinguish these more?
