### PR TITLE
Remove extraneous implicit methods in ReferenceMappingContext

### DIFF
--- a/adam-core/src/main/scala/org/bdgenomics/adam/rich/ReferenceMappingContext.scala
+++ b/adam-core/src/main/scala/org/bdgenomics/adam/rich/ReferenceMappingContext.scala
@@ -45,10 +45,4 @@ object ReferenceMappingContext {
 
     def getReferenceRegion(value: ReferenceRegion): ReferenceRegion = value
   }
-
-  implicit def adamRecordToReferenceMapped(rec: ADAMRecord): ReferenceMapping[ADAMRecord] =
-    ADAMRecordReferenceMapping
-
-  implicit def referenceRegionToReferenceMapped(reg: ReferenceRegion): ReferenceMapping[ReferenceRegion] =
-    ReferenceRegionReferenceMapping
 }


### PR DESCRIPTION
Addresses @laserson's comments on the mailing list about these methods being useless. ADAM builds without them.
