### PR TITLE
Removed extra command 'BuildInformation'

### DIFF
--- a/adam-cli/src/main/scala/org/bdgenomics/adam/cli/ADAMMain.scala
+++ b/adam-cli/src/main/scala/org/bdgenomics/adam/cli/ADAMMain.scala
@@ -39,7 +39,6 @@ object ADAMMain extends Logging {
     FindReads,
     Fasta2ADAM,
     PluginExecutor,
-    BuildInformation,
     VcfAnnotation2ADAM,
     SummarizeGenotypes,
     BuildInformation)


### PR DESCRIPTION
The command introductions included an extra "buildinfo" command, so I just deleted it.
![commands](https://cloud.githubusercontent.com/assets/4754931/3295012/33b08d30-f5b5-11e3-92b5-890d3d696283.png)
