### PR TITLE
Implemented HTTPRangedByteAccess.

### DIFF
--- a/adam-core/pom.xml
+++ b/adam-core/pom.xml
@@ -151,5 +151,47 @@
             <groupId>com.amazonaws</groupId>
             <artifactId>aws-java-sdk</artifactId>
         </dependency>
+        <dependency>
+            <groupId>org.apache.httpcomponents</groupId>
+            <artifactId>httpclient</artifactId>
+        </dependency>
     </dependencies>
+    <profiles>
+        <profile>
+            <id>default</id>
+            <activation>
+                <activeByDefault>true</activeByDefault>
+            </activation>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>org.scalatest</groupId>
+                        <artifactId>scalatest-maven-plugin</artifactId>
+                        <configuration>
+                            <tagsToExclude>org.bdgenomics.adam.util.NetworkConnected</tagsToExclude>
+                        </configuration>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+        <profile>
+            <id>network-connected</id>
+            <activation>
+                <property>
+                    <name>networkconnected</name>
+                </property>
+            </activation>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>org.scalatest</groupId>
+                        <artifactId>scalatest-maven-plugin</artifactId>
+                        <configuration>
+                            <tagsToInclude>org.bdgenomics.adam.util.NetworkConnected</tagsToInclude>
+                        </configuration>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+    </profiles>
 </project>

