### PR TITLE
Adding native Java language bindings for ADAM.

### DIFF
--- a/adam-apis/pom.xml
+++ b/adam-apis/pom.xml
@@ -1,0 +1,113 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <parent>
+        <groupId>org.bdgenomics.adam</groupId>
+        <artifactId>adam-parent</artifactId>
+        <version>0.12.1-SNAPSHOT</version>
+        <relativePath>../pom.xml</relativePath>
+    </parent>
+
+    <artifactId>adam-apis</artifactId>
+    <packaging>jar</packaging>
+    <name>ADAM: APIs for Java</name>
+    <build>
+        <plugins>
+            <!-- disable surefire -->
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-surefire-plugin</artifactId>
+                <configuration>
+                    <skipTests>true</skipTests>
+                </configuration>
+            </plugin>
+            <!-- enable scalatest -->
+            <plugin>
+                <groupId>org.scalatest</groupId>
+                <artifactId>scalatest-maven-plugin</artifactId>
+                <configuration>
+                    <reportsDirectory>${project.build.directory}/surefire-reports</reportsDirectory>
+                    <junitxml>.</junitxml>
+                    <filereports>ADAMTestSuite.txt</filereports>
+                    <!--
+                         As explained here: http://stackoverflow.com/questions/1660441/java-flag-to-enable-extended-serialization-debugging-info
+                         The second option allows us better debugging for serialization-based errors.
+                     -->
+                    <argLine>-Xmx1024m -Dsun.io.serialization.extendedDebugInfo=true</argLine>
+                </configuration>
+                <executions>
+                    <execution>
+                        <id>test</id>
+                        <goals>
+                            <goal>test</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
+                <groupId>org.codehaus.mojo</groupId>
+                <artifactId>build-helper-maven-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <id>add-source</id>
+                        <phase>generate-sources</phase>
+                        <goals>
+                            <goal>add-source</goal>
+                        </goals>
+                        <configuration>
+                            <sources>
+                                <source>src/main/scala</source>
+                            </sources>
+                        </configuration>
+                    </execution>
+                    <execution>
+                        <id>add-test-source</id>
+                        <phase>generate-test-sources</phase>
+                        <goals>
+                            <goal>add-test-source</goal>
+                        </goals>
+                        <configuration>
+                            <sources>
+                                <source>src/test/scala</source>
+                            </sources>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
+
+    <dependencies>
+        <dependency>
+            <groupId>org.bdgenomics.bdg-formats</groupId>
+            <artifactId>bdg-formats</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.bdgenomics.adam</groupId>
+            <artifactId>adam-core</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.bdgenomics.adam</groupId>
+            <artifactId>adam-core</artifactId>
+            <type>test-jar</type>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.scala-lang</groupId>
+            <artifactId>scala-library</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.slf4j</groupId>
+            <artifactId>slf4j-log4j12</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>args4j</groupId>
+            <artifactId>args4j</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.scalatest</groupId>
+            <artifactId>scalatest_${scala.artifact.suffix}</artifactId>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+</project>

