### PR TITLE
Adding maven assembly plugin configuration to create tarballs

### DIFF
--- a/adam-cli/pom.xml
+++ b/adam-cli/pom.xml
@@ -33,6 +33,23 @@
           </execution>
         </executions>
       </plugin>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-assembly-plugin</artifactId>
+        <configuration>
+          <descriptors>
+            <descriptor>src/main/assembly/assembly.xml</descriptor>
+          </descriptors>
+        </configuration>
+        <executions>
+          <execution>
+            <phase>package</phase>
+            <goals>
+              <goal>assembly</goal>
+            </goals>
+          </execution>
+        </executions>
+      </plugin>
       <!-- disable surefire -->
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>

--- a/adam-cli/src/main/assembly/assembly.xml
+++ b/adam-cli/src/main/assembly/assembly.xml
@@ -1,0 +1,55 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<assembly xmlns="http://maven.apache.org/plugins/maven-assembly-plugin/assembly/1.1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="http://maven.apache.org/plugins/maven-assembly-plugin/assembly/1.1.2 http://maven.apache.org/xsd/assembly-1.1.2.xsd">
+  <id>bin</id>
+  <formats>
+    <format>tar.gz</format>
+    <format>tar.bz2</format>
+    <format>zip</format>
+  </formats>
+  <fileSets>
+<!--
+    <fileSet>
+      <includes>
+        <include>LICENSE.txt</include>
+        <include>NOTICE.txt</include>
+        <include>CHANGES.md</include>
+        <include>CONTRIBUTING.md</include>
+        <include>README.md</include>
+      </includes>
+      <outputDirectory>.</outputDirectory>
+    </fileSet>
+-->
+    <fileSet>
+      <directory>target/appassembler/bin</directory>
+      <outputDirectory>bin</outputDirectory>
+      <excludes>
+        <exclude>*.bat</exclude>
+      </excludes>
+      <directoryMode>0755</directoryMode>
+      <fileMode>0755</fileMode>
+    </fileSet>
+    <fileSet>
+      <directory>target/appassembler/bin</directory>
+      <outputDirectory>bin</outputDirectory>
+      <includes>
+        <include>*.bat</include>
+      </includes>
+      <directoryMode>0755</directoryMode>
+      <fileMode>0644</fileMode>
+    </fileSet>
+    <fileSet>
+      <directory>target/appassembler/repo</directory>
+      <outputDirectory>repo</outputDirectory>
+      <directoryMode>0755</directoryMode>
+      <fileMode>0644</fileMode>
+    </fileSet>
+  </fileSets>
+<!--
+  <dependencySets>
+    <dependencySet>
+      <outputDirectory>repo</outputDirectory>
+    </dependencySet>
+  </dependencySets>
+-->
+</assembly>

--- a/pom.xml
+++ b/pom.xml
@@ -69,6 +69,11 @@
       <plugins>
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
+          <artifactId>maven-assembly-plugin</artifactId>
+          <version>2.4.1</version>
+        </plugin>
+        <plugin>
+          <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-javadoc-plugin</artifactId>
           <version>2.9.1</version>
         </plugin>


### PR DESCRIPTION
Adding maven assembly plugin configuration to create .tar.gz, tar.bz2, and zip tarballs; see issue #316

I'm not sure which of the accessory files if any you would like added (e.g. README.md) so I left that commented out in assembly.xml.

E.g.
https://dl.dropboxusercontent.com/u/87680069/adam-cli-0.13.1-SNAPSHOT-bin.tar.bz2
