### PR TITLE
Modifying interleaved fastq format to be hadoop version independent.

### DIFF
--- a/adam-core/pom.xml
+++ b/adam-core/pom.xml
@@ -98,11 +98,6 @@
             <artifactId>hadoop-client</artifactId>
         </dependency>
         <dependency>
-            <groupId>org.bdgenomics.adam</groupId>
-            <artifactId>adam-format</artifactId>
-            <version>${project.version}</version>
-        </dependency>
-        <dependency>
             <groupId>org.apache.spark</groupId>
             <artifactId>spark-core_${scala.artifact.suffix}</artifactId>
         </dependency>

--- a/adam-core/src/main/java/org/bdgenomics/adam/io/InterleavedFastqInputFormat.java
+++ b/adam-core/src/main/java/org/bdgenomics/adam/io/InterleavedFastqInputFormat.java
@@ -43,7 +43,10 @@ import java.io.InputStream;
  * in two separate files. This makes it much easier to Hadoopily slice
  * up a single file and feed the slices into an aligner.
  * The format is the same as fastq, but records are expected to alternate
- * between /1 and /2.
+ * between /1 and /2. As a precondition, we assume that the interleaved
+ * FASTQ files are always uncompressed; if the files are compressed, they
+ * cannot be split, and thus there is no reason to use the interleaved
+ * format.
  *
  * This reader is based on the FastqInputFormat that's part of Hadoop-BAM,
  * found at http://sourceforge.net/p/hadoop-bam/code/ci/master/tree/src/fi/tkk/ics/hadoop/bam/FastqInputFormat.java
@@ -303,12 +306,6 @@ public class InterleavedFastqInputFormat extends FileInputFormat<Void,Text> {
 
             return bytesRead;
         }
-    }
-
-    @Override
-    public boolean isSplitable(JobContext context, Path path) {
-        CompressionCodec codec = new CompressionCodecFactory(context.getConfiguration()).getCodec(path);
-        return codec == null;
     }
 
     public RecordReader<Void, Text> createRecordReader(


### PR DESCRIPTION
Final modifications. Removed the isSplittable function, as the method signature depends on the Hadoop version (specifically, the InputFileFormat API changes from Hadoop 2.2->2.3). Now, we inherit directly from the base InputFileFormat implementation, which always returns true (i.e., the file can be split). As a condition of this, we must disallow compressed interleaved FASTQ files. This condition is OK because compressed files cannot be split, and the interleaved FASTQ format (which is our own ad hoc definition of a file format) is only used to make splitting simpler.

Also, I noticed that the adam-core module still incorrectly depended on the old adam-format submodule. This was not causing tests to fail because Sonatype still contains a snapshot of adam-format. We should probably delete that snapshot...
