### PR TITLE
Adding scripts for publishing scaladoc.

### DIFF
--- a/scripts/publish-scaladoc.sh
+++ b/scripts/publish-scaladoc.sh
@@ -1,0 +1,36 @@
+#!/bin/bash
+
+# get current sha1
+sha1=$(git log -1 --pretty=format:%H)
+
+# generate scaladoc
+mvn scala:doc
+
+# get current scaladoc dir
+scaladoc=${PWD}/adam-core/target/site/scaladocs/
+
+# clone repo
+git clone git@github.com:bigdatagenomics/bigdatagenomics.github.io.git
+
+# get maven artifact version
+version=$(mvn org.apache.maven.plugins:maven-help-plugin:2.1.1:evaluate -Dexpression=project.version | grep -v "\[")
+
+# clean and make new dir
+bdgscaladocdir=${PWD}/bigdatagenomics.github.io/projects/adam/scaladoc/${version}
+rm -rf ${bdgscaladocdir}
+mkdir -p ${bdgscaladocdir}
+
+# copy scaladoc over
+cp -rv ${scaladoc}/* ${bdgscaladocdir}
+
+# step into repo
+cd bigdatagenomics.github.io
+
+# mark for add and commit
+git add projects/adam/scaladoc/${version}/*
+git commit -m "Adding scaladoc for ADAM commit ${sha1}."
+git push origin master
+
+# clean up bdg repo
+cd ..
+rm -rf bigdatagenomics.github.io


### PR DESCRIPTION
Adds a simple script that pushes scaladoc to the [BDG/ADAM website](http://bdgenomics.org/projects/adam/). E.g., for 0.12.1-SNAPSHOT, the docs are [here](http://bdgenomics.org/projects/adam/scaladoc/0.12.1-SNAPSHOT/index.html). Once this merges, I will set up Jenkins to publish scaladoc for every merge.
