### PR TITLE
MdTag "MD:Z:0" not handled correctly

### DIFF
--- a/adam-core/src/test/scala/org/bdgenomics/adam/util/MdTagSuite.scala
+++ b/adam-core/src/test/scala/org/bdgenomics/adam/util/MdTagSuite.scala
@@ -52,6 +52,15 @@ class MdTagSuite extends FunSuite {
     }
   }
 
+  test("md tag, pure insertion") {
+    // example
+    // Cigar = 101I
+    // MD:Z:0
+    val tag = MdTag("0", 1L)
+    assert(tag.start() === 1L)
+    assert(tag.toString === "0")
+  }
+
   test("md tag equality and hashcode") {
     val md1 = MdTag("0A0", 0L)
     val md1Dup = MdTag("0A0", 0L)


### PR DESCRIPTION
Wanted to bring this up, the tag "MD:Z:0" is parsed in correctly, with no matches, mismatches, or deletions, but unfortunately tag.start() will throw an error as there are no matches and so will toString (which depends on start)  

This occurs if the Cigar is something like "101I", 101 inserted bases.

As far as I can see, there is no way to compute the start position from this other than saving the original start somewhere, not sure how to get the end position at all
