### PR TITLE
Upgrade to Parquet 1.4.3

### DIFF
--- a/adam-core/src/test/scala/org/bdgenomics/adam/projections/FieldEnumerationSuite.scala
+++ b/adam-core/src/test/scala/org/bdgenomics/adam/projections/FieldEnumerationSuite.scala
@@ -79,7 +79,7 @@ class FieldEnumerationSuite extends SparkFunSuite with BeforeAndAfter {
 
     val first1 = reads1.first()
     assert(first1.getReadName === "simread:1:26472783:false")
-    assert(first1.getReadMapped === null)
+    assert(first1.getReadMapped === false)
 
     val p2 = Projection(ADAMRecordField.readName, ADAMRecordField.readMapped)
 

--- a/pom.xml
+++ b/pom.xml
@@ -22,7 +22,7 @@
         <scala.artifact.suffix>2.10</scala.artifact.suffix>
         <avro.version>1.7.4</avro.version>
         <spark.version>0.9.1</spark.version>
-        <parquet.version>1.3.2</parquet.version>
+        <parquet.version>1.4.3</parquet.version>
         <!-- Edit the following line to configure the Hadoop (HDFS) version. -->
         <hadoop.version>2.2.0</hadoop.version>
     </properties>


### PR DESCRIPTION
Note that Parqeut 1.4.3 handles default values differently
than in the past. If a record field is _not_ part of the specified
projection, it will be set to the default value (if it exists)
instead of null.
