### PR TITLE
Moving code coverage into a profile

### DIFF
--- a/adam-cli/pom.xml
+++ b/adam-cli/pom.xml
@@ -94,19 +94,6 @@
           </execution>
         </executions>
       </plugin>
-      <plugin>
-        <groupId>org.scoverage</groupId>
-        <artifactId>maven-scoverage-plugin</artifactId>
-        <version>${scoverage.version}</version>
-        <executions>
-          <execution>
-            <id>test</id>
-            <goals>
-              <goal>report</goal>
-            </goals>
-          </execution>
-        </executions>
-      </plugin>
     </plugins>
   </build>
 
@@ -148,6 +135,26 @@
     </dependency>
   </dependencies>
   <profiles>
+    <profile>
+      <id>coverage</id>
+      <build>
+        <plugins>
+          <plugin>
+            <groupId>org.scoverage</groupId>
+            <artifactId>maven-scoverage-plugin</artifactId>
+            <version>${scoverage.version}</version>
+            <executions>
+              <execution>
+                <id>test</id>
+                <goals>
+                  <goal>report</goal>
+                </goals>
+              </execution>
+            </executions>
+          </plugin>
+        </plugins>
+      </build>
+    </profile>
     <profile>
       <id>default</id>
       <activation>

--- a/adam-core/pom.xml
+++ b/adam-core/pom.xml
@@ -107,19 +107,6 @@
           </execution>
         </executions>
       </plugin>
-      <plugin>
-        <groupId>org.scoverage</groupId>
-        <artifactId>maven-scoverage-plugin</artifactId>
-        <version>${scoverage.version}</version>
-        <executions>
-          <execution>
-            <id>test</id>
-            <goals>
-              <goal>report</goal>
-            </goals>
-          </execution>
-        </executions>
-      </plugin>
     </plugins>
   </build>
 
@@ -207,6 +194,26 @@
     </dependency>
   </dependencies>
   <profiles>
+    <profile>
+      <id>coverage</id>
+      <build>
+        <plugins>
+          <plugin>
+            <groupId>org.scoverage</groupId>
+            <artifactId>maven-scoverage-plugin</artifactId>
+            <version>${scoverage.version}</version>
+            <executions>
+              <execution>
+                <id>test</id>
+                <goals>
+                  <goal>report</goal>
+                </goals>
+              </execution>
+            </executions>
+          </plugin>
+        </plugins>
+      </build>
+    </profile>
     <profile>
       <id>default</id>
       <activation>

--- a/pom.xml
+++ b/pom.xml
@@ -218,14 +218,11 @@
             <id>scala-compile-first</id>
             <phase>process-resources</phase>
             <goals>
-              <goal>add-source</goal>
               <goal>compile</goal>
             </goals>
             <configuration>
               <args>
                 <arg>-g:vars</arg>
-                <arg>-Yrangepos</arg>
-                <arg>-P:scoverage:dataDir:${project.build.directory}</arg>
               </args>
             </configuration>
           </execution>
@@ -264,13 +261,6 @@
             <javacArg>-target</javacArg>
             <javacArg>${java.version}</javacArg>
           </javacArgs>
-          <compilerPlugins>
-            <compilerPlugin>
-              <groupId>org.scoverage</groupId>
-              <artifactId>scalac-scoverage-plugin_${scala.artifact.suffix}</artifactId>
-              <version>${scoverage.version}</version>
-            </compilerPlugin>
-          </compilerPlugins>
         </configuration>
       </plugin>
       <plugin>
@@ -458,6 +448,77 @@
   </dependencyManagement>
 
   <profiles>
+    <!-- Only build coverage in when we want to run coverage -->
+    <profile>
+      <id>coverage</id>
+      <build>
+        <plugins>
+          <plugin>
+            <groupId>net.alchim31.maven</groupId>
+            <artifactId>scala-maven-plugin</artifactId>
+            <executions>
+              <execution>
+                <id>scala-compile-first</id>
+                <phase>process-resources</phase>
+                <goals>
+                  <goal>add-source</goal>
+                  <goal>compile</goal>
+                </goals>
+                <configuration>
+                  <args>
+                    <arg>-g:vars</arg>
+                    <arg>-Yrangepos</arg>
+                    <arg>-P:scoverage:dataDir:${project.build.directory}</arg>
+                  </args>
+                </configuration>
+              </execution>
+              <execution>
+                <id>scala-test-compile-first</id>
+                <phase>process-test-resources</phase>
+                <goals>
+                  <goal>testCompile</goal>
+                </goals>
+              </execution>
+              <execution>
+                <id>attach-scaladocs</id>
+                <phase>verify</phase>
+                <goals>
+                  <goal>doc-jar</goal>
+                </goals>
+              </execution>
+            </executions>
+            <configuration>
+              <scalaVersion>${scala.version}</scalaVersion>
+              <recompileMode>incremental</recompileMode>
+              <useZincServer>true</useZincServer>
+              <args>
+                <arg>-unchecked</arg>
+                <arg>-optimise</arg>
+                <arg>-deprecation</arg>
+              </args>
+              <jvmArgs>
+                <jvmArg>-Xms64m</jvmArg>
+                <jvmArg>-Xms1024m</jvmArg>
+                <jvmArg>-Xmx1024m</jvmArg>
+              </jvmArgs>
+              <javacArgs>
+                <javacArg>-source</javacArg>
+                <javacArg>${java.version}</javacArg>
+                <javacArg>-target</javacArg>
+                <javacArg>${java.version}</javacArg>
+              </javacArgs>
+              <compilerPlugins>
+                <compilerPlugin>
+                  <groupId>org.scoverage</groupId>
+                  <artifactId>scalac-scoverage-plugin_${scala.artifact.suffix}</artifactId>
+                  <version>${scoverage.version}</version>
+                </compilerPlugin>
+              </compilerPlugins>
+            </configuration>
+          </plugin>
+        </plugins>
+      </build>
+    </profile>
     <!-- Only sign artifacts when we are performing a release, not snapshots -->
     <profile>
       <id>sonatype-oss-release</id>


### PR DESCRIPTION
Fixes #331. Adds a coverage profile, and removes scoverage from the default compile. This means that artifacts will not have any coverage tracking inserted by default.
