### PR TITLE
[ADAM-364] Fixing remaining cs.berkeley.edu URLs.

### DIFF
--- a/adam-core/src/test/scala/org/bdgenomics/adam/parquet_reimpl/AvroParquetRDDSuite.scala
+++ b/adam-core/src/test/scala/org/bdgenomics/adam/parquet_reimpl/AvroParquetRDDSuite.scala
@@ -211,7 +211,7 @@ class AvroParquetRDDSuite extends SparkFunSuite {
   }
 
   sparkTest("Retrieve records from a Parquet file through HTTP", silenceSpark = true, NetworkConnected) {
-    val locator = new HTTPFileLocator(URI.create("http://www.cs.berkeley.edu/~massie/adams/reads-0-2-0"))
+    val locator = new HTTPFileLocator(URI.create("https://s3.amazonaws.com/bdgenomics-test/reads-0-2-0"))
     val rdd = new AvroParquetRDD[AlignmentRecord](
       sc,
       null,
@@ -270,7 +270,7 @@ class AvroParquetRDDSuite extends SparkFunSuite {
 
     val schema = Projection(readName, start, contig)
 
-    val locator = new HTTPFileLocator(URI.create("http://www.cs.berkeley.edu/~massie/adams/reads-0-2-0"))
+    val locator = new HTTPFileLocator(URI.create("https://s3.amazonaws.com/bdgenomics-test/reads-0-2-0"))
     val rdd = new AvroParquetRDD[AlignmentRecord](
       sc,
       null,
@@ -336,7 +336,7 @@ class AvroParquetRDDSuite extends SparkFunSuite {
     val schema = Projection(readName, start, sequence)
     val filter = new ReadNameFilter("simread:1:189606653:true")
 
-    val locator = new HTTPFileLocator(URI.create("http://www.cs.berkeley.edu/~massie/adams/reads-0-2-0"))
+    val locator = new HTTPFileLocator(URI.create("https://s3.amazonaws.com/bdgenomics-test/reads-0-2-0"))
     val rdd = new AvroParquetRDD[AlignmentRecord](
       sc,
       filter,

--- a/adam-core/src/test/scala/org/bdgenomics/adam/parquet_reimpl/ParquetCommonSuite.scala
+++ b/adam-core/src/test/scala/org/bdgenomics/adam/parquet_reimpl/ParquetCommonSuite.scala
@@ -44,7 +44,7 @@ class ParquetCommonSuite extends FunSuite {
   }
 
   test("Reading a footer from HTTP", NetworkConnected) {
-    val byteAccess = new HTTPRangedByteAccess(URI.create("http://www.cs.berkeley.edu/~massie/adams/reads-0-2-0"))
+    val byteAccess = new HTTPRangedByteAccess(URI.create("https://s3.amazonaws.com/bdgenomics-test/reads-0-2-0"))
     val footer = ParquetCommon.readFooter(byteAccess)
     assert(footer.rowGroups.length === 1)
   }


### PR DESCRIPTION
There were a few tests in the network-connected (integration test) profile that were still using a cs.berkeley.edu URL to pull down test resources. I've replaced this with links to AWS for reliability.
