### PR TITLE
Refactoring read groups to increase the amount of data stored.

### DIFF
--- a/adam-core/src/main/scala/org/bdgenomics/adam/converters/ADAMRecordConverter.scala
+++ b/adam-core/src/main/scala/org/bdgenomics/adam/converters/ADAMRecordConverter.scala
@@ -58,6 +58,8 @@ class ADAMRecordConverter extends Serializable {
       .foreach(v => builder.setAttribute("LB", v.toString))
     Option(adamRecord.getRecordGroupPlatformUnit)
       .foreach(v => builder.setAttribute("PU", v.toString))
+    Option(adamRecord.getRecordGroupSample)
+      .foreach(v => builder.setAttribute("SM", v.toString))
 
     // set the reference name, and alignment position, for mate
     Option(adamRecord.getMateReference)
@@ -142,11 +144,7 @@ class ADAMRecordConverter extends Serializable {
     val samSequenceDictionary = sd.toSAMSequenceDictionary()
     val samHeader = new SAMFileHeader
     samHeader.setSequenceDictionary(samSequenceDictionary)
-    rgd.readGroups.foreach(kv => {
-      val (_, name) = kv
-      val nextMember = new SAMReadGroupRecord(name.toString)
-      samHeader.addReadGroup(nextMember)
-    })
+    rgd.recordGroups.foreach(group => samHeader.addReadGroup(group.toSAMReadGroupRecord))
 
     samHeader
   }

--- a/adam-core/src/main/scala/org/bdgenomics/adam/converters/SAMRecordConverter.scala
+++ b/adam-core/src/main/scala/org/bdgenomics/adam/converters/SAMRecordConverter.scala
@@ -153,13 +153,9 @@ class SAMRecordConverter extends Serializable {
 
     val recordGroup: SAMReadGroupRecord = samRecord.getReadGroup
     if (recordGroup != null) {
-      Option(recordGroup.getRunDate) match {
-        case Some(date) => builder.setRecordGroupRunDateEpoch(date.getTime)
-        case None       =>
-      }
-      recordGroup.getId
-      builder.setRecordGroupId(readGroups(recordGroup.getReadGroupId))
-        .setRecordGroupName(recordGroup.getReadGroupId)
+      Option(recordGroup.getRunDate).foreach(date => builder.setRecordGroupRunDateEpoch(date.getTime))
+
+      builder.setRecordGroupName(recordGroup.getReadGroupId)
         .setRecordGroupSequencingCenter(recordGroup.getSequencingCenter)
         .setRecordGroupDescription(recordGroup.getDescription)
         .setRecordGroupFlowOrder(recordGroup.getFlowOrder)

--- a/adam-core/src/main/scala/org/bdgenomics/adam/models/RecordGroupDictionary.scala
+++ b/adam-core/src/main/scala/org/bdgenomics/adam/models/RecordGroupDictionary.scala
@@ -17,27 +17,202 @@
  */
 package org.bdgenomics.adam.models
 
-import net.sf.samtools.{ SAMFileReader, SAMFileHeader }
+import java.util.Date
+import net.sf.samtools.{ SAMFileReader, SAMFileHeader, SAMReadGroupRecord }
+import org.bdgenomics.adam.rdd.ADAMContext._
+import org.bdgenomics.formats.avro.ADAMRecord
 import scala.collection.JavaConversions._
 
 object RecordGroupDictionary {
 
+  /**
+   * Builds a record group dictionary from a SAM file header.
+   *
+   * @param header SAM file header with attached read groups.
+   * @return Returns a new record group dictionary with the read groups attached to the file header.
+   */
   def fromSAMHeader(header: SAMFileHeader): RecordGroupDictionary = {
-    val rgDict = new RecordGroupDictionary(header.getReadGroups.map(_.getReadGroupId))
-    rgDict
+    // force implicit conversion
+    val readGroups: List[SAMReadGroupRecord] = header.getReadGroups
+    new RecordGroupDictionary(readGroups.map(RecordGroup(_)))
   }
 
+  /**
+   * Builds a record group dictionary from a SAM file reader by collecting the header, and the
+   * read groups attached to the header.
+   *
+   * @param header SAM file header with attached read groups.
+   * @return Returns a new record group dictionary with the read groups attached to the file header.
+   */
   def fromSAMReader(samReader: SAMFileReader): RecordGroupDictionary = {
     fromSAMHeader(samReader.getFileHeader)
   }
 
 }
 
-class RecordGroupDictionary(readGroupNames: Seq[String]) extends Serializable {
-  val readGroups = readGroupNames.sorted.zipWithIndex.toMap
+/**
+ * Builds a dictionary containing record groups. Record groups must have a unique name across all
+ * samples in the dictionary. This dictionary provides numerical IDs for each group; these IDs
+ * are only consistent when referencing a single dictionary.
+ *
+ * @param recordGroups A seq of record groups to popualate the dictionary.
+ *
+ * @throws AssertionError Throws an assertion error if there are multiple record groups with the
+ * same name.
+ */
+class RecordGroupDictionary(val recordGroups: Seq[RecordGroup]) extends Serializable {
+  lazy val recordGroupMap = recordGroups.map(v => (v.recordGroupName, v))
+    .sortBy(kv => kv._1)
+    .zipWithIndex
+    .map(kv => {
+      val ((name, group), index) = kv
+      (name, (group, index))
+    }).toMap
 
-  def apply(readGroupName: String): Int =
-    {
-      readGroups(readGroupName)
+  assert(recordGroupMap.size == recordGroups.length,
+    "Read group dictionary contains multiple samples with identical read group names.")
+
+  /**
+   * Returns the numerical index for a given record group name.
+   *
+   * @note This index is only guaranteed to have the same value for a given record group name
+   * when the index is pulled from the same record group dictionary.
+   *
+   * @param recordGroupName The record group to find an index for.
+   * @return Returns a numerical index for a record group.
+   */
+  def getIndex(recordGroupName: String): Int = {
+    recordGroupMap(recordGroupName)._2
+  }
+
+  /**
+   * Returns the record group entry for an associated name.
+   *
+   * @param recordGroupName The record group to look up.
+   * @return Detailed info for a record group.
+   */
+  def apply(recordGroupName: String): RecordGroup = {
+    recordGroupMap(recordGroupName)._1
+  }
+}
+
+object RecordGroup {
+  /**
+   * Creates a record group from read data. Returns a None option if the record group information
+   * is not populated in the read.
+   *
+   * @param read Read to populate data from.
+   * @return Returns a filled Option if record group data is attached to the read, else returns None.
+   */
+  def apply(read: ADAMRecord): Option[RecordGroup] = {
+    Option(read.getRecordGroupSample).fold(None.asInstanceOf[Option[RecordGroup]])(rgs => {
+      Option(read.getRecordGroupName).fold(None.asInstanceOf[Option[RecordGroup]])(rgn => {
+        Some(new RecordGroup(rgs.toString,
+          rgn.toString,
+          Option(read.getRecordGroupSequencingCenter).map(_.toString),
+          Option(read.getRecordGroupDescription).map(_.toString),
+          Option(read.getRecordGroupRunDateEpoch).map(_.toLong),
+          Option(read.getRecordGroupFlowOrder).map(_.toString),
+          Option(read.getRecordGroupKeySequence).map(_.toString),
+          Option(read.getRecordGroupLibrary).map(_.toString),
+          Option(read.getRecordGroupPredictedMedianInsertSize).map(_.toInt),
+          Option(read.getRecordGroupPlatform).map(_.toString),
+          Option(read.getRecordGroupPlatformUnit).map(_.toString)))
+      })
+    })
+  }
+
+  /**
+   * Converts a SAMReadGroupRecord into a RecordGroup.
+   *
+   * @param samRGR SAMReadGroupRecord to convert.
+   * @return Returns an equivalent ADAM format record group.
+   */
+  def apply(samRGR: SAMReadGroupRecord): RecordGroup = {
+    assert(samRGR.getSample != null,
+      "Sample ID is not set for read group " + samRGR.getReadGroupId)
+    new RecordGroup(samRGR.getSample,
+      samRGR.getReadGroupId,
+      Option(samRGR.getSequencingCenter).map(_.toString),
+      Option(samRGR.getDescription).map(_.toString),
+      Option(samRGR.getRunDate).map(_.getTime),
+      Option(samRGR.getFlowOrder).map(_.toString),
+      Option(samRGR.getKeySequence).map(_.toString),
+      Option(samRGR.getLibrary).map(_.toString),
+      Option({
+        // must explicitly reference as a java.lang.integer to avoid implicit conversion
+        val i: java.lang.Integer = samRGR.getPredictedMedianInsertSize
+        i
+      }).map(_.toInt),
+      Option(samRGR.getPlatform).map(_.toString),
+      Option(samRGR.getPlatformUnit).map(_.toString))
+  }
+}
+
+class RecordGroup(val sample: String,
+                  val recordGroupName: String,
+                  val sequencingCenter: Option[String] = None,
+                  val description: Option[String] = None,
+                  val runDateEpoch: Option[Long] = None,
+                  val flowOrder: Option[String] = None,
+                  val keySequence: Option[String] = None,
+                  val library: Option[String] = None,
+                  val predictedMedianInsertSize: Option[Int] = None,
+                  val platform: Option[String] = None,
+                  val platformUnit: Option[String] = None) extends Serializable {
+
+  /**
+   * Compares equality to another object. Only checks equality via the sample and
+   * recordGroupName fields.
+   *
+   * @param o Object to compare against.
+   * @return Returns true if the object is a RecordGroup, and the sample and group name are
+   * equal. Else, returns false.
+   */
+  override def equals(o: Any): Boolean = o match {
+    case rg: RecordGroup => {
+      println("comparing: " + rg.sample + "/" + rg.recordGroupName)
+      println("against  : " + sample + "/" + rg.recordGroupName)
+      rg.sample == sample && rg.recordGroupName == recordGroupName
     }
+    case _ => {
+      println("not comparing")
+      false
+    }
+  }
+
+  /**
+   * Generates a hash from the sample and record group name fields.
+   *
+   * @return Hash code for this object.
+   */
+  override def hashCode(): Int = (sample + recordGroupName).hashCode()
+
+  /**
+   * Converts a record group into a SAM formatted record group.
+   *
+   * @return A SAM formatted record group.
+   */
+  def toSAMReadGroupRecord(): SAMReadGroupRecord = {
+    val rgr = new SAMReadGroupRecord(recordGroupName)
+
+    // set fields
+    rgr.setSample(sample)
+    sequencingCenter.foreach(rgr.setSequencingCenter)
+    description.foreach(rgr.setDescription)
+    runDateEpoch.foreach(e => rgr.setRunDate(new Date(e)))
+    flowOrder.foreach(rgr.setFlowOrder)
+    keySequence.foreach(rgr.setFlowOrder)
+    library.foreach(rgr.setLibrary)
+    predictedMedianInsertSize.foreach(is => {
+      // force implicit conversion
+      val insertSize: java.lang.Integer = is
+      rgr.setPredictedMedianInsertSize(insertSize)
+    })
+    platform.foreach(rgr.setPlatform)
+    platformUnit.foreach(rgr.setPlatformUnit)
+
+    // return
+    rgr
+  }
 }

--- a/adam-core/src/main/scala/org/bdgenomics/adam/rdd/ADAMRDDFunctions.scala
+++ b/adam-core/src/main/scala/org/bdgenomics/adam/rdd/ADAMRDDFunctions.scala
@@ -34,6 +34,7 @@ import org.bdgenomics.formats.avro.{
 import org.bdgenomics.adam.converters.ADAMRecordConverter
 import org.bdgenomics.adam.models.{
   ADAMRod,
+  RecordGroup,
   RecordGroupDictionary,
   ReferencePosition,
   ReferenceRegion,
@@ -189,8 +190,7 @@ class ADAMRecordRDDFunctions(rdd: RDD[ADAMRecord]) extends ADAMSequenceDictionar
    * @return A dictionary describing the read groups in this RDD.
    */
   def adamGetReadGroupDictionary(): RecordGroupDictionary = {
-    val rgNames = rdd.flatMap(r => Option(r.getRecordGroupName))
-      .map(_.toString)
+    val rgNames = rdd.flatMap(RecordGroup(_))
       .distinct()
       .collect()
       .toSeq

--- a/adam-core/src/test/scala/org/bdgenomics/adam/converters/ADAMRecordConverterSuite.scala
+++ b/adam-core/src/test/scala/org/bdgenomics/adam/converters/ADAMRecordConverterSuite.scala
@@ -62,7 +62,7 @@ class ADAMRecordConverterSuite extends FunSuite {
     // make sequence dictionary
     val seqRecForDict = SequenceRecord("referencetest", 5, "test://chrom1")
     val dict = SequenceDictionary(seqRecForDict)
-    val readGroups = new RecordGroupDictionary(Seq("testing"))
+    val readGroups = new RecordGroupDictionary(Seq())
 
     // allocate converters
     val adamRecordConverter = new ADAMRecordConverter

--- a/adam-core/src/test/scala/org/bdgenomics/adam/models/RecordGroupDictionarySuite.scala
+++ b/adam-core/src/test/scala/org/bdgenomics/adam/models/RecordGroupDictionarySuite.scala
@@ -1,0 +1,88 @@
+/**
+ * Licensed to Big Data Genomics (BDG) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The BDG licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.bdgenomics.adam.models
+
+import java.util.Date
+import net.sf.samtools.SAMReadGroupRecord
+import org.bdgenomics.formats.avro.ADAMRecord
+import org.scalatest.FunSuite
+
+class RecordGroupDictionarySuite extends FunSuite {
+
+  test("simple conversion to and from sam read group") {
+    val origSAMRGR = new SAMReadGroupRecord("myId")
+    origSAMRGR.setSample("mySample")
+    val rg = RecordGroup(origSAMRGR)
+
+    // sample and record name should be converted
+    assert(rg.sample == "mySample")
+    assert(rg.recordGroupName == "myId")
+
+    val newSAMRGR = rg.toSAMReadGroupRecord
+
+    // the two should be equals
+    assert(origSAMRGR.equals(newSAMRGR))
+  }
+
+  test("sample name must be set") {
+    val samRGR = new SAMReadGroupRecord("myId")
+    intercept[AssertionError] {
+      RecordGroup(samRGR)
+    }
+  }
+
+  test("create a record group from a read") {
+    val ar = ADAMRecord.newBuilder()
+      .setRecordGroupSample("mySample")
+      .setRecordGroupName("myName")
+      .build()
+
+    val rg = RecordGroup(ar)
+
+    assert(rg.isDefined)
+    assert(rg.get.sample === "mySample")
+    assert(rg.get.recordGroupName === "myName")
+  }
+
+  test("don't create a record group from a read without record group info") {
+    val ar = ADAMRecord.newBuilder()
+      .build()
+
+    val rg = RecordGroup(ar)
+
+    assert(rg.isEmpty)
+  }
+
+  test("simple equality checks") {
+    val rg1a = new RecordGroup("me", "rg1")
+    val rg1b = RecordGroup(ADAMRecord.newBuilder()
+      .setRecordGroupSample("me")
+      .setRecordGroupName("rg1")
+      .build())
+    val rg2 = new RecordGroup("me", "rg2")
+    val rg3 = new RecordGroup("you", "rg1") // all hail the king!
+
+    assert(rg1a.equals(rg1a))
+    assert(rg1a.sample === rg1b.get.sample)
+    assert(rg1a.recordGroupName === rg1b.get.recordGroupName)
+    assert(!rg1a.equals(rg1b))
+    assert(rg1a.equals(rg1b.get))
+    assert(!rg1a.equals(rg2))
+    assert(!rg1a.equals(rg3))
+  }
+}


### PR DESCRIPTION
With the current read group dictionary data structure, we only log the read group names. As a consequence of this, we don't write the full record group information to the SAM file header when converting back to SAM/BAM (we use the record group dictionary to aggregate the record group data). This leads to compatibility issues with downstream tools that expect this data to be present.
