### PR TITLE
Adding k-mer and q-mer counting.

### DIFF
--- a/adam-cli/src/main/scala/org/bdgenomics/adam/cli/ADAMMain.scala
+++ b/adam-cli/src/main/scala/org/bdgenomics/adam/cli/ADAMMain.scala
@@ -44,6 +44,7 @@ object ADAMMain extends Logging {
     VcfAnnotation2ADAM,
     Vcf2FlatGenotype,
     SummarizeGenotypes,
+    CountKmers,
     BuildInformation)
 
   private def printCommands() {

--- a/adam-cli/src/main/scala/org/bdgenomics/adam/cli/CountKmers.scala
+++ b/adam-cli/src/main/scala/org/bdgenomics/adam/cli/CountKmers.scala
@@ -1,0 +1,92 @@
+/*
+ * Copyright (c) 2014. Regents of the University of California
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.bdgenomics.adam.cli
+
+import org.apache.hadoop.mapreduce.Job
+import org.bdgenomics.adam.util.ParquetLogger
+import org.kohsuke.args4j.{ Argument, Option => Args4jOption }
+import org.bdgenomics.adam.avro.ADAMRecord
+import org.bdgenomics.adam.rdd.ADAMContext._
+import org.apache.spark.{ SparkContext, Logging }
+import org.apache.spark.rdd.RDD
+import java.util.logging.Level
+
+object CountKmers extends ADAMCommandCompanion {
+  val commandName = "count_kmers"
+  val commandDescription = "Counts the k-mers/q-mers from a read dataset."
+
+  def apply(cmdLine: Array[String]) = {
+    new CountKmers(Args4j[CountKmersArgs](cmdLine))
+  }
+}
+
+class CountKmersArgs extends Args4jBase with ParquetArgs with SparkArgs {
+  @Argument(required = true, metaVar = "INPUT", usage = "The ADAM, BAM or SAM file to count kmers from", index = 0)
+  var inputPath: String = null
+  @Argument(required = true, metaVar = "OUTPUT", usage = "Location for storing k-mer counts", index = 1)
+  var outputPath: String = null
+  @Argument(required = true, metaVar = "KMER_LENGTH", usage = "Length of k-mers", index = 2)
+  var kmerLength: Int = 0
+  @Args4jOption(required = false, name = "-countQmers", usage = "Counts q-mers instead of k-mers.")
+  var countQmers: Boolean = false
+  @Args4jOption(required = false, name = "-printHistogram", usage = "Prints a histogram of counts.")
+  var printHistogram: Boolean = false
+}
+
+class CountKmers(protected val args: CountKmersArgs) extends ADAMSparkCommand[CountKmersArgs] with Logging {
+  val companion = CountKmers
+
+  def run(sc: SparkContext, job: Job) {
+
+    // Quiet Parquet...
+    ParquetLogger.hadoopLoggerLevel(Level.SEVERE)
+
+    // read from disk
+    var adamRecords: RDD[ADAMRecord] = sc.adamLoad(args.inputPath)
+
+    if (args.repartition != -1) {
+      log.info("Repartitioning reads to '%d' partitions".format(args.repartition))
+      adamRecords = adamRecords.repartition(args.repartition)
+    }
+
+    // count kmers
+    val countedKmers = if (args.countQmers) {
+      adamRecords.adamCountQmers(args.kmerLength)
+    } else {
+      adamRecords.adamCountKmers(args.kmerLength).map(kv => (kv._1, kv._2.toDouble))
+    }
+
+    // cache counted kmers
+    countedKmers.cache()
+
+    // print histogram, if requested
+    if (args.printHistogram) {
+      countedKmers.map(kv => kv._2.toLong)
+        .countByValue()
+        .toSeq
+        .sortBy(kv => kv._1)
+        .foreach(println)
+    }
+
+    // save as text file
+    if (args.countQmers) {
+      countedKmers.map(kv => kv._1 + ", " + kv._2)
+    } else {
+      countedKmers.map(kv => kv._1 + ", " + kv._2.toLong)
+    }.saveAsTextFile(args.outputPath)
+  }
+
+}

--- a/adam-core/src/main/scala/org/bdgenomics/adam/rdd/correction/ErrorCorrection.scala
+++ b/adam-core/src/main/scala/org/bdgenomics/adam/rdd/correction/ErrorCorrection.scala
@@ -1,0 +1,82 @@
+/*
+ * Copyright (c) 2014 The Regents of the University of California
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.bdgenomics.adam.rdd.correction
+
+import org.apache.spark.Logging
+import org.apache.spark.SparkContext._
+import org.apache.spark.rdd.RDD
+import org.bdgenomics.adam.avro.ADAMRecord
+import org.bdgenomics.adam.rdd.ADAMContext._
+import org.bdgenomics.adam.util.PhredUtils
+
+private[rdd] object ErrorCorrection extends Logging {
+
+  val ec = new ErrorCorrection
+
+  /**
+   * Cuts reads into _q_-mers, and then finds the _q_-mer weight. Q-mers are described in:
+   *
+   * Kelley, David R., Michael C. Schatz, and Steven L. Salzberg. "Quake: quality-aware detection
+   * and correction of sequencing errors." Genome Biol 11.11 (2010): R116.
+   *
+   * _Q_-mers are _k_-mers weighted by the quality score of the bases in the _k_-mer.
+   *
+   * @param rdd RDD to count q-mers on.
+   * @param qmerLength The value of _q_ to use for cutting _q_-mers.
+   * @return Returns an RDD containing q-mer/weight pairs.
+   */
+  def countQmers(rdd: RDD[ADAMRecord],
+                 qmerLength: Int): RDD[(String, Double)] = {
+    // generate qmer counts
+    rdd.flatMap(ec.readToQmers(_, qmerLength))
+      .reduceByKey(_ + _)
+  }
+}
+
+private[correction] class ErrorCorrection extends Serializable with Logging {
+
+  /**
+   * Cuts a single read into q-mers.
+   *
+   * @param read Read to cut.
+   * @param qmerLength The length of the qmer to cut.
+   * @return Returns an iterator containing q-mer/weight mappings.
+   */
+  def readToQmers(read: ADAMRecord,
+                  qmerLength: Int = 20): Iterator[(String, Double)] = {
+    // get read bases and quality scores
+    val bases = read.getSequence.toSeq
+    val scores = read.getQual.toString.toCharArray.map(q => {
+      PhredUtils.phredToSuccessProbability(q - 33)
+    })
+
+    // zip and put into sliding windows to get qmers
+    bases.zip(scores)
+      .sliding(qmerLength)
+      .map(w => {
+        // bases are first in tuple
+        val b = w.map(_._1)
+
+        // quals are second
+        val q = w.map(_._2)
+
+        // reduce bases into string, reduce quality scores
+        (b.map(_.toString).reduce(_ + _), q.reduce(_ * _))
+      })
+  }
+
+}