--- a/adam-apis/src/main/scala/org/bdgenomics/adam/apis/java/JavaADAMContext.scala
+++ b/adam-apis/src/main/scala/org/bdgenomics/adam/apis/java/JavaADAMContext.scala
@@ -1,0 +1,126 @@
+/**
+ * Licensed to Big Data Genomics (BDG) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The BDG licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.bdgenomics.adam.apis.java
+
+import org.apache.spark.SparkContext
+import org.apache.spark.rdd.RDD
+import org.apache.spark.api.java.{ JavaRDD, JavaSparkContext }
+import org.bdgenomics.adam.instrumentation.ADAMMetricsListener
+import org.bdgenomics.adam.predicates.ADAMPredicate
+import org.bdgenomics.adam.rdd.ADAMContext._
+import org.bdgenomics.adam.rdd.ADAMContext
+import org.bdgenomics.formats.avro._
+import scala.collection.JavaConversions._
+
+object JavaADAMContext {
+  // convert to and from java/scala implementations
+  implicit def fromADAMContext(ac: ADAMContext): JavaADAMContext = new JavaADAMContext(ac)
+  implicit def toADAMContext(jac: JavaADAMContext): ADAMContext = jac.ac
+}
+
+class JavaADAMContext(val ac: ADAMContext) extends Serializable {
+
+  /**
+   * @return Returns the Java Spark Context associated with this Java ADAM Context.
+   */
+  def getSparkContext(): JavaSparkContext = new JavaSparkContext(ac.sc)
+
+  /**
+   * Builds this Java ADAM Context by creating a new Spark Context.
+   *
+   * @param name Name of the Spark Context to create.
+   * @param master The URI of the Spark master.
+   * @param sparkHome Path to the Spark home directory.
+   * @param sparkJars JAR files to include.
+   * @param sparkEnvVars A map containing envars and their settings.
+   * @param sparkAddStatsListener Whether or not to include a stats listener.
+   * @param sparkKryoBufferSize The size of the kryo serialization buffer in MB.
+   * @param sparkMetricsListener A metrics listener to attach. Can be null.
+   * @param loadSystemValues Whether to load system values or not.
+   * @param sparkDriverPort The port mapping for the Spark driver. Can be null.
+   * @return Returns a new Java ADAM Context, built on a new Spark Context.
+   */
+  def this(name: java.lang.String,
+           master: java.lang.String,
+           sparkHome: java.lang.String,
+           sparkJars: java.util.List[java.lang.String],
+           sparkEnvVars: java.util.Map[java.lang.String, java.lang.String],
+           sparkAddStatsListener: java.lang.Boolean,
+           sparkKryoBufferSize: java.lang.Integer,
+           sparkMetricsListener: ADAMMetricsListener,
+           loadSystemValues: java.lang.Boolean,
+           sparkDriverPort: java.lang.Integer) = {
+    this(new ADAMContext(ADAMContext.createSparkContext(name,
+      master,
+      sparkHome, {
+        // force implicit conversion
+        val sj: List[java.lang.String] = sparkJars
+
+        sj.map(_.toString)
+      }, {
+        // force implicit conversion
+        val sev: Map[java.lang.String, java.lang.String] = mapAsScalaMap(sparkEnvVars).toMap
+
+        sev.map(kv => (kv._1.toString,
+          kv._2.toString)).toSeq
+      }, sparkAddStatsListener,
+      sparkKryoBufferSize,
+      Option(sparkMetricsListener),
+      loadSystemValues,
+      Option(sparkDriverPort).map(_.toInt))))
+  }
+
+  /**
+   * Builds this Java ADAM Context by creating a new Spark Context.
+   *
+   * @param name Name of the Spark Context to create.
+   * @param master The URI of the Spark master.
+   * @return Returns a new Java ADAM Context, built on a new Spark Context.
+   */
+  def this(name: java.lang.String,
+           master: java.lang.String) = this(new ADAMContext(
+    ADAMContext.createSparkContext(name, master)))
+
+  /**
+   * Builds this Java ADAM Context using an existing Java Spark Context.
+   *
+   * @param jsc Java Spark Context to use to build this ADAM Context.
+   * @return A new Java ADAM Context.
+   */
+  def this(jsc: JavaSparkContext) = this(new ADAMContext(jsc))
+
+  /**
+   * Builds this Java ADAM Context using an existing Spark Context.
+   *
+   * @param sc Spark Context to use to build this ADAM Context.
+   * @return A new Java ADAM Context.
+   */
+  def this(sc: SparkContext) = this(new ADAMContext(sc))
+
+  /**
+   * Loads in an ADAM read file. This method can load SAM, BAM, and ADAM files.
+   *
+   * @param filePath Path to load the file from.
+   * @return Returns a read RDD.
+   *
+   * @tparam U A predicate to apply on the load.
+   */
+  def adamRecordLoad[U <: ADAMPredicate[ADAMRecord]](filePath: java.lang.String): JavaADAMRecordRDD = {
+    new JavaADAMRecordRDD(ac.adamLoad[ADAMRecord, U](filePath).toJavaRDD())
+  }
+}

