### PR TITLE
Fixes issue in reference models where strings are not sanitized on collection from avro.

### DIFF
--- a/adam-core/src/main/scala/org/bdgenomics/adam/models/ReferencePosition.scala
+++ b/adam-core/src/main/scala/org/bdgenomics/adam/models/ReferencePosition.scala
@@ -96,7 +96,7 @@ object ReferencePosition {
    */
   def apply(record: ADAMRecord): Option[ReferencePosition] = {
     if (mappedPositionCheck(record)) {
-      Some(new ReferencePosition(record.getContig.getContigName, record.getStart))
+      Some(new ReferencePosition(record.getContig.getContigName.toString, record.getStart))
     } else {
       None
     }

--- a/adam-core/src/main/scala/org/bdgenomics/adam/models/ReferenceRegion.scala
+++ b/adam-core/src/main/scala/org/bdgenomics/adam/models/ReferenceRegion.scala
@@ -33,7 +33,7 @@ object ReferenceRegion {
    */
   def apply(record: ADAMRecord): Option[ReferenceRegion] = {
     if (record.getReadMapped) {
-      Some(ReferenceRegion(record.getContig.getContigName, record.getStart, RichADAMRecord(record).end.get))
+      Some(ReferenceRegion(record.getContig.getContigName.toString, record.getStart, RichADAMRecord(record).end.get))
     } else {
       None
     }

--- a/adam-core/src/test/scala/org/bdgenomics/adam/models/ReferenceRegionSuite.scala
+++ b/adam-core/src/test/scala/org/bdgenomics/adam/models/ReferenceRegionSuite.scala
@@ -182,6 +182,31 @@ class ReferenceRegionSuite extends FunSuite {
     assert(hull1.end == 10L)
   }
 
+  test("region name is sanitized when creating region from read") {
+    val contig = ADAMContig.newBuilder()
+      .setContigName("chrM")
+      .build()
+
+    val read = ADAMRecord.newBuilder()
+      .setStart(5L)
+      .setSequence("ACGT")
+      .setContig(contig)
+      .setReadMapped(true)
+      .setCigar("5M")
+      .setMismatchingPositions("5")
+      .build()
+
+    val region = ReferenceRegion(read)
+
+    assert(region.isDefined)
+
+    val r = region.get
+
+    assert(r.referenceName === "chrM")
+    assert(r.start === 5L)
+    assert(r.end === 10L)
+  }
+
   def region(refName: String, start: Long, end: Long): ReferenceRegion =
     ReferenceRegion(refName, start, end)
 


### PR DESCRIPTION
The reference models (ReferenceRegion/ReferencePosition) do not convert strings from Avro (e.g., .toString), which causes string comparison errors because of avro localization.

This is a blocker on https://github.com/bigdatagenomics/avocado/issues/79.
