### PR TITLE
Adding reference assembly name to ADAMContig.

### DIFF
--- a/adam-format/src/main/resources/avro/adam.avdl
+++ b/adam-format/src/main/resources/avro/adam.avdl
@@ -6,6 +6,8 @@ record ADAMContig {
   union { null, long }   contigLength = null;
   union { null, string } contigMD5 = null;
   union { null, string } referenceURL = null;
+  union { null, string } assembly = null;
+  union { null, string } species = null;
 }
 
 record ADAMRecord {


### PR DESCRIPTION
Adds the reference assembly name to ADAMContig. Also, cleans up conversion to/from SAMReferenceRecord, to ensure that we are properly converting assembly/species/etc. fields back to SAM.
