### PR TITLE
Added AdamContext.referenceLengthFromCigar

### DIFF
--- a/adam-core/src/test/scala/org/bdgenomics/adam/rich/RichADAMRecordSuite.scala
+++ b/adam-core/src/test/scala/org/bdgenomics/adam/rich/RichADAMRecordSuite.scala
@@ -22,6 +22,16 @@ import org.bdgenomics.adam.models.{ ReferencePosition, TagType, Attribute }
 
 class RichADAMRecordSuite extends FunSuite {
 
+  test("referenceLengthFromCigar") {
+    assert(referenceLengthFromCigar("3M") === 3)
+    assert(referenceLengthFromCigar("30M") === 30)
+    assert(referenceLengthFromCigar("10Y") === 0) // should abort when it hits an illegal operator
+    assert(referenceLengthFromCigar("10M1Y") === 10) // same
+    assert(referenceLengthFromCigar("10M1I10M") === 20)
+    assert(referenceLengthFromCigar("10M1D10M") === 21)
+    assert(referenceLengthFromCigar("1S10M1S") === 10)
+  }
+
   test("Unclipped Start") {
     val recordWithoutClipping = ADAMRecord.newBuilder().setReadMapped(true).setCigar("10M").setStart(42).build()
     val recordWithClipping = ADAMRecord.newBuilder().setReadMapped(true).setCigar("2S8M").setStart(42).build()


### PR DESCRIPTION
Adds a new method which has some utility (for some of our code): 

ADAMContext.referenceLengthFromCigar, which calculates the 'length along the reference sequence' of an alignment record from its Cigar string. This is useful because the 'rec.start + referenceLengthFromCigar(rec.cigar)' is a natural 'end' value which can be used to calculate whether an ADAMRecord overlaps a given region _along the reference_.  

From this, we can calculate overlap queries on ADAMRecords without having to go through the (somewhat cumbersome) ReferenceMapping framework.  

Thoughts?  Does this duplicate code that's already somewhere else in ADAM?  Also, I'm not parsing the Cigar strings using Picard but rather defining my own quick-and-dirty regex for them, I don't know how people feel about that.  
