### PR TITLE
Consolidate Parquet logging configuration

### DIFF
--- a/adam-cli/src/main/scala/org/bdgenomics/adam/cli/ADAMMain.scala
+++ b/adam-cli/src/main/scala/org/bdgenomics/adam/cli/ADAMMain.scala
@@ -17,6 +17,8 @@ package org.bdgenomics.adam.cli
 
 import org.apache.spark.Logging
 import scala.Some
+import org.bdgenomics.adam.util.ParquetLogger
+import java.util.logging.Level._
 
 object ADAMMain extends Logging {
 
@@ -64,8 +66,10 @@ object ADAMMain extends Logging {
       printCommands()
     } else {
       commands.find(_.commandName == args(0)) match {
-        case None      => printCommands()
-        case Some(cmd) => cmd.apply(args drop 1).run()
+        case None => printCommands()
+        case Some(cmd) =>
+          init(Args4j[InitArgs](args drop 1, ignoreCmdLineExceptions = true))
+          cmd.apply(args drop 1).run()
       }
     }
   }
@@ -75,5 +79,12 @@ object ADAMMain extends Logging {
   private def argsToString(args: Array[String]): String = {
     def escapeArg(s: String) = "\"" + s.replaceAll("\\\"", "\\\\\"") + "\""
     args.map(escapeArg).mkString(" ")
+  }
+
+  class InitArgs extends Args4jBase with ParquetArgs {}
+
+  private def init(args: InitArgs) {
+    // Set parquet logging (default: severe)
+    ParquetLogger.hadoopLoggerLevel(parse(args.logLevel))
   }
 }

--- a/adam-cli/src/main/scala/org/bdgenomics/adam/cli/Bam2ADAM.scala
+++ b/adam-cli/src/main/scala/org/bdgenomics/adam/cli/Bam2ADAM.scala
@@ -15,7 +15,6 @@
  */
 package org.bdgenomics.adam.cli
 
-import org.bdgenomics.adam.util.ParquetLogger
 import org.kohsuke.args4j.{ Option => Args4jOption, Argument }
 import net.sf.samtools._
 import org.bdgenomics.adam.avro.ADAMRecord
@@ -25,7 +24,6 @@ import parquet.avro.AvroParquetWriter
 import org.apache.hadoop.fs.Path
 import java.util.concurrent._
 import scala.Some
-import java.util.logging.Level
 import org.bdgenomics.adam.models.{ RecordGroupDictionary, SequenceDictionary }
 import org.bdgenomics.adam.converters.SAMRecordConverter
 
