### PR TITLE
Parquet-related Utility Classes

### DIFF
--- a/adam-core/pom.xml
+++ b/adam-core/pom.xml
@@ -147,5 +147,9 @@
             <artifactId>scalatest_${scala.artifact.suffix}</artifactId>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>com.amazonaws</groupId>
+            <artifactId>aws-java-sdk</artifactId>
+        </dependency>
     </dependencies>
 </project>

--- a/adam-core/src/main/scala/org/bdgenomics/adam/util/ByteAccess.scala
+++ b/adam-core/src/main/scala/org/bdgenomics/adam/util/ByteAccess.scala
@@ -1,0 +1,100 @@
+/**
+ * Copyright 2014 Genome Bridge LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.bdgenomics.adam.util
+
+import java.io._
+import com.amazonaws.services.s3.AmazonS3
+import com.amazonaws.services.s3.model.GetObjectRequest
+import scala.Serializable
+
+/**
+ * ByteAccess is a wrapper trait around sources of bytes which are accessible at arbitrary offsets.
+ *
+ * (We can use this to wrap byte buffers, S3, FileInputStreams, or even range-accessible web services.)
+ */
+trait ByteAccess {
+  def length(): Long
+  def readByteStream(offset: Long, length: Int): InputStream
+
+  /**
+   * readFully is a helper method, for when you're going to use readByteStream and just read
+   * all the bytes immediately.
+   * @param offset The offset in the resource at which you want to start reading
+   * @param length The number of bytes to read
+   * @return An Array of bytes read. The length of this array will be <= the 'length' argument.
+   */
+  def readFully(offset: Long, length: Int): Array[Byte] = {
+    assert(length >= 0, "length %d should be non-negative".format(length))
+    assert(offset >= 0, "offset %d should be non-negative".format(offset))
+    var totalBytesRead: Int = 0
+    val buffer = new Array[Byte](length)
+    val is = readByteStream(offset, length)
+    while (totalBytesRead < length) {
+      val bytesRead = is.read(buffer, totalBytesRead, length - totalBytesRead)
+      totalBytesRead += bytesRead
+    }
+    buffer
+  }
+}
+
+class ByteArrayByteAccess(val bytes: Array[Byte]) extends ByteAccess with Serializable {
+
+  private val inputStream = new ByteArrayInputStream(bytes)
+  assert(inputStream.markSupported(), "ByteArrayInputStream doesn't support marks")
+
+  inputStream.mark(bytes.length)
+
+  override def length(): Long = bytes.length
+  override def readByteStream(offset: Long, length: Int): InputStream = {
+    inputStream.reset()
+    inputStream.skip(offset)
+    inputStream
+  }
+}
+
+/**
+ * This is somewhat poorly named, it probably should be LocalFileByteAccess
+ *
+ * @param f the file to read bytes from
+ */
+class LocalFileByteAccess(f: File) extends ByteAccess {
+
+  assert(f.isFile, "\"%s\" isn't a file".format(f.getAbsolutePath))
+  assert(f.exists(), "File \"%s\" doesn't exist".format(f.getAbsolutePath))
+  assert(f.canRead, "File \"%s\" can't be read".format(f.getAbsolutePath))
+
+  override def length(): Long = f.length()
+
+  override def readByteStream(offset: Long, length: Int): InputStream = {
+    val fileIo = new FileInputStream(f)
+    fileIo.skip(offset)
+    fileIo
+  }
+
+}
+
+class S3ByteAccess(client: AmazonS3, bucket: String, keyName: String) extends ByteAccess {
+  assert(bucket != null)
+  assert(keyName != null)
+
+  lazy val objectMetadata = client.getObjectMetadata(bucket, keyName)
+  override def length(): Long = objectMetadata.getContentLength
+  override def readByteStream(offset: Long, length: Int): InputStream = {
+    val getObjectRequest = new GetObjectRequest(bucket, keyName).withRange(offset, offset + length)
+    client.getObject(getObjectRequest).getObjectContent
+  }
+
+}

