### PR TITLE
[ADAM-357] Added Java Plugin hook for ADAM.

### DIFF
--- a/adam-apis/pom.xml
+++ b/adam-apis/pom.xml
@@ -74,6 +74,17 @@
           </execution>
         </executions>
       </plugin>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-jar-plugin</artifactId>
+        <executions>
+          <execution>
+            <goals>
+              <goal>test-jar</goal>
+            </goals>
+          </execution>
+        </executions>
+      </plugin>
     </plugins>
   </build>
 

--- a/adam-apis/src/main/scala/org/bdgenomics/adam/apis/java/JavaADAMPlugin.scala
+++ b/adam-apis/src/main/scala/org/bdgenomics/adam/apis/java/JavaADAMPlugin.scala
@@ -1,0 +1,75 @@
+/**
+ * Licensed to Big Data Genomics (BDG) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The BDG licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.bdgenomics.adam.apis.java
+
+import org.apache.avro.Schema
+import org.apache.spark.SparkContext
+import org.apache.spark.api.java.{ JavaRDD, JavaSparkContext }
+import org.apache.spark.rdd.RDD
+import org.bdgenomics.adam.plugins.ADAMPlugin
+import org.bdgenomics.adam.rdd.ADAMContext._
+
+private[java] abstract class JavaADAMPlugin[Input, Output] extends ADAMPlugin[Input, Output] with Serializable {
+  final override def projection: Option[Schema] = Option(recordProjection)
+
+  /**
+   * The fields of the input record that should be populated. If a projection should not
+   * be applied, this should be null. Code upstream will check for a null value, so this
+   * is safe.
+   *
+   * @return A schema describing the projection to apply to all records.
+   */
+  def recordProjection: Schema
+
+  final override def run(sc: SparkContext, recs: RDD[Input], args: String): RDD[Output] = {
+    run(new JavaSparkContext(sc), recs.toJavaRDD(), args)
+  }
+
+  /**
+   * Run method to be implemented by plugin implementor.
+   *
+   * @param jsc Java Spark Context that this plugin is running inside of.
+   * @param recs Input RDD of records.
+   * @param args Command line arguments passed to this plugin.
+   * @return Output RDD to be saved to disk.
+   */
+  def run(jsc: JavaSparkContext, recs: JavaRDD[Input], args: java.lang.String): JavaRDD[Output]
+}
+
+/**
+ * Plugins that seek to apply a predicate on the input records should extend
+ * this class.
+ */
+abstract class JavaADAMPluginWithPredicate[Input, Output] extends JavaADAMPlugin[Input, Output] {
+  final override def predicate: Option[Input => Boolean] = Some(recordPredicate)
+
+  /**
+   * The predicate function to apply on each input record.
+   *
+   * @param record The input record to push predicates down on.
+   * @return True if this should be filtered, else, false.
+   */
+  def recordPredicate(record: Input): java.lang.Boolean
+}
+
+/**
+ * Plugins that do not want to apply a predicate should extend this class.
+ */
+abstract class JavaADAMPluginWithoutPredicate[Input, Output] extends JavaADAMPlugin[Input, Output] {
+  final override def predicate: Option[Input => Boolean] = None
+}

--- a/adam-apis/src/test/java/org/bdgenomics/adam/apis/java/JavaTake10Plugin.java
+++ b/adam-apis/src/test/java/org/bdgenomics/adam/apis/java/JavaTake10Plugin.java
@@ -1,0 +1,38 @@
+/**
+ * Licensed to Big Data Genomics (BDG) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The BDG licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.bdgenomics.adam.apis.java;
+
+import org.apache.avro.Schema;
+import org.apache.spark.api.java.JavaRDD;
+import org.apache.spark.api.java.JavaSparkContext;
+import org.bdgenomics.formats.avro.AlignmentRecord;
+
+public class JavaTake10Plugin extends JavaADAMPluginWithoutPredicate<AlignmentRecord,AlignmentRecord> {
+    
+    @Override
+    public Schema recordProjection() {
+        return null;
+    }
+
+    @Override
+    public JavaRDD<AlignmentRecord> run(JavaSparkContext jsc,
+                                 JavaRDD<AlignmentRecord> recs,
+                                 String args) {
+        return jsc.parallelize(recs.take(10));
+    }
+}

--- a/adam-cli/pom.xml
+++ b/adam-cli/pom.xml
@@ -134,6 +134,16 @@
       <scope>test</scope>
     </dependency>
     <dependency>
+      <groupId>org.bdgenomics.adam</groupId>
+      <artifactId>adam-apis</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.bdgenomics.adam</groupId>
+      <artifactId>adam-apis</artifactId>
+      <type>test-jar</type>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
       <groupId>org.scala-lang</groupId>
       <artifactId>scala-library</artifactId>
     </dependency>

--- a/adam-cli/src/test/scala/org/bdgenomics/adam/cli/PluginExecutorSuite.scala
+++ b/adam-cli/src/test/scala/org/bdgenomics/adam/cli/PluginExecutorSuite.scala
@@ -45,6 +45,29 @@ class PluginExecutorSuite extends FunSuite {
     assert(outputString.lines.size === 10)
   }
 
+  test("java take10 works correctly on example SAM") {
+
+    val args = new PluginExecutorArgs()
+    args.plugin = "org.bdgenomics.adam.apis.java.JavaTake10Plugin"
+    val stream = Thread.currentThread().getContextClassLoader.getResourceAsStream("reads12.sam")
+    val file = File.createTempFile("reads12", ".sam")
+    val os = new FileOutputStream(file)
+    val bytes = new Array[Byte](stream.available())
+    stream.read(bytes)
+    os.write(bytes)
+    args.input = file.getAbsolutePath
+
+    val pluginExecutor = new PluginExecutor(args)
+
+    val bytesWritten = new ByteArrayOutputStream()
+    scala.Console.withOut(bytesWritten)(pluginExecutor.run())
+
+    val outputString = bytesWritten.toString
+
+    // Make sure that 10 lines are output
+    assert(outputString.lines.size === 10)
+  }
+
   test("takeN works correctly on example SAM with arg of '3'") {
 
     val args = new PluginExecutorArgs()

--- a/pom.xml
+++ b/pom.xml
@@ -341,6 +341,18 @@
         <scope>test</scope>
       </dependency>
       <dependency>
+        <groupId>org.bdgenomics.adam</groupId>
+        <artifactId>adam-apis</artifactId>
+        <version>${project.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>org.bdgenomics.adam</groupId>
+        <artifactId>adam-apis</artifactId>
+        <version>${project.version}</version>
+        <type>test-jar</type>
+        <scope>test</scope>
+      </dependency>
+      <dependency>
         <groupId>org.apache.hadoop</groupId>
         <artifactId>hadoop-client</artifactId>
         <version>${hadoop.version}</version>


### PR DESCRIPTION
Adds a Java plugin interface for ADAM. @heuermh this is my parallel solution to the Java plugin issues we'd corresponded about on IRC and email a week and a half ago (https://github.com/heuermh/adam-plugins/commit/2b03b8fb489a9167986eb2c05c421473a39e8e33). I'm interested in your thoughts; I think building the abstraction on the Scala side removes a lot of the ugly plumbing needed for Java<->Scala interop.