--- a/adam-core/src/main/scala/org/bdgenomics/adam/io/ByteArrayByteAccess.scala
+++ b/adam-core/src/main/scala/org/bdgenomics/adam/io/ByteArrayByteAccess.scala
@@ -1,0 +1,35 @@
+/**
+ * Licensed to Big Data Genomics (BDG) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The BDG licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.bdgenomics.adam.io
+
+import java.io.{ ByteArrayInputStream, InputStream }
+
+class ByteArrayByteAccess(val bytes: Array[Byte]) extends ByteAccess with Serializable {
+
+  private val inputStream = new ByteArrayInputStream(bytes)
+  assert(inputStream.markSupported(), "ByteArrayInputStream doesn't support marks")
+
+  inputStream.mark(bytes.length)
+
+  override def length(): Long = bytes.length
+  override def readByteStream(offset: Long, length: Int): InputStream = {
+    inputStream.reset()
+    inputStream.skip(offset)
+    inputStream
+  }
+}

--- a/adam-core/src/main/scala/org/bdgenomics/adam/io/ByteArrayLocator.scala
+++ b/adam-core/src/main/scala/org/bdgenomics/adam/io/ByteArrayLocator.scala
@@ -1,0 +1,24 @@
+/**
+ * Licensed to Big Data Genomics (BDG) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The BDG licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.bdgenomics.adam.io
+
+class ByteArrayLocator(val byteData: Array[Byte]) extends FileLocator {
+  override def relativeLocator(relativePath: String): FileLocator = this
+  override def parentLocator(): Option[FileLocator] = None
+  override def bytes: ByteAccess = new ByteArrayByteAccess(byteData)
+}

--- a/adam-core/src/main/scala/org/bdgenomics/adam/io/FileLocator.scala
+++ b/adam-core/src/main/scala/org/bdgenomics/adam/io/FileLocator.scala
@@ -15,11 +15,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.bdgenomics.adam.util
-
-import com.amazonaws.auth.AWSCredentials
-import com.amazonaws.services.s3.AmazonS3Client
-import java.io.File
+package org.bdgenomics.adam.io
 
 /**
  * FileLocator is a trait which is meant to combine aspects of
@@ -53,41 +49,4 @@ object FileLocator {
       case None    => None
       case Some(m) => Some(m.group(1), m.group(2))
     }
-}
-
-class S3FileLocator(val credentials: AWSCredentials, val bucket: String, val key: String) extends FileLocator {
-
-  override def parentLocator(): Option[FileLocator] = FileLocator.parseSlash(key) match {
-    case Some((parent, child)) => Some(new S3FileLocator(credentials, bucket, parent))
-    case None                  => None
-  }
-
-  override def relativeLocator(relativePath: String): FileLocator =
-    new S3FileLocator(credentials, bucket, "%s/%s".format(key.stripSuffix("/"), relativePath))
-
-  override def bytes: ByteAccess = new S3ByteAccess(new AmazonS3Client(credentials), bucket, key)
-}
-
-class LocalFileLocator(val file: File) extends FileLocator {
-  override def relativeLocator(relativePath: String): FileLocator = new LocalFileLocator(new File(file, relativePath))
-  override def bytes: ByteAccess = new LocalFileByteAccess(file)
-
-  override def parentLocator(): Option[FileLocator] = file.getParentFile match {
-    case null             => None
-    case parentFile: File => Some(new LocalFileLocator(parentFile))
-  }
-
-  override def hashCode(): Int = file.hashCode()
-  override def equals(x: Any): Boolean = {
-    x match {
-      case loc: LocalFileLocator => file.equals(loc.file)
-      case _                     => false
-    }
-  }
-}
-
-class ByteArrayLocator(val byteData: Array[Byte]) extends FileLocator {
-  override def relativeLocator(relativePath: String): FileLocator = this
-  override def parentLocator(): Option[FileLocator] = None
-  override def bytes: ByteAccess = new ByteArrayByteAccess(byteData)
 }

--- a/adam-core/src/main/scala/org/bdgenomics/adam/io/HTTPRangedByteAccess.scala
+++ b/adam-core/src/main/scala/org/bdgenomics/adam/io/HTTPRangedByteAccess.scala
@@ -1,0 +1,141 @@
+/**
+ * Licensed to Big Data Genomics (BDG) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The BDG licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.bdgenomics.adam.io
+
+import java.io.InputStream
+import java.net.URI
+import org.apache.http.client.HttpClient
+import org.apache.http.client.methods.{ HttpGet, HttpHead }
+import org.apache.http.impl.client.DefaultHttpClient
+import org.apache.spark.Logging
+
+/**
+ * HTTPRangedByteAccess supports Ranged GET queries against HTTP resources.
+ *
+ * @param uri The URL of the resource, which should support ranged queries
+ */
+class HTTPRangedByteAccess(uri: URI) extends ByteAccess with Logging {
+
+  private def readLength(): Long = {
+    val httpClient: HttpClient = new DefaultHttpClient()
+    val head = new HttpHead(uri)
+    val response = httpClient.execute(head)
+    val headers = response.getAllHeaders
+
+    // The spec (http://www.w3.org/Protocols/rfc2616/rfc2616-sec14.html#sec14.5) says that
+    // Accept-Ranges can return values of 'bytes', 'none', or any other acceptable range-unit;
+    // however, "bytes" is the only range-unit recognized in HTTP/1.1 and that clients may choose
+    // to ignore other range-unit values.
+    // Therefore, we ignore non-standard range values, issuing only a warning when we see them.
+    // The spec says that _no_ Accept-Ranges header is possible and the resource may still
+    // respect range queries -- but if the Accept-Ranges header _is_ present, and the value is
+    // "none", then no range requests are allowed.  In this case, that means we throw an
+    // exception.
+    headers.find(_.getName == "Accept-Ranges") match {
+      case Some(header) => header.getValue match {
+        case "none" => throw new IllegalStateException(
+          "Server for \"%s\" doesn't accept range requests (\"Accept-Ranges: none\" header in HEAD request response)"
+            .format(uri.toString))
+        case "bytes" =>
+        case value: String => logWarning(
+          "Server returned a header of \"Accept-Ranges: %s\", but the only values that we can handle are \"none\" and \"bytes\"".format(value))
+      }
+      case None =>
+    }
+
+    // This is the Content-Length of the entire resource (as opposed to the Content-Length value
+    // on the range request, below -- that's just the length of the portion of the resource that
+    // was returned).
+    headers.find(_.getName == "Content-Length") match {
+      case None => throw new IllegalStateException("Unknown length of content for \"%s\" (No \"Content-Length\" header)"
+        .format(uri.toString))
+      case Some(header) => header.getValue.toLong
+    }
+  }
+
+  private lazy val _length = readLength()
+
+  /*
+   Regex to read the Content-Range response header, as described in:
+   http://www.w3.org/Protocols/rfc2616/rfc2616-sec14.html#sec14.16
+    */
+  private val byteRangeResponseRegex = "bytes\\s((?:\\*|\\d+-\\d+))/((?:\\*|\\d+))".r
+
+  override def length(): Long = _length
+
+  /**
+   * In this initial implementation, we throw an error when we get a partial response from the
+   * server whose content is less than the bytes we originally requested.
+   *
+   * @param offset The offset into the resource at which we want to start reading bytesd
+   * @param length The number of bytes to be read
+   * @return An InputStream from a ranged HTTP GET, which should contain just the requested bytes
+   */
+  override def readByteStream(offset: Long, length: Int): InputStream = {
+    val httpClient: HttpClient = new DefaultHttpClient()
+    val get = new HttpGet(uri)
+
+    // I believe the 'end' coordinate on the range request is _inclusive_
+    get.setHeader("Range", "bytes=%d-%d".format(offset, offset + length - 1))
+
+    val response = httpClient.execute(get)
+
+    // We want a 206 response to a ranged request, not your normal 200!
+    require(response.getStatusLine.getStatusCode == 206,
+      "Range request on \"%s\", expected status code 206 but received %d (%s)"
+        .format(uri.toString, response.getStatusLine.getStatusCode, response.getStatusLine.getReasonPhrase))
+
+    // This big nested set of case statements is to make sure that
+    // 1. we have a Content-Range in the header,
+    // 2. that the value of the Content-Range header matches the regex (see above), and
+    // 3. that the regex, if it contains a range field "start-end", that the
+    //    a) 'start' value matches the 'offset' argument, and
+    //    b) 'end' - 'start' + 1 matches the 'length' argument.
+
+    // First, we check condition (1)
+    response.getAllHeaders.find(_.getName == "Content-Range") match {
+      case None => throw new IllegalStateException("Ranged GET didn't return a Content-Range header")
+
+      // Now, we check condition (2)
+      case Some(header) => byteRangeResponseRegex.findFirstMatchIn(header.getValue) match {
+        case None => throw new IllegalStateException("Content-Range header value \"%s\" didn't match the expected format".format(header.getValue))
+
+        // Finally, we check condition (3)
+        case Some(m) => m.group(1) match {
+          case "*" =>
+          case str: String => str.split("-").toSeq match {
+            case Seq(start, end) =>
+              // Here is the check on (3a)
+              if (start.toLong != offset)
+                throw new IllegalArgumentException(
+                  "Content-Range response start %d (from header \"%s\") doesn't match offset %d"
+                    .format(start.toLong, header.getValue, offset))
+              // here is the check on (3b)
+              if (end.toLong - start.toLong + 1 != length)
+                throw new IllegalArgumentException(
+                  "Content-Range response length %d (from header \"%s\") doesn't match length %d"
+                    .format(end.toLong - start.toLong + 1, header.getValue, length))
+          }
+
+        }
+      }
+    }
+
+    response.getEntity.getContent
+  }
+}

