### PR TITLE
Adding code coverage collection

### DIFF
--- a/adam-cli/pom.xml
+++ b/adam-cli/pom.xml
@@ -117,10 +117,27 @@
           </execution>
         </executions>
       </plugin>
+      <plugin>
+        <groupId>org.scoverage</groupId>
+        <artifactId>maven-scoverage-plugin</artifactId>
+        <version>${scoverage.version}</version>
+        <executions>
+          <execution>
+            <id>test</id>
+            <goals>
+              <goal>report</goal>
+            </goals>
+          </execution>
+        </executions>
+      </plugin>
     </plugins>
   </build>
 
   <dependencies>
+    <dependency>
+      <groupId>org.scoverage</groupId>
+      <artifactId>scalac-scoverage-plugin_${scala.artifact.suffix}</artifactId>
+    </dependency>
     <dependency>
       <groupId>org.bdgenomics.bdg-formats</groupId>
       <artifactId>bdg-formats</artifactId>

--- a/adam-core/pom.xml
+++ b/adam-core/pom.xml
@@ -107,10 +107,27 @@
           </execution>
         </executions>
       </plugin>
+      <plugin>
+        <groupId>org.scoverage</groupId>
+        <artifactId>maven-scoverage-plugin</artifactId>
+        <version>${scoverage.version}</version>
+        <executions>
+          <execution>
+            <id>test</id>
+            <goals>
+              <goal>report</goal>
+            </goals>
+          </execution>
+        </executions>
+      </plugin>
     </plugins>
   </build>
 
   <dependencies>
+    <dependency>
+      <groupId>org.scoverage</groupId>
+      <artifactId>scalac-scoverage-plugin_${scala.artifact.suffix}</artifactId>
+    </dependency>
     <dependency>
       <groupId>org.bdgenomics.bdg-formats</groupId>
       <artifactId>bdg-formats</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -26,6 +26,7 @@
     <parquet.version>1.4.3</parquet.version>
     <!-- Edit the following line to configure the Hadoop (HDFS) version. -->
     <hadoop.version>2.2.0</hadoop.version>
+    <scoverage.version>0.99.2</scoverage.version>
   </properties>
   
   <modules>
@@ -217,8 +218,16 @@
             <id>scala-compile-first</id>
             <phase>process-resources</phase>
             <goals>
+              <goal>add-source</goal>
               <goal>compile</goal>
             </goals>
+            <configuration>
+              <args>
+                <arg>-g:vars</arg>
+                <arg>-Yrangepos</arg>
+                <arg>-P:scoverage:dataDir:${project.build.directory}</arg>
+              </args>
+            </configuration>
           </execution>
           <execution>
             <id>scala-test-compile-first</id>
@@ -255,6 +264,13 @@
             <javacArg>-target</javacArg>
             <javacArg>${java.version}</javacArg>
           </javacArgs>
+          <compilerPlugins>
+            <compilerPlugin>
+              <groupId>org.scoverage</groupId>
+              <artifactId>scalac-scoverage-plugin_${scala.artifact.suffix}</artifactId>
+              <version>${scoverage.version}</version>
+            </compilerPlugin>
+          </compilerPlugins>
         </configuration>
       </plugin>
       <plugin>
@@ -287,6 +303,11 @@
   
   <dependencyManagement>
     <dependencies>
+      <dependency>
+        <groupId>org.scoverage</groupId>
+        <artifactId>scalac-scoverage-plugin_${scala.artifact.suffix}</artifactId>
+        <version>${scoverage.version}</version>
+      </dependency>
       <dependency>
         <groupId>org.bdgenomics.bdg-formats</groupId>
         <artifactId>bdg-formats</artifactId>


### PR DESCRIPTION
Adds code coverage collection via [scoverage](https://github.com/scoverage/maven-scoverage-plugin).

This change is two commits:
1. Reformated pom.xml files to use two spaces per indent, as per the [Maven conventions](http://maven.apache.org/developers/conventions/code.html)
2. Added code coverage collection
