### PR TITLE
Making sample ID field in genotype nullable.

### DIFF
--- a/adam-format/src/main/resources/avro/adam.avdl
+++ b/adam-format/src/main/resources/avro/adam.avdl
@@ -197,7 +197,7 @@ record ADAMGenotype {
   union { null, VariantCallingAnnotations } variantCallingAnnotations = null;
 
   // Sample-level data, i.e. data specific to this particular sample
-  string sampleId;
+  union { null, string }  sampleId = null;
   union { null, string }  sampleDescription = null;
   union { null, string }  processingDescription = null;
 


### PR DESCRIPTION
I missed one field in #245... this change makes sample ID (which had no default value after #238/#243) nullable in ADAMGenotype.
