### PR TITLE
Cleaning hadoop dependencies

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -335,28 +335,9 @@
                         <groupId>org.sonatype.sisu.inject</groupId>
                         <artifactId>*</artifactId>
                     </exclusion>
-                </exclusions>
-            </dependency>
-            <dependency>
-                <groupId>org.apache.hadoop</groupId>
-                <artifactId>hadoop-mapreduce</artifactId>
-                <version>${hadoop.version}</version>
-                <exclusions>
                     <exclusion>
-                        <groupId>asm</groupId>
-                        <artifactId>asm</artifactId>
-                    </exclusion>
-                    <exclusion>
-                        <groupId>org.jboss.netty</groupId>
-                        <artifactId>netty</artifactId>
-                    </exclusion>
-                    <exclusion>
-                        <groupId>org.codehaus.jackson</groupId>
-                        <artifactId>*</artifactId>
-                    </exclusion>
-                    <exclusion>
-                        <groupId>org.sonatype.sisu.inject</groupId>
-                        <artifactId>*</artifactId>
+                        <groupId>javax.servlet</groupId>
+                        <artifactId>servlet-api</artifactId>
                     </exclusion>
                 </exclusions>
             </dependency>
@@ -364,6 +345,16 @@
                 <groupId>org.apache.spark</groupId>
                 <artifactId>spark-core_${scala.artifact.suffix}</artifactId>
                 <version>${spark.version}</version>
+                <exclusions>
+                    <exclusion>
+                        <groupId>org.apache.hadoop</groupId>
+                        <artifactId>hadoop-client</artifactId>
+                    </exclusion>
+                    <exclusion>
+                        <groupId>org.apache.hadoop</groupId>
+                        <artifactId>hadoop-mapreduce</artifactId>
+                    </exclusion>
+                </exclusions>
             </dependency>
             <dependency>
                 <groupId>org.apache.avro</groupId>


### PR DESCRIPTION
Adding further exclusions to clean up issues that make it difficult to run downstream jobs with hadoop versions other than 2.2