--- a/adam-core/src/main/scala/org/bdgenomics/adam/util/CredentialsProperties.scala
+++ b/adam-core/src/main/scala/org/bdgenomics/adam/util/CredentialsProperties.scala
@@ -1,0 +1,106 @@
+/**
+ * Copyright 2014 Genome Bridge LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.bdgenomics.adam.util
+
+import java.io.{ FileInputStream, File }
+import org.apache.spark.Logging
+import scala.io.Source
+import com.amazonaws.auth.AWSCredentials
+
+/**
+ * CredentialsProperties is a wrapper class which extracts Amazon S3 keys (although it could be
+ * modified to extract other key / secret-key pairs) from a key-value-formatted file (see below),
+ * if available, or from the System environment otherwise.
+ *
+ * (This is to make testing and running on a local environment easier.)
+ *
+ * The 'location' parameter names a file which should have the format of
+ *   key=value
+ * one per line.  Whitespace around both 'key' and 'value' are stripped.
+ *
+ * @param location The location of the file which will be read _if it exists and is readable_,
+ *                 otherwise the parameters will be read from the System environment.
+ */
+class CredentialsProperties(location: File) extends Serializable with Logging {
+
+  val defaultAccessKey = System.getenv("AWS_ACCESS_KEY_ID")
+  val defaultSecretKey = System.getenv("AWS_SECRET_KEY")
+  private val defaultMap = Map("accessKey" -> defaultAccessKey, "secretKey" -> defaultSecretKey)
+  val configuration = new ConfigurationFile(location, Some(defaultMap))
+
+  /**
+   * Retrieves the value associated with a given key from the configuration file.
+   *
+   * The optional 'suffix' argument is used for differentiating different key/value pairs,
+   * used for different purposes but with similar keys.  For example, we (Genome Bridge)
+   * will create configuration files with one key 'accessKey' which contains the AWS access key
+   * for accessing almost all our AWS resources -- however, we use a different access (and secret)
+   * key for accessing S3, and that's put into the same configuration file with a key name
+   * 'accessKey_s3'.  (Similarly for 'secretKey' and 'secretKey_s3').
+   *
+   * @param keyName The base key used to retrieve a value
+   * @param suffix If suffix is None, then the base key is used to retrieve the corresponding
+   *               value.  If suffix is specified, then '[base key]_[suffix]' is used instead.
+   *               If '[base key]_[suffix]' doesn't exist in the file, then the properties
+   *               falls back to retrieving the value just associated with the base key itself.
+   * @return The (string) value associated with the given key, or null if no such key exists.
+   */
+  def configuredValue(keyName: String, suffix: Option[String] = None): String = {
+    suffix match {
+      case None => configuration.properties(keyName)
+      case Some(suffixString) => {
+        val combinedKey = "%s_%s".format(keyName, suffixString)
+        if (configuration.properties.contains(combinedKey)) {
+          configuration.properties(combinedKey)
+        } else {
+          configuration.properties(keyName)
+        }
+      }
+    }
+  }
+
+  def accessKey(suffix: Option[String]): String = configuredValue("accessKey", suffix)
+  def secretKey(suffix: Option[String]): String = configuredValue("secretKey", suffix)
+
+  def awsCredentials(suffix: Option[String] = None): AWSCredentials = {
+    new SerializableAWSCredentials(accessKey(suffix), secretKey(suffix))
+  }
+}
+
+private[util] case class ConfigurationFile(properties: Map[String, String]) extends Serializable {
+  def this(f: File, defaultValues: Option[Map[String, String]] = None) = this(ConfigurationParser(f, defaultValues))
+}
+
+private[util] object ConfigurationParser extends Logging {
+
+  def apply(f: File, defaultValues: Option[Map[String, String]] = None): Map[String, String] = {
+    if (!f.exists() || !f.canRead) {
+      logWarning("File \"%s\" does not exist, using default values.".format(f.getAbsolutePath))
+      defaultValues.get
+
+    } else {
+      logInfo("Reading configuration values from \"%s\"".format(f.getAbsolutePath))
+      val is = new FileInputStream(f)
+      // we wrote our own key=value parsing, since we were having problems with whitespace
+      // using the Java util.Properties parsing.
+      val lines = Source.fromInputStream(is).getLines().map(_.trim)
+      val nonComments = lines.filter(line => !line.startsWith("#") && line.contains("="))
+      val map = nonComments.map(_.split("=")).map(array => array.map(_.trim)).map(array => (array(0), array(1))).toMap
+      is.close()
+      map
+    }
+  }
+}