--- a/adam-apis/src/main/scala/org/bdgenomics/adam/apis/java/JavaADAMRecordRDD.scala
+++ b/adam-apis/src/main/scala/org/bdgenomics/adam/apis/java/JavaADAMRecordRDD.scala
@@ -1,0 +1,79 @@
+/**
+ * Licensed to Big Data Genomics (BDG) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The BDG licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.bdgenomics.adam.apis.java
+
+import org.apache.spark.rdd.RDD
+import org.apache.spark.api.java.JavaSparkContext._
+import org.apache.spark.api.java.{ JavaRDD, JavaSparkContext }
+import org.bdgenomics.adam.rdd.ADAMContext._
+import org.bdgenomics.adam.rdd.ADAMContext
+import org.bdgenomics.formats.avro._
+import parquet.hadoop.metadata.CompressionCodecName
+
+class JavaADAMRecordRDD(val jrdd: JavaRDD[ADAMRecord]) extends Serializable {
+
+  /**
+   * Saves this RDD to disk as a Parquet file.
+   *
+   * @param filePath Path to save the file at.
+   * @param blockSize Size per block.
+   * @param pageSize Size per page.
+   * @param compressCodec Name of the compression codec to use.
+   * @param disableDictionaryEncoding Whether or not to disable bit-packing.
+   */
+  def adamSave(filePath: java.lang.String,
+               blockSize: java.lang.Integer,
+               pageSize: java.lang.Integer,
+               compressCodec: CompressionCodecName,
+               disableDictionaryEncoding: java.lang.Boolean) {
+    jrdd.rdd.adamSave(filePath,
+      blockSize,
+      pageSize,
+      compressCodec,
+      disableDictionaryEncoding)
+  }
+
+  /**
+   * Saves this RDD to disk as a Parquet file.
+   *
+   * @param filePath Path to save the file at.
+   */
+  def adamSave(filePath: java.lang.String) {
+    jrdd.rdd.adamSave(filePath)
+  }
+
+  /**
+   * Saves this RDD to disk as a SAM/BAM file.
+   *
+   * @param filePath Path to save the file at.
+   * @param asSam If true, saves as SAM. If false, saves as BAM.
+   */
+  def adamSAMSave(filePath: java.lang.String,
+                  asSam: java.lang.Boolean) {
+    jrdd.rdd.adamSAMSave(filePath, asSam)
+  }
+
+  /**
+   * Saves this RDD to disk as a SAM/BAM file.
+   *
+   * @param filePath Path to save the file at.
+   */
+  def adamSAMSave(filePath: java.lang.String) {
+    jrdd.rdd.adamSAMSave(filePath)
+  }
+}

--- a/adam-apis/src/test/java/org/bdgenomics/adam/apis/java/JavaADAMConduit.java
+++ b/adam-apis/src/test/java/org/bdgenomics/adam/apis/java/JavaADAMConduit.java
@@ -1,0 +1,46 @@
+/**
+ * Licensed to Big Data Genomics (BDG) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The BDG licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.bdgenomics.adam.apis.java;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import org.apache.spark.api.java.JavaRDD;
+import org.apache.spark.api.java.JavaSparkContext;
+import org.bdgenomics.adam.apis.java.JavaADAMContext;
+import org.bdgenomics.adam.predicates.HighQualityReadPredicate;
+import org.bdgenomics.formats.avro.ADAMRecord;
+
+/**
+ * A simple test class for the JavaADAMRDD/Context. Writes an RDD to
+ * disk and reads it back.
+ */
+public class JavaADAMConduit {
+    public static JavaADAMRecordRDD conduit(JavaRDD<ADAMRecord> rdd) throws IOException {
+        JavaADAMRecordRDD recordRdd = new JavaADAMRecordRDD(rdd);
+
+        // make temp directory and save file
+        Path tempDir = Files.createTempDirectory("javaAC");
+        String fileName = tempDir.toString() + "/testRdd";
+        recordRdd.adamSave(fileName);
+
+        // create a new adam context and load the file
+        JavaADAMContext jac = new JavaADAMContext(rdd.context());
+        return jac.adamRecordLoad(fileName);
+    }
+}

--- a/adam-apis/src/test/resources/small.sam
+++ b/adam-apis/src/test/resources/small.sam
@@ -1,0 +1,1 @@
+../../../../adam-core/src/test/resources/small.sam

