### PR TITLE
Added clarifying note to `ADAMVariantContext`

### DIFF
--- a/adam-core/src/main/scala/org/bdgenomics/adam/models/ADAMVariantContext.scala
+++ b/adam-core/src/main/scala/org/bdgenomics/adam/models/ADAMVariantContext.scala
@@ -21,6 +21,11 @@ import org.bdgenomics.adam.avro.{ ADAMGenotype, ADAMDatabaseVariantAnnotation, A
 import org.bdgenomics.adam.rich.RichADAMVariant
 import org.bdgenomics.adam.rich.RichADAMVariant._
 
+/**
+ * Note: ADAMVariantContext inherits its name from the Picard VariantContext, and is not related to the SparkContext object.
+ * If you're looking for the latter, see [[org.bdgenomics.adam.rdd.variation.ADAMVariationContext]]
+ */
+
 object ADAMVariantContext {
 
   /**


### PR DESCRIPTION
Not to be confused with `ADAMVariationContext`.

This is probably not the right place to put this note.  Where should it go?