@@ -59,9 +57,6 @@ class Bam2ADAM(args: Bam2ADAMArgs) extends ADAMCommand {
     (list, threadNum) =>
       {
         val writerThread = new Thread(new Runnable {
-
-          // Quiet parquet...
-          ParquetLogger.hadoopLoggerLevel(Level.SEVERE)
 
           val parquetWriter = new AvroParquetWriter[ADAMRecord](
             new Path(args.outputPath + "/part%d".format(threadNum)),

--- a/adam-cli/src/main/scala/org/bdgenomics/adam/cli/CalculateDepth.scala
+++ b/adam-cli/src/main/scala/org/bdgenomics/adam/cli/CalculateDepth.scala
@@ -15,7 +15,6 @@
  */
 package org.bdgenomics.adam.cli
 
-import java.util.logging.Level
 import scala.io._
 
 import org.kohsuke.args4j.{ Argument, Option => Args4jOption }
@@ -32,7 +31,6 @@ import org.bdgenomics.adam.projections.ADAMRecordField._
 import org.bdgenomics.adam.rdd.ADAMContext._
 import org.bdgenomics.adam.rdd.RegionJoin
 import org.bdgenomics.adam.rich.ReferenceMappingContext._
-import org.bdgenomics.adam.util.ParquetLogger
 
 /**
  * CalculateDepth (accessible as the command 'depth' through the CLI) takes two arguments,
@@ -66,8 +64,6 @@ class CalculateDepth(protected val args: CalculateDepthArgs) extends ADAMSparkCo
   val companion: ADAMCommandCompanion = CalculateDepth
 
   def run(sc: SparkContext, job: Job): Unit = {
-    // Quiet parquet logging...
-    ParquetLogger.hadoopLoggerLevel(Level.SEVERE)
 
     val proj = Projection(contig, start, cigar, readMapped)
 

--- a/adam-cli/src/main/scala/org/bdgenomics/adam/cli/CompareADAM.scala
+++ b/adam-cli/src/main/scala/org/bdgenomics/adam/cli/CompareADAM.scala
@@ -27,7 +27,6 @@ import org.apache.spark.rdd.RDD
 import org.kohsuke.args4j.{ Option => Args4jOption, Argument }
 
 import scala.collection.Seq
-import java.util.logging.Level
 import java.io.{ PrintWriter, OutputStreamWriter }
 import org.bdgenomics.adam.rdd.comparisons.ComparisonTraversalEngine
 import org.bdgenomics.adam.metrics.{ DefaultComparisons, CombinedComparisons, Collection, BucketComparisons }
@@ -173,8 +172,6 @@ class CompareADAM(protected val args: CompareADAMArgs) extends ADAMSparkCommand[
   }
 
   def run(sc: SparkContext, job: Job): Unit = {
-
-    ParquetLogger.hadoopLoggerLevel(Level.SEVERE)
 
     if (args.listComparisons) {
       println("\nAvailable comparisons:")

--- a/adam-cli/src/main/scala/org/bdgenomics/adam/cli/FindReads.scala
+++ b/adam-cli/src/main/scala/org/bdgenomics/adam/cli/FindReads.scala
@@ -15,11 +15,9 @@
  */
 package org.bdgenomics.adam.cli
 
-import org.bdgenomics.adam.util.ParquetLogger
 import org.kohsuke.args4j.{ Option => Args4jOption, Argument }
 import org.apache.spark.SparkContext
 import org.apache.hadoop.mapreduce.Job
-import java.util.logging.Level
 import scala.collection.Seq
 import java.util.regex.Pattern
 import org.apache.hadoop.fs.{ Path, FileSystem }
@@ -114,7 +112,6 @@ class FindReads(protected val args: FindReadsArgs) extends ADAMSparkCommand[Find
   val companion: ADAMCommandCompanion = FindReads
 
   def run(sc: SparkContext, job: Job): Unit = {
-    ParquetLogger.hadoopLoggerLevel(Level.SEVERE)
 
     val filter = FindReads.parseFilters(args.filter)
     val generator = filter.comparison

--- a/adam-cli/src/main/scala/org/bdgenomics/adam/cli/FlagStat.scala
+++ b/adam-cli/src/main/scala/org/bdgenomics/adam/cli/FlagStat.scala
@@ -16,13 +16,11 @@
 
 package org.bdgenomics.adam.cli
 
-import org.bdgenomics.adam.util.ParquetLogger
 import org.bdgenomics.adam.rdd.ADAMContext._
 import org.kohsuke.args4j.Argument
 import org.apache.hadoop.mapreduce.Job
 import org.bdgenomics.adam.avro.ADAMRecord
 import org.bdgenomics.adam.projections.{ Projection, ADAMRecordField }
-import java.util.logging.Level
 import org.apache.spark.SparkContext
 import org.apache.spark.rdd.RDD
 
@@ -44,8 +42,6 @@ class FlagStat(protected val args: FlagStatArgs) extends ADAMSparkCommand[FlagSt
   val companion: ADAMCommandCompanion = FlagStat
 
   def run(sc: SparkContext, job: Job): Unit = {
-    // Quiet parquet logging...
-    ParquetLogger.hadoopLoggerLevel(Level.SEVERE)
 
     val projection = Projection(
       ADAMRecordField.readMapped, ADAMRecordField.mateMapped, ADAMRecordField.readPaired,

--- a/adam-cli/src/main/scala/org/bdgenomics/adam/cli/ListDict.scala
+++ b/adam-cli/src/main/scala/org/bdgenomics/adam/cli/ListDict.scala
@@ -15,12 +15,10 @@
  */
 package org.bdgenomics.adam.cli
 
-import org.bdgenomics.adam.util.ParquetLogger
 import org.bdgenomics.adam.rdd.ADAMContext._
 import org.kohsuke.args4j.Argument
 import org.apache.spark.SparkContext
 import org.apache.hadoop.mapreduce.Job
-import java.util.logging.Level
 import org.bdgenomics.adam.avro.ADAMRecord
 import org.bdgenomics.adam.models.SequenceRecord
 
@@ -42,9 +40,6 @@ class ListDict(protected val args: ListDictArgs) extends ADAMSparkCommand[ListDi
   val companion: ADAMCommandCompanion = ListDict
 
   def run(sc: SparkContext, job: Job): Unit = {
-    // Quiet parquet logging...
-    ParquetLogger.hadoopLoggerLevel(Level.SEVERE)
-
     val dict = sc.adamDictionaryLoad[ADAMRecord](args.inputPath)
 
     dict.records.foreach {

--- a/adam-cli/src/main/scala/org/bdgenomics/adam/cli/ParquetArgs.scala
+++ b/adam-cli/src/main/scala/org/bdgenomics/adam/cli/ParquetArgs.scala
@@ -28,5 +28,7 @@ trait ParquetArgs extends Args4jBase {
   var compressionCodec = CompressionCodecName.GZIP
   @Option(name = "-parquet_disable_dictionary", usage = "Disable dictionary encoding")
   var disableDictionary = false
+  @Option(required = false, name = "-parquet_logging_level", usage = "Parquet logging level (default = severe)")
+  var logLevel = "SEVERE"
 }
 

--- a/adam-cli/src/main/scala/org/bdgenomics/adam/cli/PrintTags.scala
+++ b/adam-cli/src/main/scala/org/bdgenomics/adam/cli/PrintTags.scala
@@ -15,12 +15,10 @@
  */
 package org.bdgenomics.adam.cli
 
-import org.bdgenomics.adam.util.ParquetLogger
 import org.bdgenomics.adam.rdd.ADAMContext._
 import org.kohsuke.args4j.{ Option, Argument }
 import org.apache.spark.SparkContext
 import org.apache.hadoop.mapreduce.Job
-import java.util.logging.Level
 import org.bdgenomics.adam.avro.ADAMRecord
 import org.bdgenomics.adam.projections.{ Projection, ADAMRecordField }
 import org.apache.spark.rdd.RDD
@@ -58,10 +56,6 @@ class PrintTags(protected val args: PrintTagsArgs) extends ADAMSparkCommand[Prin
   val companion: ADAMCommandCompanion = PrintTags
 
   def run(sc: SparkContext, job: Job): Unit = {
-
-    // Quiet parquet logging...
-    ParquetLogger.hadoopLoggerLevel(Level.SEVERE)
-
     val toCount = if (args.count != null) args.count.split(",").toSet else Set()
 
     val proj = Projection(attributes, primaryAlignment, readMapped, readPaired, failedVendorQualityChecks)

--- a/adam-cli/src/main/scala/org/bdgenomics/adam/cli/Transform.scala
+++ b/adam-cli/src/main/scala/org/bdgenomics/adam/cli/Transform.scala
@@ -16,7 +16,6 @@
 package org.bdgenomics.adam.cli
 
 import org.apache.hadoop.mapreduce.Job
-import org.bdgenomics.adam.util.ParquetLogger
 import org.kohsuke.args4j.{ Argument, Option => Args4jOption }
 import org.bdgenomics.adam.avro.ADAMRecord
 import org.bdgenomics.adam.rdd.ADAMContext._
@@ -24,7 +23,6 @@ import org.bdgenomics.adam.rdd.variation.ADAMVariationContext._
 import org.bdgenomics.adam.models.SnpTable
 import org.apache.spark.{ SparkContext, Logging }
 import org.apache.spark.rdd.RDD
-import java.util.logging.Level
 import org.bdgenomics.adam.rich.RichADAMVariant
 
 object Transform extends ADAMCommandCompanion {
@@ -71,9 +69,6 @@ class Transform(protected val args: TransformArgs) extends ADAMSparkCommand[Tran
   val companion = Transform
 
   def run(sc: SparkContext, job: Job) {
-
-    // Quiet Parquet...
-    ParquetLogger.hadoopLoggerLevel(Level.SEVERE)
 
     var adamRecords: RDD[ADAMRecord] = sc.adamLoad(args.inputPath)
 


### PR DESCRIPTION
This should fix [Issue #77](https://github.com/bigdatagenomics/adam/issues/77). Adds an option for the user to specify the level of logging they want (default: severe) and sets Parquet logging level in ADAMMain before the command is run.
