### PR TITLE
Making the CredentialsProperties file optional

### DIFF
--- a/adam-core/src/test/scala/org/bdgenomics/adam/io/ByteAccessSuite.scala
+++ b/adam-core/src/test/scala/org/bdgenomics/adam/io/ByteAccessSuite.scala
@@ -26,7 +26,7 @@ import org.scalatest.FunSuite
 
 class ByteAccessSuite extends FunSuite {
 
-  lazy val credentials = new CredentialsProperties(new File(System.getProperty("user.home") + "/spark.conf"))
+  lazy val credentials = new CredentialsProperties(Some(new File(System.getProperty("user.home") + "/spark.conf")))
     .awsCredentials(Some("s3"))
 
   lazy val bucketName = System.getenv("BUCKET_NAME")

--- a/adam-core/src/test/scala/org/bdgenomics/adam/parquet_reimpl/AvroParquetRDDSuite.scala
+++ b/adam-core/src/test/scala/org/bdgenomics/adam/parquet_reimpl/AvroParquetRDDSuite.scala
@@ -187,7 +187,7 @@ object RDDFunSuite {
 
 class AvroParquetRDDSuite extends SparkFunSuite {
 
-  lazy val credentials = new CredentialsProperties(new File(System.getProperty("user.home") + "/spark.conf"))
+  lazy val credentials = new CredentialsProperties(Some(new File(System.getProperty("user.home") + "/spark.conf")))
     .awsCredentials(Some("s3"))
 
   lazy val bucketName = System.getenv("BUCKET_NAME")

--- a/adam-core/src/test/scala/org/bdgenomics/adam/parquet_reimpl/ParquetCommonSuite.scala
+++ b/adam-core/src/test/scala/org/bdgenomics/adam/parquet_reimpl/ParquetCommonSuite.scala
@@ -27,7 +27,7 @@ import org.bdgenomics.adam.util.{ S3Test, NetworkConnected, CredentialsPropertie
 import org.scalatest.FunSuite
 
 class ParquetCommonSuite extends FunSuite {
-  lazy val credentials = new CredentialsProperties(new File(System.getProperty("user.home") + "/spark.conf"))
+  lazy val credentials = new CredentialsProperties(Some(new File(System.getProperty("user.home") + "/spark.conf")))
     .awsCredentials(Some("s3"))
 
   lazy val bucketName = System.getenv("bucket-name")

--- a/adam-core/src/test/scala/org/bdgenomics/adam/util/CredentialPropertiesSuite.scala
+++ b/adam-core/src/test/scala/org/bdgenomics/adam/util/CredentialPropertiesSuite.scala
@@ -25,7 +25,7 @@ class CredentialsPropertiesTestSuite extends FunSuite {
   test("Can parse a simple configuration file with CredentialsProperties") {
     val path = Thread.currentThread().getContextClassLoader.getResource("test.conf").getFile
     val file = new File(path)
-    val cp = new CredentialsProperties(file)
+    val cp = new CredentialsProperties(Some(file))
 
     val aws = cp.awsCredentials()
     assert(aws.getAWSAccessKeyId === "accessKey")


### PR DESCRIPTION
This is to help downstream `CredentialsProperties` users, in the case they only want to use the environment variables.
