### PR TITLE
Fix for a NullPointerException when hostname is null in Task Metrics

### DIFF
--- a/adam-core/src/main/scala/org/bdgenomics/adam/instrumentation/ADAMMetricsListener.scala
+++ b/adam-core/src/main/scala/org/bdgenomics/adam/instrumentation/ADAMMetricsListener.scala
@@ -42,7 +42,7 @@ class ADAMMetricsListener(val adamMetrics: ADAMMetrics) extends SparkListener {
     val taskInfo = Option(taskEnd.taskInfo)
 
     implicit val taskContext = TaskContext(
-      if (taskMetrics.isDefined) taskMetrics.get.hostname else "unknown",
+      if (taskMetrics.isDefined && taskMetrics.get.hostname != null) taskMetrics.get.hostname else "unknown",
       taskEnd.stageId)
 
     taskMetrics.foreach(e => {


### PR DESCRIPTION
If the hostname is null in the Spark Task Metrics, this causes the following NullPointerException:

java.lang.NullPointerException
    at com.google.common.base.Preconditions.checkNotNull(Preconditions.java:191)
    at com.google.common.collect.MapMakerInternalMap.putIfAbsent(MapMakerInternalMap.java:3507)
    at com.google.common.collect.Interners$WeakInterner.intern(Interners.java:85)
    at com.netflix.servo.tag.Tags.intern(Tags.java:33)
    at com.netflix.servo.tag.Tags.newTag(Tags.java:53)
    at org.bdgenomics.adam.instrumentation.TaskTimer$$anonfun$$plus$eq$1.apply(SparkMetrics.scala:184)
    at org.bdgenomics.adam.instrumentation.TaskTimer$$anonfun$$plus$eq$1.apply(SparkMetrics.scala:184)
    at scala.collection.mutable.MapLike$class.getOrElseUpdate(MapLike.scala:189)
    at scala.collection.mutable.AbstractMap.getOrElseUpdate(Map.scala:91)
    at org.bdgenomics.adam.instrumentation.TaskTimer.$plus$eq(SparkMetrics.scala:183)
    at org.bdgenomics.adam.instrumentation.ADAMMetricsListener.onTaskEnd(ADAMMetricsListener.scala:48)
<stack trace truncated>

It's not clear under what circumstances this happens, but I've seen it when a job was cancelled part-way through.
