### PR TITLE
Make mismatch and deletes positions accessible

### DIFF
--- a/adam-core/src/main/scala/org/bdgenomics/adam/util/MdTag.scala
+++ b/adam-core/src/main/scala/org/bdgenomics/adam/util/MdTag.scala
@@ -286,9 +286,9 @@ object MdTag {
 }
 
 class MdTag(
-    private val matches: immutable.List[NumericRange[Long]],
-    private val mismatches: immutable.Map[Long, Char],
-    private val deletes: immutable.Map[Long, Char]) {
+    val matches: immutable.List[NumericRange[Long]],
+    val mismatches: immutable.Map[Long, Char],
+    val deletes: immutable.Map[Long, Char]) {
 
   /**
    * Returns whether a base is a match against the reference.


### PR DESCRIPTION
Follow on from #329 - this is to be able to answer a question like "How many mismatches are with k bases of each other?"  I'd only need the mismatch positions for this, but I could imagine someone wanting to additionally query "How many mismatches are with k bases of each other and are they the same change?"

And very perhaps similarly with deletions, so I removed private from all of them, but we can do it piecemeal
