### PR TITLE
Minor cleanup on interleaved FASTQ input format. 

### DIFF
--- a/adam-core/src/main/java/org/bdgenomics/adam/io/InterleavedFastqInputFormat.java
+++ b/adam-core/src/main/java/org/bdgenomics/adam/io/InterleavedFastqInputFormat.java
@@ -15,19 +15,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-/*
- * This class is a Hadoop reader for "interleaved fastq" -- that is,
- * fastq with paired reads in the same file, interleaved, rather than
- * in two separate files. This makes it much easier to Hadoopily slice
- * up a single file and feed the slices into an aligner.
- * The format is the same as fastq, but records are expected to alternate
- * between /1 and /2.
- *
- * This reader is based on the FastqInputFormat that's part of Hadoop-BAM,
- * found at http://sourceforge.net/p/hadoop-bam/code/ci/master/tree/src/fi/tkk/ics/hadoop/bam/FastqInputFormat.java
- *
- * --Jeremy Elson (jelson@microsoft.com), Feb 2014
- */
 
 package org.bdgenomics.adam.io;
 
@@ -50,28 +37,40 @@ import java.io.EOFException;
 import java.io.IOException;
 import java.io.InputStream;
 
-public class InterleavedFastqInputFormat extends FileInputFormat<Void,Text>
-{
-
-    public static class InterleavedFastqRecordReader extends RecordReader<Void,Text>
-    {
-    /*
-     * fastq format:
-     * <fastq>  :=  <block>+
-     * <block>  :=  @<seqname>\n<seq>\n+[<seqname>]\n<qual>\n
-     * <seqname>  :=  [A-Za-z0-9_.:-]+
-     * <seq>  :=  [A-Za-z\n\.~]+
-     * <qual> :=  [!-~\n]+
-     *
-     * LP: this format is broken, no?  You can have multi-line sequence and quality strings,
-     * and the quality encoding includes '@' in its valid character range.  So how should one
-     * distinguish between \n@ as a record delimiter and and \n@ as part of a multi-line
-     * quality string?
-     *
-     * For now I'm going to assume single-line sequences.  This works for our sequencing
-     * application.  We'll see if someone complains in other applications.
-     */
-
+/**
+ * This class is a Hadoop reader for "interleaved fastq" -- that is,
+ * fastq with paired reads in the same file, interleaved, rather than
+ * in two separate files. This makes it much easier to Hadoopily slice
+ * up a single file and feed the slices into an aligner.
+ * The format is the same as fastq, but records are expected to alternate
+ * between /1 and /2.
+ *
+ * This reader is based on the FastqInputFormat that's part of Hadoop-BAM,
+ * found at http://sourceforge.net/p/hadoop-bam/code/ci/master/tree/src/fi/tkk/ics/hadoop/bam/FastqInputFormat.java
+ *
+ * @author Jeremy Elson (jelson@microsoft.com)
+ * @date Feb 2014
+ */
+public class InterleavedFastqInputFormat extends FileInputFormat<Void,Text> {
+    
+    public static class InterleavedFastqRecordReader extends RecordReader<Void,Text> {
+        /*
+         * fastq format:
+         * <fastq>  :=  <block>+
+         * <block>  :=  @<seqname>\n<seq>\n+[<seqname>]\n<qual>\n
+         * <seqname>  :=  [A-Za-z0-9_.:-]+
+         * <seq>  :=  [A-Za-z\n\.~]+
+         * <qual> :=  [!-~\n]+
+         *
+         * LP: this format is broken, no?  You can have multi-line sequence and quality strings,
+         * and the quality encoding includes '@' in its valid character range.  So how should one
+         * distinguish between \n@ as a record delimiter and and \n@ as part of a multi-line
+         * quality string?
+         *
+         * For now I'm going to assume single-line sequences.  This works for our sequencing
+         * application.  We'll see if someone complains in other applications.
+         */
+        
         // start:  first valid data index
         private long start;
         // end:  first index value beyond the slice, i.e. slice is in range [start,end)
@@ -80,7 +79,7 @@ public class InterleavedFastqInputFormat extends FileInputFormat<Void,Text>
         private long pos;
         // file:  the file being read
         private Path file;
-
+        
         private LineReader lineReader;
         private InputStream inputStream;
         private Text currentValue;
@@ -89,8 +88,7 @@ public class InterleavedFastqInputFormat extends FileInputFormat<Void,Text>
         // How long can a read get?
         private static final int MAX_LINE_LENGTH = 10000;
 
-        public InterleavedFastqRecordReader(Configuration conf, FileSplit split) throws IOException
-        {
+        public InterleavedFastqRecordReader(Configuration conf, FileSplit split) throws IOException {
             file = split.getPath();
             start = split.getStart();
             end = start + split.getLength();
@@ -101,15 +99,14 @@ public class InterleavedFastqInputFormat extends FileInputFormat<Void,Text>
             CompressionCodecFactory codecFactory = new CompressionCodecFactory(conf);
             CompressionCodec        codec        = codecFactory.getCodec(file);
 
-            if (codec == null) // no codec.  Uncompressed file.
-            {
+            if (codec == null) { // no codec.  Uncompressed file.
                 positionAtFirstRecord(fileIn);
                 inputStream = fileIn;
-            }
-            else
-            { // compressed file
-                if (start != 0)
+            } else { 
+                // compressed file
+                if (start != 0) {
                     throw new RuntimeException("Start position for compressed file is not 0! (found " + start + ")");
+                }
 
                 inputStream = codec.createInputStream(fileIn);
                 end = Long.MAX_VALUE; // read until the end of the file
@@ -118,16 +115,13 @@ public class InterleavedFastqInputFormat extends FileInputFormat<Void,Text>
             lineReader = new LineReader(inputStream);
         }
 
-
-        /*
+        /**
          * Position the input stream at the start of the first record.
          */
-        private void positionAtFirstRecord(FSDataInputStream stream) throws IOException
-        {
+        private void positionAtFirstRecord(FSDataInputStream stream) throws IOException {
             Text buffer = new Text();
 
-            if (true) // (start > 0) // use start>0 to assume that files start with valid data
-            {
+            if (true) { // (start > 0) // use start>0 to assume that files start with valid data
                 // Advance to the start of the first record that ends with /1
                 // We use a temporary LineReader to read lines until we find the
                 // position of the right one.  We then seek the file to that position.
@@ -135,21 +129,15 @@ public class InterleavedFastqInputFormat extends FileInputFormat<Void,Text>
                 LineReader reader = new LineReader(stream);
 
                 int bytesRead = 0;
-                do
-                {
+                do {
                     bytesRead = reader.readLine(buffer, (int)Math.min(MAX_LINE_LENGTH, end - start));
-                    if (bytesRead > 0 && (
-                            buffer.getLength() <= 0 ||
-                                    buffer.getBytes()[0] != '@' ||
-                                    buffer.getBytes()[buffer.getLength()-2] != '/' ||
-                                    buffer.getBytes()[buffer.getLength()-1] != '1'
-                    )
-                            )
-                    {
+                    int bufferLength = buffer.getLength();
+                    if (bytesRead > 0 && (bufferLength <= 0 ||
+                                          buffer.getBytes()[0] != '@' ||
+                                          (bufferLength >= 2 && buffer.getBytes()[bufferLength - 2] != '/') ||
+                                          (bufferLength >= 1 && buffer.getBytes()[bufferLength - 1] != '1'))) {
                         start += bytesRead;
-                    }
-                    else
-                    {
+                    } else {
                         // line starts with @.  Read two more and verify that it starts with a +
                         //
                         // If this isn't the start of a record, we want to backtrack to its end
@@ -157,10 +145,9 @@ public class InterleavedFastqInputFormat extends FileInputFormat<Void,Text>
 
                         bytesRead = reader.readLine(buffer, (int)Math.min(MAX_LINE_LENGTH, end - start));
                         bytesRead = reader.readLine(buffer, (int)Math.min(MAX_LINE_LENGTH, end - start));
-                        if (bytesRead > 0 && buffer.getLength() > 0 && buffer.getBytes()[0] == '+')
+                        if (bytesRead > 0 && buffer.getLength() > 0 && buffer.getBytes()[0] == '+') {
                             break; // all good!
-                        else
-                        {
+                        } else {
                             // backtrack to the end of the record we thought was the start.
                             start = backtrackPosition;
                             stream.seek(start);
@@ -178,31 +165,26 @@ public class InterleavedFastqInputFormat extends FileInputFormat<Void,Text>
         /**
          * Added to use mapreduce API.
          */
-        public void initialize(InputSplit split, TaskAttemptContext context) throws IOException, InterruptedException
-        {
-        }
+        public void initialize(InputSplit split, TaskAttemptContext context) throws IOException, InterruptedException {}
 
         /**
          * Added to use mapreduce API.
          */
-        public Void getCurrentKey()
-        {
+        public Void getCurrentKey() {
             return null;
         }
 
         /**
          * Added to use mapreduce API.
          */
-        public Text getCurrentValue()
-        {
+        public Text getCurrentValue() {
             return currentValue;
         }
 
         /**
          * Added to use mapreduce API.
          */
-        public boolean nextKeyValue() throws IOException, InterruptedException
-        {
+        public boolean nextKeyValue() throws IOException, InterruptedException {
             currentValue = new Text();
 
             return next(currentValue);
@@ -211,50 +193,46 @@ public class InterleavedFastqInputFormat extends FileInputFormat<Void,Text>
         /**
          * Close this RecordReader to future operations.
          */
-        public void close() throws IOException
-        {
+        public void close() throws IOException {
             inputStream.close();
         }
 
         /**
          * Create an object of the appropriate type to be used as a key.
          */
-        public Text createKey()
-        {
+        public Text createKey() {
             return new Text();
         }
 
         /**
          * Create an object of the appropriate type to be used as a value.
          */
-        public Text createValue()
-        {
+        public Text createValue() {
             return new Text();
         }
 
         /**
          * Returns the current position in the input.
          */
-        public long getPos() { return pos; }
+        public long getPos() { 
+            return pos; 
+        }
 
         /**
          * How much of the input has the RecordReader consumed i.e.
          */
-        public float getProgress()
-        {
+        public float getProgress() {
             if (start == end)
                 return 1.0f;
             else
                 return Math.min(1.0f, (pos - start) / (float)(end - start));
         }
 
-        public String makePositionMessage()
-        {
+        public String makePositionMessage() {
             return file.toString() + ":" + pos;
         }
 
-        protected boolean lowLevelFastqRead(Text readName, Text value) throws IOException
-        {
+        protected boolean lowLevelFastqRead(Text readName, Text value) throws IOException {
             // ID line
             readName.clear();
             long skipped = appendLineInto(readName, true);
@@ -282,12 +260,10 @@ public class InterleavedFastqInputFormat extends FileInputFormat<Void,Text>
         /**
          * Reads the next key/value pair from the input for processing.
          */
-        public boolean next(Text value) throws IOException
-        {
+        public boolean next(Text value) throws IOException {
             if (pos >= end)
                 return false; // past end of slice
-            try
-            {
+            try {
                 Text readName1 = new Text();
                 Text readName2 = new Text();
 
@@ -308,15 +284,13 @@ public class InterleavedFastqInputFormat extends FileInputFormat<Void,Text>
                     return false;
 
                 return true;
-            }
-            catch (EOFException e) {
+            } catch (EOFException e) {
                 throw new RuntimeException("unexpected end of file in fastq record at " + makePositionMessage());
             }
         }
 
 
-        private int appendLineInto(Text dest, boolean eofOk) throws EOFException, IOException
-        {
+        private int appendLineInto(Text dest, boolean eofOk) throws EOFException, IOException {
             Text buf = new Text();
             int bytesRead = lineReader.readLine(buf, MAX_LINE_LENGTH);
 
@@ -332,17 +306,18 @@ public class InterleavedFastqInputFormat extends FileInputFormat<Void,Text>
     }
 
     @Override
-    public boolean isSplitable(JobContext context, Path path)
-    {
+    public boolean isSplitable(JobContext context, Path path) {
         CompressionCodec codec = new CompressionCodecFactory(context.getConfiguration()).getCodec(path);
         return codec == null;
     }
 
     public RecordReader<Void, Text> createRecordReader(
             InputSplit genericSplit,
-            TaskAttemptContext context) throws IOException, InterruptedException
-    {
+            TaskAttemptContext context) throws IOException, InterruptedException {
         context.setStatus(genericSplit.toString());
-        return new InterleavedFastqRecordReader(context.getConfiguration(), (FileSplit)genericSplit); // cast as per example in TextInputFormat
+
+        // cast as per example in TextInputFormat
+        return new InterleavedFastqRecordReader(context.getConfiguration(), 
+                                                (FileSplit)genericSplit); 
     }
 }

--- a/pom.xml
+++ b/pom.xml
@@ -334,6 +334,29 @@
                 </exclusions>
             </dependency>
             <dependency>
+                <groupId>org.apache.hadoop</groupId>
+                <artifactId>hadoop-mapreduce</artifactId>
+                <version>${hadoop.version}</version>
+                <exclusions>
+                    <exclusion>
+                        <groupId>asm</groupId>
+                        <artifactId>asm</artifactId>
+                    </exclusion>
+                    <exclusion>
+                        <groupId>org.jboss.netty</groupId>
+                        <artifactId>netty</artifactId>
+                    </exclusion>
+                    <exclusion>
+                        <groupId>org.codehaus.jackson</groupId>
+                        <artifactId>*</artifactId>
+                    </exclusion>
+                    <exclusion>
+                        <groupId>org.sonatype.sisu.inject</groupId>
+                        <artifactId>*</artifactId>
+                    </exclusion>
+                </exclusions>
+            </dependency>
+            <dependency>
                 <groupId>org.apache.spark</groupId>
                 <artifactId>spark-core_${scala.artifact.suffix}</artifactId>
                 <version>${spark.version}</version>


### PR DESCRIPTION
Added explicit dependency on hadoop-mapreduce which is necessary for running downstream. If this dependency isn't added, the hadoop-mapreduce package can take a different version from the hadoop-core package, which can lead to class change exceptions:

```
Exception in thread "main" java.lang.IncompatibleClassChangeError: Found interface org.apache.hadoop.mapreduce.JobContext, but class was expected
    at org.bdgenomics.adam.io.InterleavedFastqInputFormat.isSplitable(InterleavedFastqInputFormat.java:337)
    at org.apache.hadoop.mapreduce.lib.input.FileInputFormat.getSplits(FileInputFormat.java:352)
    at org.apache.spark.rdd.NewHadoopRDD.getPartitions(NewHadoopRDD.scala:90)
```