--- a/adam-core/src/test/scala/org/bdgenomics/adam/rdd/correction/ErrorCorrectionSuite.scala
+++ b/adam-core/src/test/scala/org/bdgenomics/adam/rdd/correction/ErrorCorrectionSuite.scala
@@ -1,0 +1,47 @@
+/*
+ * Copyright (c) 2014 The Regents of the University of California
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.bdgenomics.adam.rdd.correction
+
+import org.bdgenomics.adam.avro.ADAMRecord
+import org.scalatest.FunSuite
+import scala.math.abs
+
+class ErrorCorectionSuite extends FunSuite {
+
+  val ec = new ErrorCorrection
+
+  def fpCompare(a: Double, b: Double, epsilon: Double = 1e-3): Boolean = abs(a - b) < epsilon
+
+  test("cut a short read into qmers") {
+    val read = ADAMRecord.newBuilder
+      .setSequence("ACTCATG")
+      .setQual("??;957:")
+      .build()
+
+    val qmers = ec.readToQmers(read, 3).toMap
+
+    // check that the qmer count is correct
+    assert(qmers.size === 5)
+
+    // find our qmers and check their values
+    assert(fpCompare(qmers("ACT"), 0.995))
+    assert(fpCompare(qmers("CTC"), 0.992))
+    assert(fpCompare(qmers("TCA"), 0.983))
+    assert(fpCompare(qmers("CAT"), 0.979))
+    assert(fpCompare(qmers("ATG"), 0.980))
+  }
+}


### PR DESCRIPTION
This adds functions for _k_-mer and _q_-mer counting, which is necessary for error correction. Additionally, this adds commands that support counting _k_/_q_-mers from the CLI.

_q_-mers are quality score weighted _k_-mers, and are described in http://genomebiology.com/2010/11/11/R116/abstract.
