### PR TITLE
Cosmetic changes to FastaConverter and FastaConverterSuite.

### DIFF
--- a/adam-core/src/main/scala/org/bdgenomics/adam/converters/FastaConverter.scala
+++ b/adam-core/src/main/scala/org/bdgenomics/adam/converters/FastaConverter.scala
@@ -89,19 +89,19 @@ private[adam] object FastaConverter {
 
     val converter = new FastaConverter(maxFragmentLength)
 
-    val convertedData = groupedContigs.flatMap(kv => {
-      val (id, lines) = kv
-      val descriptionLine = indexToContigDescription.value.getOrElse(id, FastaDescriptionLine())
+    groupedContigs.flatMap {
+      case (id, lines) =>
 
-      assert(lines.length != 0, "Sequence " + descriptionLine.seqId + " has no sequence data.")
-      val sequence: Seq[String] = lines.sortBy(kv => kv._1).map(kv => cleanSequence(kv._2))
-      converter.convert(descriptionLine.contigName,
-        descriptionLine.seqId,
-        sequence,
-        descriptionLine.contigDescription)
-    })
+        val descriptionLine = indexToContigDescription.value.getOrElse(id, FastaDescriptionLine())
+        assert(lines.length != 0, "Sequence " + descriptionLine.seqId + " has no sequence data.")
 
-    convertedData
+        val sequence: Seq[String] = lines.sortBy(_._1).map(kv => cleanSequence(kv._2))
+        converter.convert(descriptionLine.contigName,
+          descriptionLine.seqId,
+          sequence,
+          descriptionLine.contigDescription)
+    }
+
   }
 
   private def cleanSequence(sequence: String): String = {
@@ -115,7 +115,7 @@ private[adam] object FastaConverter {
   def getDescriptionLines(rdd: RDD[(Long, String)]): Map[Long, FastaDescriptionLine] = {
 
     rdd.filter(kv => isDescriptionLine(kv._2))
-      .collect
+      .collect()
       .zipWithIndex
       .map(kv => (kv._1._1, FastaDescriptionLine(kv._1._1, kv._2, Some(kv._1._2))))
       .toMap
@@ -160,7 +160,7 @@ private[converters] class FastaConverter(fragmentLength: Long) extends Serializa
     }
 
     // run addFragment on all fragments
-    sequences.foreach(addFragment(_))
+    sequences.foreach(addFragment)
 
     // if we still have a remaining sequence that is not part of a fragment, add it
     if (sequence.length != 0) {

--- a/adam-core/src/test/scala/org/bdgenomics/adam/converters/FastaConverterSuite.scala
+++ b/adam-core/src/test/scala/org/bdgenomics/adam/converters/FastaConverterSuite.scala
@@ -17,6 +17,7 @@ package org.bdgenomics.adam.converters
 
 import org.bdgenomics.adam.rdd.ADAMContext._
 import org.bdgenomics.adam.util.SparkFunSuite
+import java.io.File
 
 class FastaConverterSuite extends SparkFunSuite {
 
@@ -212,6 +213,8 @@ class FastaConverterSuite extends SparkFunSuite {
     assert(referenceSequences.slice(0, referenceSequences.length - 2).forall(_.getFragmentSequence.length == 10))
 
     val reassembledSequence = referenceSequences.sortBy(_.getFragmentNumber).map(_.getFragmentSequence).mkString
-  }
+    val originalSequence = scala.io.Source.fromFile(new File(chr1File)).getLines().filter(!_.startsWith(">")).mkString
 
+    assert(reassembledSequence === originalSequence)
+  }
 }


### PR DESCRIPTION
Just making a few little cosmetic changes to FastaConverter, to make part of the code more readable.

Also, added a second condition to one of the tests in FastaConverterSuite, to check that the reassembled
sequence (which had been created, but wasn't being used) matched what was in the original file.

These changes are minor enough that I don't believe they need a separate entry in the CHANGES file.