--- a/adam-core/src/main/scala/org/bdgenomics/adam/util/FileLocator.scala
+++ b/adam-core/src/main/scala/org/bdgenomics/adam/util/FileLocator.scala
@@ -1,0 +1,91 @@
+/**
+ * Copyright 2014 Genome Bridge LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.bdgenomics.adam.util
+
+import com.amazonaws.auth.AWSCredentials
+import com.amazonaws.services.s3.AmazonS3Client
+import java.io.File
+
+/**
+ * FileLocator is a trait which is meant to combine aspects of
+ * - Java's File
+ * - Hadoop's Path
+ * - S3 locations (including bucket and key)
+ * - classpath-relative URLs (classpath://, used in testing)
+ *
+ * It provides methods for relative addressing (parent and child locators,
+ * which are equivalent to the File(parent, child) constructor and the getParentFile method
+ * on the Java File class), as well as accessing the bytes named by a locator
+ * by retrieving a ByteAccess value.
+ *
+ * We're using implementations of FileLocator to provide a uniform access interface
+ * to Parquet files, whether they're in HDFS, a local filesystem, S3, or embedded in the
+ * classpath as part of tests.
+ */
+trait FileLocator extends Serializable {
+
+  def parentLocator(): Option[FileLocator]
+  def relativeLocator(relativePath: String): FileLocator
+  def bytes: ByteAccess
+}
+
+object FileLocator {
+
+  val slashDivided = "^(.*)/([^/]+/?)$".r
+
+  def parseSlash(path: String): Option[(String, String)] =
+    slashDivided.findFirstMatchIn(path) match {
+      case None    => None
+      case Some(m) => Some(m.group(1), m.group(2))
+    }
+}
+
+class S3FileLocator(val credentials: AWSCredentials, val bucket: String, val key: String) extends FileLocator {
+
+  override def parentLocator(): Option[FileLocator] = FileLocator.parseSlash(key) match {
+    case Some((parent, child)) => Some(new S3FileLocator(credentials, bucket, parent))
+    case None                  => None
+  }
+
+  override def relativeLocator(relativePath: String): FileLocator =
+    new S3FileLocator(credentials, bucket, "%s/%s".format(key.stripSuffix("/"), relativePath))
+
+  override def bytes: ByteAccess = new S3ByteAccess(new AmazonS3Client(credentials), bucket, key)
+}
+
+class LocalFileLocator(val file: File) extends FileLocator {
+  override def relativeLocator(relativePath: String): FileLocator = new LocalFileLocator(new File(file, relativePath))
+  override def bytes: ByteAccess = new LocalFileByteAccess(file)
+
+  override def parentLocator(): Option[FileLocator] = file.getParentFile match {
+    case null             => None
+    case parentFile: File => Some(new LocalFileLocator(parentFile))
+  }
+
+  override def hashCode(): Int = file.hashCode()
+  override def equals(x: Any): Boolean = {
+    x match {
+      case loc: LocalFileLocator => file.equals(loc.file)
+      case _                     => false
+    }
+  }
+}
+
+class ByteArrayLocator(val byteData: Array[Byte]) extends FileLocator {
+  override def relativeLocator(relativePath: String): FileLocator = this
+  override def parentLocator(): Option[FileLocator] = None
+  override def bytes: ByteAccess = new ByteArrayByteAccess(byteData)
+}