--- a/adam-core/src/main/scala/org/bdgenomics/adam/io/LocalFileByteAccess.scala
+++ b/adam-core/src/main/scala/org/bdgenomics/adam/io/LocalFileByteAccess.scala
@@ -1,0 +1,41 @@
+/**
+ * Licensed to Big Data Genomics (BDG) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The BDG licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.bdgenomics.adam.io
+
+import java.io.{ File, FileInputStream, InputStream }
+
+/**
+ * This is somewhat poorly named, it probably should be LocalFileByteAccess
+ *
+ * @param f the file to read bytes from
+ */
+class LocalFileByteAccess(f: File) extends ByteAccess {
+
+  assert(f.isFile, "\"%s\" isn't a file".format(f.getAbsolutePath))
+  assert(f.exists(), "File \"%s\" doesn't exist".format(f.getAbsolutePath))
+  assert(f.canRead, "File \"%s\" can't be read".format(f.getAbsolutePath))
+
+  override def length(): Long = f.length()
+
+  override def readByteStream(offset: Long, length: Int): InputStream = {
+    val fileIo = new FileInputStream(f)
+    fileIo.skip(offset)
+    fileIo
+  }
+
+}

--- a/adam-core/src/main/scala/org/bdgenomics/adam/io/LocalFileLocator.scala
+++ b/adam-core/src/main/scala/org/bdgenomics/adam/io/LocalFileLocator.scala
@@ -1,0 +1,38 @@
+/**
+ * Licensed to Big Data Genomics (BDG) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The BDG licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.bdgenomics.adam.io
+
+import java.io.File
+
+class LocalFileLocator(val file: File) extends FileLocator {
+  override def relativeLocator(relativePath: String): FileLocator = new LocalFileLocator(new File(file, relativePath))
+  override def bytes: ByteAccess = new LocalFileByteAccess(file)
+
+  override def parentLocator(): Option[FileLocator] = file.getParentFile match {
+    case null             => None
+    case parentFile: File => Some(new LocalFileLocator(parentFile))
+  }
+
+  override def hashCode(): Int = file.hashCode()
+  override def equals(x: Any): Boolean = {
+    x match {
+      case loc: LocalFileLocator => file.equals(loc.file)
+      case _                     => false
+    }
+  }
+}

--- a/adam-core/src/main/scala/org/bdgenomics/adam/io/S3ByteAccess.scala
+++ b/adam-core/src/main/scala/org/bdgenomics/adam/io/S3ByteAccess.scala
@@ -1,0 +1,35 @@
+/**
+ * Licensed to Big Data Genomics (BDG) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The BDG licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.bdgenomics.adam.io
+
+import com.amazonaws.services.s3.AmazonS3
+import com.amazonaws.services.s3.model.GetObjectRequest
+import java.io.InputStream
+
+class S3ByteAccess(client: AmazonS3, bucket: String, keyName: String) extends ByteAccess {
+  assert(bucket != null)
+  assert(keyName != null)
+
+  lazy val objectMetadata = client.getObjectMetadata(bucket, keyName)
+  override def length(): Long = objectMetadata.getContentLength
+  override def readByteStream(offset: Long, length: Int): InputStream = {
+    val getObjectRequest = new GetObjectRequest(bucket, keyName).withRange(offset, offset + length)
+    client.getObject(getObjectRequest).getObjectContent
+  }
+
+}

--- a/adam-core/src/main/scala/org/bdgenomics/adam/io/S3FileLocator.scala
+++ b/adam-core/src/main/scala/org/bdgenomics/adam/io/S3FileLocator.scala
@@ -1,0 +1,34 @@
+/**
+ * Licensed to Big Data Genomics (BDG) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The BDG licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.bdgenomics.adam.io
+
+import com.amazonaws.auth.AWSCredentials
+import com.amazonaws.services.s3.AmazonS3Client
+
+class S3FileLocator(val credentials: AWSCredentials, val bucket: String, val key: String) extends FileLocator {
+
+  override def parentLocator(): Option[FileLocator] = FileLocator.parseSlash(key) match {
+    case Some((parent, child)) => Some(new S3FileLocator(credentials, bucket, parent))
+    case None                  => None
+  }
+
+  override def relativeLocator(relativePath: String): FileLocator =
+    new S3FileLocator(credentials, bucket, "%s/%s".format(key.stripSuffix("/"), relativePath))
+
+  override def bytes: ByteAccess = new S3ByteAccess(new AmazonS3Client(credentials), bucket, key)
+}

--- a/adam-core/src/test/scala/org/bdgenomics/adam/io/FileLocatorSuite.scala
+++ b/adam-core/src/test/scala/org/bdgenomics/adam/io/FileLocatorSuite.scala
@@ -15,10 +15,11 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.bdgenomics.adam.util
+package org.bdgenomics.adam.io
+
+import java.io.{ File, FileWriter, PrintWriter }
 
 import org.scalatest.FunSuite
-import java.io.{ PrintWriter, FileWriter, File }
 
 class FileLocatorSuite extends FunSuite {
 

--- a/adam-core/src/test/scala/org/bdgenomics/adam/util/SparkFunSuite.scala
+++ b/adam-core/src/test/scala/org/bdgenomics/adam/util/SparkFunSuite.scala
@@ -23,8 +23,6 @@ import java.net.ServerSocket
 import org.apache.log4j.Level
 import org.bdgenomics.adam.rdd.ADAMContext
 
-object SparkTest extends org.scalatest.Tag("org.bdgenomics.adam.util.SparkFunSuite")
-
 trait SparkFunSuite extends FunSuite with BeforeAndAfter {
 
   var sc: SparkContext = _

--- a/adam-core/src/test/scala/org/bdgenomics/adam/util/TestTags.scala
+++ b/adam-core/src/test/scala/org/bdgenomics/adam/util/TestTags.scala
@@ -1,0 +1,24 @@
+/**
+ * Licensed to Big Data Genomics (BDG) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The BDG licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.bdgenomics.adam.util
+
+import org.scalatest.Tag
+
+object SparkTest extends Tag("org.bdgenomics.adam.util.SparkFunSuite")
+
+object NetworkConnected extends Tag("org.bdgenomics.adam.util.NetworkConnected")

--- a/pom.xml
+++ b/pom.xml
@@ -400,6 +400,11 @@
                 <version>1.7.5</version>
                 <scope>provided</scope>
             </dependency>
+            <dependency>
+                <groupId>org.apache.httpcomponents</groupId>
+                <artifactId>httpclient</artifactId>
+                <version>4.2.6</version>
+            </dependency>
         </dependencies>
     </dependencyManagement>
 

--- a/scripts/jenkins-test
+++ b/scripts/jenkins-test
@@ -8,6 +8,8 @@ PROJECT_ROOT="$DIR/.."
 VERSION=$(grep "<version>" "$PROJECT_ROOT/pom.xml"  | head -2 | tail -1 | sed 's/ *<version>//g' | sed 's/<\/version>//g')
 echo "Testing ADAM version $VERSION"
 
+MAVEN_OPTS="-Xmx1536m -XX:MaxPermSize=1g" mvn test -Dnetworkconnected
+
 ADAM_TMP_DIR=$(mktemp -d -t "adamTestXXXXXXX")
 # Just to be paranoid.. use a directory internal to the ADAM_TMP_DIR
 ADAM_TMP_DIR="$ADAM_TMP_DIR/deleteMePleaseThisIsNoLongerNeeded"


### PR DESCRIPTION
HTTPRangedByteAccess supports HTTP range requests for ranges of resources. Includes a test
that executes against a few bytes of the test mouse chromosome on the berkeley server.

(Matt or Frank, check out the additional test case in ByteAccessSuite, let me know if using the URL of the mouse_chrM.bam, which is the same bam as used in the integration tests, is okay here in the unit tests too.) 

This branch is a precursor to fixing the tests / integration tests on the big Parquet / RDD PR.