--- a/adam-apis/src/test/scala/org/bdgenomics/adam/apis/java/JavaADAMContextSuite.scala
+++ b/adam-apis/src/test/scala/org/bdgenomics/adam/apis/java/JavaADAMContextSuite.scala
@@ -1,0 +1,45 @@
+/**
+ * Licensed to Big Data Genomics (BDG) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The BDG licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.bdgenomics.adam.apis.java
+
+import org.apache.spark.rdd.RDD
+import org.apache.spark.api.java.JavaRDD._
+import org.apache.spark.api.java.JavaRDD
+import org.bdgenomics.adam.predicates.HighQualityReadPredicate
+import org.bdgenomics.adam.rdd.ADAMContext._
+import org.bdgenomics.adam.util.SparkFunSuite
+import org.bdgenomics.formats.avro.ADAMRecord
+
+class JavaADAMContextSuite extends SparkFunSuite {
+
+  sparkTest("can read a small .SAM file") {
+    val path = ClassLoader.getSystemClassLoader.getResource("small.sam").getFile
+    val ctx = new JavaADAMContext(sc)
+    val reads: JavaADAMRecordRDD = ctx.adamRecordLoad[HighQualityReadPredicate](path)
+    assert(reads.jrdd.count() === 20)
+  }
+
+  sparkTest("can read a small .SAM file inside of java") {
+    val path = ClassLoader.getSystemClassLoader.getResource("small.sam").getFile
+    val reads: RDD[ADAMRecord] = sc.adamLoad(path)
+
+    val newReads: JavaADAMRecordRDD = JavaADAMConduit.conduit(reads)
+
+    assert(newReads.jrdd.count() === 20)
+  }
+}

--- a/adam-core/src/main/scala/org/bdgenomics/adam/rdd/ADAMContext.scala
+++ b/adam-core/src/main/scala/org/bdgenomics/adam/rdd/ADAMContext.scala
@@ -96,6 +96,8 @@ object ADAMContext {
 
   implicit def mapToJavaMap[A, B](map: Map[A, B]): java.util.Map[A, B] = mapAsJavaMap(map)
 
+  implicit def javaMapToMap[A, B](map: java.util.Map[A, B]): Map[A, B] = mapAsScalaMap(map).toMap
+
   implicit def iterableToJavaCollection[A](i: Iterable[A]): java.util.Collection[A] = asJavaCollection(i)
 
   implicit def setToJavaSet[A](set: Set[A]): java.util.Set[A] = setAsJavaSet(set)
@@ -158,7 +160,7 @@ object ADAMContext {
   }
 }
 
-class ADAMContext(sc: SparkContext) extends Serializable with Logging {
+class ADAMContext(val sc: SparkContext) extends Serializable with Logging {
 
   private def adamBamDictionaryLoad(filePath: String): SequenceDictionary = {
     val samHeader = SAMHeaderReader.readSAMHeaderFrom(new Path(filePath), sc.hadoopConfiguration)
@@ -167,7 +169,6 @@ class ADAMContext(sc: SparkContext) extends Serializable with Logging {
 
   private def adamBamDictionaryLoad(samHeader: SAMFileHeader): SequenceDictionary = {
     SequenceDictionary(samHeader)
-
   }
 
   private def adamBamLoadReadGroups(samHeader: SAMFileHeader): RecordGroupDictionary = {

--- a/adam-core/src/main/scala/org/bdgenomics/adam/rdd/ADAMRDDFunctions.scala
+++ b/adam-core/src/main/scala/org/bdgenomics/adam/rdd/ADAMRDDFunctions.scala
@@ -69,7 +69,7 @@ class ADAMRDDFunctions[T <% SpecificRecord: Manifest](rdd: RDD[T]) extends Seria
 
   def adamSave(filePath: String, blockSize: Int = 128 * 1024 * 1024,
                pageSize: Int = 1 * 1024 * 1024, compressCodec: CompressionCodecName = CompressionCodecName.GZIP,
-               disableDictionaryEncoding: Boolean = false): RDD[T] = {
+               disableDictionaryEncoding: Boolean = false) {
     val job = HadoopUtil.newJob(rdd.context)
     ParquetLogger.hadoopLoggerLevel(Level.SEVERE)
     ParquetOutputFormat.setCompression(job, compressCodec)
@@ -83,8 +83,6 @@ class ADAMRDDFunctions[T <% SpecificRecord: Manifest](rdd: RDD[T]) extends Seria
     recordToSave.saveAsNewAPIHadoopFile(filePath,
       classOf[java.lang.Void], manifest[T].runtimeClass.asInstanceOf[Class[T]], classOf[AvroParquetOutputFormat],
       ContextUtil.getConfiguration(job))
-    // Return the origin rdd
-    rdd
   }
 
 }

--- a/pom.xml
+++ b/pom.xml
@@ -30,6 +30,7 @@
 
     <modules>
         <module>adam-core</module>
+        <module>adam-apis</module>
         <module>adam-cli</module>
     </modules>
 


### PR DESCRIPTION
Just taking a step towards Java language "bindings"... these will support the native Java language type/container classes. The big push for this is to allow Python (and possibly R eventually?) bindings.
