### PR TITLE
Changing to AvroParquetOutputFormat.

### DIFF
--- a/adam-core/src/main/scala/org/bdgenomics/adam/rdd/ADAMRDDFunctions.scala
+++ b/adam-core/src/main/scala/org/bdgenomics/adam/rdd/ADAMRDDFunctions.scala
@@ -68,7 +68,6 @@ class ADAMRDDFunctions[T <% SpecificRecord: Manifest](rdd: RDD[T]) extends Seria
                disableDictionaryEncoding: Boolean = false): RDD[T] = {
     val job = HadoopUtil.newJob(rdd.context)
     ParquetLogger.hadoopLoggerLevel(Level.SEVERE)
-    ParquetOutputFormat.setWriteSupportClass(job, classOf[AvroWriteSupport])
     ParquetOutputFormat.setCompression(job, compressCodec)
     ParquetOutputFormat.setEnableDictionary(job, !disableDictionaryEncoding)
     ParquetOutputFormat.setBlockSize(job, blockSize)
@@ -78,7 +77,7 @@ class ADAMRDDFunctions[T <% SpecificRecord: Manifest](rdd: RDD[T]) extends Seria
     val recordToSave = rdd.map(p => (null, p))
     // Save the values to the ADAM/Parquet file
     recordToSave.saveAsNewAPIHadoopFile(filePath,
-      classOf[java.lang.Void], manifest[T].runtimeClass.asInstanceOf[Class[T]], classOf[ParquetOutputFormat[T]],
+      classOf[java.lang.Void], manifest[T].runtimeClass.asInstanceOf[Class[T]], classOf[AvroParquetOutputFormat],
       ContextUtil.getConfiguration(job))
     // Return the origin rdd
     rdd


### PR DESCRIPTION
As noted in [AvroWriteSupport](https://github.com/Parquet/parquet-mr/blob/parquet-1.4.3/parquet-avro/src/main/java/parquet/avro/AvroWriteSupport.java), the AvroWriteSupport class shouldn't be used by users, instead the [AvroParquetOutputFormat](https://github.com/Parquet/parquet-mr/blob/parquet-1.4.3/parquet-avro/src/main/java/parquet/avro/AvroParquetOutputFormat.java) should be used in place of the ParquetOutputFormat. This change solves a ClassNotFoundException thrown on Hadoop 2.4.0:

```
14/07/07 20:31:53 INFO Configuration.deprecation: mapred.output.value.class is deprecated. Instead, use mapreduce.job.output.value.class
14/07/07 20:31:53 ERROR executor.Executor: Exception in task ID 1043
parquet.hadoop.BadConfigurationException: could not instanciate class parquet.avro.AvroWriteSupport set in job conf at parquet.write.support.class
        at parquet.hadoop.ParquetOutputFormat.getWriteSupportClass(ParquetOutputFormat.java:121)
        at parquet.hadoop.ParquetOutputFormat.getWriteSupport(ParquetOutputFormat.java:302)
        at parquet.hadoop.ParquetOutputFormat.getRecordWriter(ParquetOutputFormat.java:262)
        at parquet.hadoop.ParquetOutputFormat.getRecordWriter(ParquetOutputFormat.java:252)
        at org.apache.spark.rdd.PairRDDFunctions.org$apache$spark$rdd$PairRDDFunctions$$writeShard$1(PairRDDFunctions.scala:712)
        at org.apache.spark.rdd.PairRDDFunctions$$anonfun$saveAsNewAPIHadoopDataset$1.apply(PairRDDFunctions.scala:730)
```