--- a/adam-core/src/main/scala/org/bdgenomics/adam/util/SerializableAWSCredentials.scala
+++ b/adam-core/src/main/scala/org/bdgenomics/adam/util/SerializableAWSCredentials.scala
@@ -1,0 +1,24 @@
+/**
+ * Copyright 2014 Genome Bridge LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.bdgenomics.adam.util
+
+import com.amazonaws.auth.AWSCredentials
+
+class SerializableAWSCredentials(accessKey: String, secretKey: String) extends AWSCredentials with Serializable {
+  def this() = this(System.getenv("AWS_ACCESS_KEY_ID"), System.getenv("AWS_SECRET_KEY"))
+  def getAWSAccessKeyId: String = accessKey
+  def getAWSSecretKey: String = secretKey
+}

--- a/adam-core/src/test/resources/test.conf
+++ b/adam-core/src/test/resources/test.conf
@@ -1,0 +1,6 @@
+
+accessKey=accessKey
+secretKey=secretKey
+
+accessKey_s3 = accessKey_s3
+secretKey_s3=secretKey_s3

--- a/adam-core/src/test/scala/org/bdgenomics/adam/util/ByteAccessSuite.scala
+++ b/adam-core/src/test/scala/org/bdgenomics/adam/util/ByteAccessSuite.scala
@@ -1,0 +1,53 @@
+/**
+ * Copyright 2014 Genome Bridge LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.bdgenomics.adam.util
+
+import org.scalatest.FunSuite
+import java.io.{ PrintWriter, File, ByteArrayInputStream }
+import java.nio.charset.Charset
+
+class ByteAccessSuite extends FunSuite {
+
+  test("ByteArrayByteAccess returns arbitrary subsets of bytes correctly") {
+    val bytes = Array[Byte](0, 1, 2, 3, 4, 5, 6, 7, 8, 9)
+    val access = new ByteArrayByteAccess(bytes)
+
+    assert(access.length() === bytes.length)
+    assert(access.readFully(5, 5) === bytes.slice(5, 10))
+  }
+
+  test("ByteArrayByteAccess supports two successive calls with different offsets") {
+    val bytes = Array[Byte](0, 1, 2, 3, 4, 5, 6, 7, 8, 9)
+    val access = new ByteArrayByteAccess(bytes)
+
+    assert(access.length() === bytes.length)
+    assert(access.readFully(5, 5) === bytes.slice(5, 10))
+    assert(access.readFully(3, 5) === bytes.slice(3, 8))
+  }
+
+  test("LocalFileByteAccess returns arbitrary subsets of bytes correctly") {
+    val content = "abcdefghij"
+    val temp = File.createTempFile("byteaccesssuite", "test")
+
+    val writer = new PrintWriter(temp)
+    writer.print(content)
+    writer.close()
+
+    val access = new LocalFileByteAccess(temp)
+    assert(access.length() === content.length())
+    assert(access.readFully(3, 5) === content.substring(3, 8).getBytes("ASCII"))
+  }
+}

--- a/adam-core/src/test/scala/org/bdgenomics/adam/util/CredentialPropertiesSuite.scala
+++ b/adam-core/src/test/scala/org/bdgenomics/adam/util/CredentialPropertiesSuite.scala
@@ -1,0 +1,83 @@
+package org.bdgenomics.adam.util
+
+import org.scalatest.FunSuite
+import java.io.File
+
+class CredentialsPropertiesTestSuite extends FunSuite {
+
+  test("Can parse a simple configuration file with CredentialsProperties") {
+    val path = Thread.currentThread().getContextClassLoader.getResource("test.conf").getFile
+    val file = new File(path)
+    val cp = new CredentialsProperties(file)
+
+    val aws = cp.awsCredentials()
+    assert(aws.getAWSAccessKeyId === "accessKey")
+    assert(aws.getAWSSecretKey === "secretKey")
+
+    val aws_s3 = cp.awsCredentials(Some("s3"))
+    assert(aws_s3.getAWSAccessKeyId === "accessKey_s3")
+    assert(aws_s3.getAWSSecretKey === "secretKey_s3")
+
+  }
+
+}
+
+class ConfigurationFileSuite extends FunSuite {
+
+  test("Can read values out of a file") {
+    val path = Thread.currentThread().getContextClassLoader.getResource("test.conf").getFile
+    val file = new File(path)
+    val config = new ConfigurationFile(file)
+    assert(config.properties.contains("accessKey"))
+    assert(config.properties.contains("secretKey"))
+    assert(config.properties.contains("accessKey_s3"))
+    assert(config.properties.contains("secretKey_s3"))
+    assert(config.properties("accessKey") === "accessKey")
+    assert(config.properties("secretKey") === "secretKey")
+    assert(config.properties("accessKey_s3") === "accessKey_s3")
+    assert(config.properties("secretKey_s3") === "secretKey_s3")
+  }
+
+  test("Reads default values when the file does not exist.") {
+    val path = "/foo/bar.conf"
+    val file = new File(path)
+    val defaultMap = Seq("accessKey" -> "foo", "secretKey" -> "bar").toMap
+    val config = new ConfigurationFile(file, Some(defaultMap))
+    assert(config.properties.contains("accessKey"))
+    assert(config.properties.contains("secretKey"))
+    assert(config.properties("accessKey") === "foo")
+    assert(config.properties("secretKey") === "bar")
+  }
+
+  test("Does not read the default values, when the file does exist.") {
+    val path = Thread.currentThread().getContextClassLoader.getResource("test.conf").getFile
+    val file = new File(path)
+    val defaultMap = Seq("accessKey" -> "foo", "secretKey" -> "bar").toMap
+    val config = new ConfigurationFile(file, Some(defaultMap))
+    assert(config.properties.contains("accessKey"))
+    assert(config.properties.contains("secretKey"))
+    assert(config.properties("accessKey") === "accessKey")
+    assert(config.properties("secretKey") === "secretKey")
+  }
+
+}
+
+class ConfigurationParserSuite extends FunSuite {
+  test("parses a simple file") {
+    val path = Thread.currentThread().getContextClassLoader.getResource("test.conf").getFile
+    val file = new File(path)
+    val map: Map[String, String] = ConfigurationParser(file)
+
+    assert(map.size === 4)
+
+    assert(map.contains("accessKey"))
+    assert(map.contains("secretKey"))
+    assert(map("accessKey") === "accessKey")
+    assert(map("secretKey") === "secretKey")
+
+    assert(map.contains("accessKey_s3"))
+    assert(map.contains("secretKey_s3"))
+    assert(map("accessKey_s3") === "accessKey_s3")
+    assert(map("secretKey_s3") === "secretKey_s3")
+  }
+}

--- a/adam-core/src/test/scala/org/bdgenomics/adam/util/FileLocatorSuite.scala
+++ b/adam-core/src/test/scala/org/bdgenomics/adam/util/FileLocatorSuite.scala
@@ -1,0 +1,84 @@
+/**
+ * Copyright 2014 Genome Bridge LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.bdgenomics.adam.util
+
+import org.scalatest.FunSuite
+import java.io.{ PrintWriter, FileWriter, File }
+
+class FileLocatorSuite extends FunSuite {
+
+  test("parseSlash can correctly parse a one-slash string") {
+    assert(FileLocator.parseSlash("foo/bar") === Some(("foo", "bar")))
+    assert(FileLocator.parseSlash("/foo") === Some(("", "foo")))
+  }
+
+  test("parseSlash can correctly parse a two-slash string") {
+    assert(FileLocator.parseSlash("foo/bar") === Some(("foo", "bar")))
+    assert(FileLocator.parseSlash("/foo/bar") === Some(("/foo", "bar")))
+  }
+
+  test("parseSlash can correctly parse a no-slash string") {
+    assert(FileLocator.parseSlash("foo") === None)
+  }
+}
+
+class LocalFileLocatorSuite extends FunSuite {
+
+  test("parentLocator retrieves the parent directory") {
+    val temp: File = File.createTempFile("LocalFileLocatorSuite", "test")
+    val loc: FileLocator = new LocalFileLocator(temp)
+    val parentLocOpt: Option[FileLocator] = loc.parentLocator()
+
+    parentLocOpt match {
+      case Some(parentLoc) => assert(parentLoc === new LocalFileLocator(temp.getParentFile))
+      case None            => fail("parentLoc wasn't defined")
+    }
+  }
+
+  test("relativeLocator retrieves a subdirectory") {
+    val temp1: File = File.createTempFile("LocalFileLocatorSuite", "test")
+    val tempDir = temp1.getParentFile
+
+    val tempDirLoc = new LocalFileLocator(tempDir)
+    val tempLoc = tempDirLoc.relativeLocator(temp1.getName)
+
+    assert(tempLoc === new LocalFileLocator(temp1))
+  }
+
+  test("bytes accesses the named underlying file") {
+    val temp = File.createTempFile("LocalFileLocatorSuite", "test")
+    val pw = new PrintWriter(new FileWriter(temp))
+    pw.println("abcdefghij")
+    pw.close()
+
+    val loc = new LocalFileLocator(temp)
+    val io = loc.bytes
+
+    val str = new String(io.readFully(3, 3), "UTF-8")
+    assert(str === "def")
+  }
+}
+
+class ByteArrayLocatorSuite extends FunSuite {
+  test("byte access can be wrapped in a locator correctly") {
+    val bytes = Array[Byte](1, 2, 3, 4, 5)
+    val loc = new ByteArrayLocator(bytes)
+
+    val io = loc.bytes
+    val read = io.readFully(2, 3)
+    assert(read === Array[Byte](3, 4, 5))
+  }
+}

--- a/pom.xml
+++ b/pom.xml
@@ -367,6 +367,12 @@
                 <artifactId>slf4j-log4j12</artifactId>
                 <version>1.7.5</version>
             </dependency>
+            <dependency>
+                <groupId>com.amazonaws</groupId>
+                <artifactId>aws-java-sdk</artifactId>
+                <version>1.7.5</version>
+                <scope>provided</scope>
+            </dependency>
         </dependencies>
     </dependencyManagement>
 


### PR DESCRIPTION
This includes several utility classes that we wrote, as part of our work to adapt and re-use Parquet within Spark and ADAM.  

One of our goals was to re-use as little Hadoop-specific functionality as possible, since disentangling Parquet from Hadoop was important (for a number of reasons, not least of which are class conflicts when it comes to wrapping HTTP services around a Spark cluster).  

This PR includes three major components: 
- ByteAccess -- which is a trait whose implementations wrap any source of bytes to which random access is available
- some classes that help us load and manage S3 and AWS credentials, and 
- FileLocator -- a trait whose implementations are a union of Hadoop's "Path" class, Java's File class, URLs, and pointers into S3.  

Carl and I are eager to hear, though, if anyone objects to these implementations and would like to suggest an alternative class or type that already exists and does the same thing.  We're eager not to re-invent too many wheels.
