### PR TITLE
Allow retrying on failure for HTTPRangedByteAccess

### DIFF
--- a/adam-core/src/main/scala/org/bdgenomics/adam/io/HTTPFileLocator.scala
+++ b/adam-core/src/main/scala/org/bdgenomics/adam/io/HTTPFileLocator.scala
@@ -19,10 +19,10 @@ package org.bdgenomics.adam.io
 
 import java.net.URI
 
-class HTTPFileLocator(uri: URI) extends FileLocator {
+class HTTPFileLocator(uri: URI, retries: Int = 3) extends FileLocator {
   override def parentLocator(): Option[FileLocator] = ???
 
   override def relativeLocator(relativePath: String): FileLocator = ???
 
-  override def bytes: ByteAccess = new HTTPRangedByteAccess(uri)
+  override def bytes: ByteAccess = new HTTPRangedByteAccess(uri, retries)
 }

--- a/pom.xml
+++ b/pom.xml
@@ -442,7 +442,7 @@
       <dependency>
         <groupId>org.apache.httpcomponents</groupId>
         <artifactId>httpclient</artifactId>
-        <version>4.2.6</version>
+        <version>4.3.2</version>
       </dependency>
       <dependency>
         <groupId>com.netflix.servo</groupId>


### PR DESCRIPTION
The pushes the retry logic down into HTTPRangedByteAccess instead of in the tests; this allows us to also use this in the ParquetRDD class.
