### PR TITLE
Modifying conversion code to resolve #112.

### DIFF
--- a/adam-core/src/main/scala/org/bdgenomics/adam/converters/ADAMRecordConverter.scala
+++ b/adam-core/src/main/scala/org/bdgenomics/adam/converters/ADAMRecordConverter.scala
@@ -102,6 +102,8 @@ class ADAMRecordConverter extends Serializable {
             .foreach(v => builder.setReadNegativeStrandFlag(v.booleanValue))
           Option(adamRecord.getPrimaryAlignment)
             .foreach(v => builder.setNotPrimaryAlignmentFlag(!v.booleanValue))
+          Option(adamRecord.getSupplementaryAlignment)
+            .foreach(v => builder.setSupplementaryAlignmentFlag(v.booleanValue))
           Option(adamRecord.getStart)
             .foreach(s => builder.setAlignmentStart(s.toInt + 1))
           Option(adamRecord.getMapq).foreach(v => builder.setMappingQuality(v))

--- a/adam-core/src/main/scala/org/bdgenomics/adam/rich/DecadentRead.scala
+++ b/adam-core/src/main/scala/org/bdgenomics/adam/rich/DecadentRead.scala
@@ -56,15 +56,13 @@ object DecadentRead {
 
 class DecadentRead(val record: RichADAMRecord) extends Logging {
   // Can't be a primary alignment unless it has been aligned
-  //
-  // FIXME(#112): This is currently unenforceable; SAMRecordConverter sets PrimaryAlignment on unmapped reads
-  //require(!record.getPrimaryAlignment || record.getReadMapped, "Unaligned read can't be a primary alignment")
+  require(!record.getPrimaryAlignment || record.getReadMapped, "Unaligned read can't be a primary alignment")
 
   // Should have quality scores for all residues
   require(record.getSequence.length == record.qualityScores.length, "sequence and qualityScores must be same length")
 
   // MapQ should be valid
-  require(record.getMapq == null || (record.getMapq >= 0 && record.getMapq <= 255), "MapQ must be in [0, 255]")
+  require(record.getMapq == null || (record.getMapq >= 0 && record.getMapq <= 93), "MapQ must be in [0, 255]")
 
   // Alignment must be valid
   require(!record.getReadMapped || record.getStart >= 0, "Invalid alignment start index")

--- a/adam-format/src/main/resources/avro/adam.avdl
+++ b/adam-format/src/main/resources/avro/adam.avdl
@@ -41,13 +41,24 @@ record ADAMRecord {
     union { boolean, null } properPair = false;
     union { boolean, null } readMapped = false;
     union { boolean, null } mateMapped = false;
-    union { boolean, null } readNegativeStrand = false;
-    union { boolean, null } mateNegativeStrand = false;
     union { boolean, null } firstOfPair = false;
     union { boolean, null } secondOfPair = false;
-    union { boolean, null } primaryAlignment = false;
     union { boolean, null } failedVendorQualityChecks = false;
     union { boolean, null } duplicateRead = false;
+
+    // alignment flags (all default to null, as readMapped defaults to false)
+    union { boolean, null } readNegativeStrand = false; // aligned to reverse compliment
+    union { boolean, null } mateNegativeStrand = false; // mate aligned to reverse compliment
+    // primary vs. secondary vs. supplementary:
+    // - primary is either the best linear alignment or the "first" linear alignment 
+    //   in a chimeric alignment
+    // - supplementary is a non-primary linear alignment in a chimeric alignment
+    // - secondary is an alignment that is not the best alignment (an alignment that is
+    //   worse than the primary alignment) and that is not a supplimental linear alignment in a 
+    //   chimeric alignment (thus not supplimentary)
+    union { boolean, null } primaryAlignment = false;
+    union { boolean, null } secondaryAlignment = false;
+    union { boolean, null } supplementaryAlignment = false;
 
     // Commonly used optional attributes
     union { null, string } mismatchingPositions = null;


### PR DESCRIPTION
Resolves #112. Specifically:
- Adds code to SAM->ADAM conversion to only set mapping flags if the record is mapped.
- Adds fields to the ADAMRecord to disambiguate secondary vs. supplementary alignments
- Adds accompanying code to the ADAM->SAM conversion to ensure that secondary vs. supplementary alignments are properly converted back to SAM.
- Updates DecadentRead to add the requirement statement that was removed because of #112.
