### PR TITLE
Added table of (wall-clock) stage durations when print_metrics is used

### DIFF
--- a/adam-cli/src/main/scala/org/bdgenomics/adam/cli/ADAMCommand.scala
+++ b/adam-cli/src/main/scala/org/bdgenomics/adam/cli/ADAMCommand.scala
@@ -70,7 +70,7 @@ trait ADAMSparkCommand[A <: Args4jBase with SparkArgs] extends ADAMCommand with 
       out.println()
       out.println("Overall Duration: " + DurationFormatting.formatNanosecondDuration(totalTime))
       out.println()
-      listener.adamMetrics.sparkTaskMetrics.print(out)
+      listener.adamMetrics.adamSparkMetrics.print(out)
       logInfo("Metrics:" + bytes.toString("UTF-8"))
     })
   }

--- a/adam-cli/src/main/scala/org/bdgenomics/adam/cli/Args4j.scala
+++ b/adam-cli/src/main/scala/org/bdgenomics/adam/cli/Args4j.scala
@@ -23,7 +23,7 @@ import scala.collection.JavaConversions._
 class Args4jBase {
   @Option(name = "-h", aliases = Array("-help", "--help", "-?"), usage = "Print help")
   var doPrintUsage: Boolean = false
-  @Option(name = "-print_metrics", usage = "Print metrics on completion")
+  @Option(name = "-print_metrics", usage = "Print metrics to the log on completion")
   var printMetrics: Boolean = false
 }
 

--- a/adam-core/src/main/scala/org/bdgenomics/adam/instrumentation/ADAMMetrics.scala
+++ b/adam-core/src/main/scala/org/bdgenomics/adam/instrumentation/ADAMMetrics.scala
@@ -22,9 +22,9 @@ package org.bdgenomics.adam.instrumentation
  */
 class ADAMMetrics {
 
-  val sparkTaskMetrics = new TaskMetrics()
+  val adamSparkMetrics = new ADAMSparkMetrics()
 
-  class TaskMetrics extends SparkMetrics {
+  class ADAMSparkMetrics extends SparkMetrics {
     val executorRunTime = taskTimer("Executor Run Time")
     val executorDeserializeTime = taskTimer("Executor Deserialization Time")
     val resultSerializationTime = taskTimer("Result Serialization Time")

--- a/adam-core/src/main/scala/org/bdgenomics/adam/instrumentation/MonitorTable.scala
+++ b/adam-core/src/main/scala/org/bdgenomics/adam/instrumentation/MonitorTable.scala
@@ -88,10 +88,23 @@ object ValueExtractor {
   def forTagValueWithKey(key: String): ValueExtractor = {
     new MonitorTagValueExtractor(key)
   }
+
+  /**
+   * Creates a [[ValueExtractor]] which returns the value of the specified monitor
+   */
+  def forMonitorValue(): ValueExtractor = {
+    new SimpleMonitorValueExtractor()
+  }
 }
 
 trait ValueExtractor {
   def extractValue(monitor: Monitor[_]): Option[Any]
+}
+
+private class SimpleMonitorValueExtractor() extends ValueExtractor {
+  override def extractValue(monitor: Monitor[_]): Option[Any] = {
+    Option(monitor.getValue)
+  }
 }
 
 private class MonitorTagValueExtractor(key: String) extends ValueExtractor {

--- a/adam-core/src/main/scala/org/bdgenomics/adam/instrumentation/SparkMetrics.scala
+++ b/adam-core/src/main/scala/org/bdgenomics/adam/instrumentation/SparkMetrics.scala
@@ -18,7 +18,7 @@
 package org.bdgenomics.adam.instrumentation
 
 import scala.collection.mutable
-import com.netflix.servo.monitor.MonitorConfig
+import com.netflix.servo.monitor.{ Monitor, LongGauge, MonitorConfig }
 import java.io.PrintStream
 import scala.collection.mutable.ArrayBuffer
 import com.netflix.servo.tag.Tags.newTag
@@ -26,6 +26,7 @@ import org.bdgenomics.adam.instrumentation.ServoTimer._
 import org.bdgenomics.adam.instrumentation.ValueExtractor._
 import com.netflix.servo.tag.Tag
 import org.bdgenomics.adam.instrumentation.SparkMetrics._
+import scala.concurrent.duration._
 
 /**
  * Allows metrics for Spark to be captured and rendered in tabular form.
@@ -35,12 +36,18 @@ abstract class SparkMetrics {
   private val taskTimers = new mutable.ArrayBuffer[TaskTimer]()
   private val stageIdToName = new mutable.HashMap[Int, String]()
 
+  // Maps the stage ID and name to the duration of the stage in nanoseconds
+  private[instrumentation] val stageTimes = new mutable.HashMap[String, LongGauge]()
+
   def print(out: PrintStream) = {
+    val stageMonitors = createStageDurationRows()
     val overallMonitors = taskTimers.map(_.getOverallTimings).sortBy(-_.getTotalTime)
     val ordering = getOrdering(overallMonitors)
     val monitorsByHost = taskTimers.flatMap(_.getHostTimings).sorted(ordering)
     val monitorsByStageName = taskTimers.flatMap(_.getStageTimings).map(addStageName).sorted(ordering)
-    renderTable(out, "Task Timings", overallMonitors, createBaseHeader())
+    renderTable(out, "Stage Durations", stageMonitors, createStageHeader())
+    out.println()
+    renderTable(out, "Task Timings", overallMonitors, createTaskHeader())
     out.println()
     renderTable(out, "Task Timings By Host", monitorsByHost,
       createHeaderWith(TableHeader(name = "Host", valueExtractor = forTagValueWithKey(HostTagKey), alignment = Alignment.Left), 1))
@@ -51,6 +58,12 @@ abstract class SparkMetrics {
 
   def mapStageIdToName(stageId: Int, stageName: String) {
     stageIdToName.put(stageId, stageName)
+  }
+
+  def recordStageDuration(stageId: Int, stageName: Option[String], duration: Duration) = {
+    val stageIdAndName = formatStageIdAndName(stageId, stageName)
+    val gauge: LongGauge = createStageDurationMonitor(stageIdAndName, duration)
+    stageTimes.put(stageIdAndName, gauge)
   }
 
   /**
@@ -92,25 +105,50 @@ abstract class SparkMetrics {
     }).toMap
   }
 
+  private def createStageDurationRows(): Seq[LongGauge] = {
+    val unsortedStageMonitors = stageTimes.values.toBuffer
+    val stageMonitors = unsortedStageMonitors.sortBy(-_.getNumber.longValue())
+    val stagesTotal = stageMonitors.map(_.getNumber.longValue()).sum
+    stageMonitors += createStageDurationMonitor("TOTAL", Duration(stagesTotal, NANOSECONDS))
+    stageMonitors
+  }
+
+  private def createStageDurationMonitor(name: String, duration: Duration): LongGauge = {
+    val tag = newTag(StageNameTagKey, name)
+    val gauge = new LongGauge(MonitorConfig.builder(name).withTag(tag).build())
+    gauge.set(duration.toNanos)
+    gauge
+  }
+
   private def addStageName(stageIdAndTimer: (Int, ServoTimer)): ServoTimer = {
-    val stageName = stageIdAndTimer._1 + ": " + stageIdToName.get(stageIdAndTimer._1).getOrElse("unknown")
-    stageIdAndTimer._2.addTag(newTag(StageNameTagKey, stageName))
+    val stageIdAndName = formatStageIdAndName(stageIdAndTimer._1, stageIdToName.get(stageIdAndTimer._1))
+    stageIdAndTimer._2.addTag(newTag(StageNameTagKey, stageIdAndName))
     stageIdAndTimer._2
   }
 
-  private def renderTable(out: PrintStream, name: String, timers: Seq[ServoTimer], header: ArrayBuffer[TableHeader]) = {
+  private def formatStageIdAndName(stageId: Int, stageName: Option[String]): String = {
+    stageId + ": " + stageName.getOrElse("unknown")
+  }
+
+  private def renderTable(out: PrintStream, name: String, timers: Seq[Monitor[_]], header: ArrayBuffer[TableHeader]) = {
     val monitorTable = new MonitorTable(header.toArray, timers.toArray)
     out.println(name)
     monitorTable.print(out)
   }
 
   private def createHeaderWith(header: TableHeader, position: Int): ArrayBuffer[TableHeader] = {
-    val baseHeader = createBaseHeader()
+    val baseHeader = createTaskHeader()
     baseHeader.insert(position, header)
     baseHeader
   }
 
-  private def createBaseHeader(): ArrayBuffer[TableHeader] = {
+  private def createStageHeader(): ArrayBuffer[TableHeader] = {
+    ArrayBuffer(
+      TableHeader(name = "Stage ID & Name", valueExtractor = forTagValueWithKey(StageNameTagKey), alignment = Alignment.Left),
+      TableHeader(name = "Duration", valueExtractor = forMonitorValue(), formatFunction = Some(formatNanos)))
+  }
+
+  private def createTaskHeader(): ArrayBuffer[TableHeader] = {
     ArrayBuffer(
       TableHeader(name = "Metric", valueExtractor = forTagValueWithKey(NameTagKey), alignment = Alignment.Left),
       TableHeader(name = "Total Time", valueExtractor = forMonitorMatchingTag(TotalTimeTag), formatFunction = Some(formatNanos)),

--- a/adam-core/src/test/scala/org/bdgenomics/adam/instrumentation/ADAMMetricsListenerSuite.scala
+++ b/adam-core/src/test/scala/org/bdgenomics/adam/instrumentation/ADAMMetricsListenerSuite.scala
@@ -41,11 +41,12 @@ class ADAMMetricsListenerSuite extends SparkFunSuite with Eventually with Integr
     }
 
     eventually {
-      // There's nothing sensible we can assert based on the timings, so just assert based on the timings
-      assert(metrics.sparkTaskMetrics.duration.getOverallTimings.getCount === 8)
-      assert(metrics.sparkTaskMetrics.executorRunTime.getOverallTimings.getCount === 8)
-      assert(metrics.sparkTaskMetrics.executorDeserializeTime.getOverallTimings.getCount === 8)
-      assert(metrics.sparkTaskMetrics.resultSerializationTime.getOverallTimings.getCount === 8)
+      // There's nothing sensible we can assert based on the timings, so just assert based on the counts
+      assert(metrics.adamSparkMetrics.duration.getOverallTimings.getCount === 8)
+      assert(metrics.adamSparkMetrics.executorRunTime.getOverallTimings.getCount === 8)
+      assert(metrics.adamSparkMetrics.executorDeserializeTime.getOverallTimings.getCount === 8)
+      assert(metrics.adamSparkMetrics.resultSerializationTime.getOverallTimings.getCount === 8)
+      assert(metrics.adamSparkMetrics.stageTimes.iterator.hasNext)
     }
 
   }

--- a/adam-core/src/test/scala/org/bdgenomics/adam/instrumentation/MonitorTableSuite.scala
+++ b/adam-core/src/test/scala/org/bdgenomics/adam/instrumentation/MonitorTableSuite.scala
@@ -28,7 +28,8 @@ class MonitorTableSuite extends FunSuite {
 
     val headers = Array(
       new TableHeader(name = "Col1", valueExtractor = ValueExtractor.forTagValueWithKey("TagKey1"), None, alignment = Alignment.Left),
-      new TableHeader(name = "Col2", valueExtractor = ValueExtractor.forMonitorMatchingTag(ServoTimer.TotalTimeTag), formatFunction = Some(formatFunction1)))
+      new TableHeader(name = "Col2", valueExtractor = ValueExtractor.forMonitorMatchingTag(ServoTimer.TotalTimeTag), formatFunction = Some(formatFunction1)),
+      new TableHeader(name = "Col3", valueExtractor = ValueExtractor.forMonitorValue()))
 
     val rows = Array[Monitor[_]](
       new ServoTimer(MonitorConfig.builder("timer1").build()),
@@ -43,6 +44,8 @@ class MonitorTableSuite extends FunSuite {
     val monitorTable = new MonitorTable(headers, rows)
 
     val renderedTable = getRenderedTable(monitorTable)
+
+    println(renderedTable)
 
     assert(renderedTable === expectedTable)
 
@@ -60,12 +63,12 @@ class MonitorTableSuite extends FunSuite {
   }
 
   val expectedTable =
-    """+-------------------------+--------------------+
-      #|          Col1           |        Col2        |
-      #+-------------------------+--------------------+
-      #| Col1Value1              |    100 nanoseconds |
-      #| Col1Value2 A Bit Longer | 200000 nanoseconds |
-      #+-------------------------+--------------------+
+    """+-------------------------+--------------------+--------+
+      #|          Col1           |        Col2        |  Col3  |
+      #+-------------------------+--------------------+--------+
+      #| Col1Value1              |    100 nanoseconds |    100 |
+      #| Col1Value2 A Bit Longer | 200000 nanoseconds | 200000 |
+      #+-------------------------+--------------------+--------+
       #""".stripMargin('#')
 
 }


### PR DESCRIPTION
The ADAMMetricsListener now records the wall-clock duration of each Spark stage. Previously only the total time taken for all of the tasks in the stage was recorded, but this is different from the wall-clock time on a multiple node cluster.

Also changed the text of the print_metrics option to clarify that metrics are printed to the log (as opposed to stdout)
