### PR TITLE
[ADAM-366] Add parallel region multi-join.

### DIFF
--- a/adam-core/src/main/scala/org/bdgenomics/adam/models/ReferenceRegion.scala
+++ b/adam-core/src/main/scala/org/bdgenomics/adam/models/ReferenceRegion.scala
@@ -168,6 +168,15 @@ case class ReferenceRegion(referenceName: String, start: Long, end: Long) extend
   def width: Long = end - start - 1
 
   /**
+   * From one reference region, creates reference positions spanning the region.
+   *
+   * @return Returns a seq of positions covering the region.
+   */
+  def toPositions(): Seq[ReferencePosition] = {
+    (start until end).map(i => ReferencePosition(referenceName, i))
+  }
+
+  /**
    * Merges two reference regions that are contiguous.
    *
    * @throws AssertionError Thrown if regions are not overlapping or adjacent.

--- a/adam-core/src/main/scala/org/bdgenomics/adam/rdd/ParallelRegionMultijoin.scala
+++ b/adam-core/src/main/scala/org/bdgenomics/adam/rdd/ParallelRegionMultijoin.scala
@@ -1,0 +1,194 @@
+/**
+ * Licensed to Big Data Genomics (BDG) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The BDG licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.bdgenomics.adam.rdd
+
+import org.apache.spark.SparkContext._
+import org.apache.spark.rdd.RDD
+import org.bdgenomics.adam.models.{ ReferenceMapping, ReferencePosition, ReferenceRegion }
+import scala.annotation.tailrec
+import scala.reflect.ClassTag
+
+object ParallelRegionMultijoin extends Serializable {
+
+  /**
+   * Multi-joins together two RDDs that contain objects that map to reference regions.
+   * The elements from the first RDD become the key of the output RDD, and the value
+   * contains all elements from the second RDD which overlap the region of the key.
+   * This is a multi-join, so it preserves n-to-m relationships between regions.
+   *
+   * @tparam T1 Type of the objects in the first RDD.
+   * @tparam T2 Type of the objects in the second RDD.
+   *
+   * @param rdd1 RDD of values
+   */
+  def overlapJoin[T1, T2](rdd1: RDD[T1],
+                          rdd2: RDD[T2])(implicit t1Mapping: ReferenceMapping[T1],
+                                         t2Mapping: ReferenceMapping[T2],
+                                         t1Manifest: ClassTag[T1],
+                                         t2Manifest: ClassTag[T2]): RDD[(T1, Iterable[T2])] = {
+    // map to join items and then cache
+    val jRdd1: RDD[Item] = rdd1.map(r => {
+      val i: Item = JoinItem(t1Mapping.getReferenceRegion(r), r)
+      i
+    })
+    val jRdd2: RDD[Item] = rdd2.map(r => {
+      val i: Item = JoinItem(t2Mapping.getReferenceRegion(r), r)
+      i
+    })
+    jRdd1.cache()
+    jRdd2.cache()
+
+    // generate the set of points that exist
+    val points = jRdd1.flatMap(i => {
+      // cast
+      val ji = i.asInstanceOf[JoinItem[T1]]
+
+      ji.r.toPositions.map(p => (p, (ji.r, true)))
+    }) ++ jRdd2.flatMap(i => {
+      // cast
+      val ji = i.asInstanceOf[JoinItem[T2]]
+
+      ji.r.toPositions.map(p => (p, (ji.r, false)))
+    })
+
+    // tail recursive helper function to see if a collection contains both true and false
+    // boolean values that opportunistically returns early
+    def hasTrueAndFalse(iter: Iterator[Boolean]): Boolean = {
+      @tailrec def hasTrueAndFalseHelper(iter: Iterator[Boolean],
+                                         b: Boolean): Boolean = {
+        if (!iter.hasNext) {
+          false
+        } else {
+          val curr = iter.next
+
+          if (curr != b) {
+            true
+          } else {
+            hasTrueAndFalseHelper(iter, curr)
+          }
+        }
+      }
+
+      // do we have elements?
+      if (iter.hasNext) {
+        val b = iter.next
+        hasTrueAndFalseHelper(iter, b)
+      } else {
+        false
+      }
+    }
+
+    // group the points by their position and filter all points where we don't
+    // have members from both original rdds
+    val overlappingPositions = points.groupByKey()
+      .filter(kv => hasTrueAndFalse(kv._2.map(p => p._2).toIterator))
+
+    // if we have points from both sets, are we at the earliest possible intersection point?
+    // if so, emit that region pair
+    val overlappingRegions: RDD[Item] = overlappingPositions.flatMap(kv => {
+      val (pos, regions) = kv
+      val firstRegions = regions.filter(p => p._2).map(p => p._1)
+      val secondRegions = regions.filter(p => !p._2).map(p => p._1)
+
+      firstRegions.flatMap(r1 => {
+        secondRegions.flatMap(r2 => {
+          if (r1.start == pos.pos || r2.start == pos.pos) {
+            val item: Item = RegionItem(r1, r2)
+            Some(item)
+          } else {
+            None
+          }
+        })
+      })
+    })
+
+    // create second rdd joined against
+    val firstJoinRdd: RDD[Item] = (jRdd2 ++ overlappingRegions.map(_.asInstanceOf[RegionItem].flip))
+      .groupBy(_.r)
+      .flatMap(kv => {
+        val (_, items) = kv
+
+        // do we have items to join at this site? if so, cartesian and return, else emit nullset
+        val joinItems = items.flatMap(i => i match {
+          case ji: JoinItem[T2] => Some(ji)
+          case _                => None
+        })
+        if (joinItems.size > 0) {
+          items.flatMap(i => i match {
+            case ri: RegionItem => Some(ri)
+            case _              => None
+          }).map(r => JoinedItem[T2](r.item, joinItems.map(_.item)))
+        } else {
+          Iterable[JoinedItem[T2]]()
+        }
+      })
+
+    // unpersist intermediate join rdds
+    jRdd2.unpersist()
+
+    // now, create final join rdd
+    val finalJoinRdd: RDD[(T1, Iterable[T2])] = (jRdd1 ++ firstJoinRdd)
+      .groupBy(_.r)
+      .flatMap(kv => {
+        val (_, items) = kv
+
+        // get our items of type 1 and of type 2
+        val firstClassItems: Iterable[T1] = items.flatMap(i => i match {
+          case ji: JoinItem[T1] => Some(ji.item)
+          case _                => None
+        })
+        val secondClassItems: Iterable[T2] = items.flatMap(i => i match {
+          case ji: JoinedItem[T2] => ji.items
+          case _                  => Iterable[T2]()
+        })
+        // the second class items aren't second class citizens, rather, they're class 2 out of {T1, T2}
+        // we do not begrudge their existance
+
+        // cartesian these good classes up, if we've got them
+        if (firstClassItems.size > 0 && secondClassItems.size > 0) {
+          firstClassItems.map(fci => (fci, secondClassItems))
+        } else {
+          Iterable[(T1, Iterable[T2])]()
+        }
+      })
+
+    // unpersist intermediate join rdd
+    jRdd1.unpersist()
+
+    // return
+    finalJoinRdd
+  }
+}
+
+class Item(val r: ReferenceRegion) extends Serializable {
+  override def toString: String = r.toString
+}
+
+case class JoinItem[T](override val r: ReferenceRegion, item: T) extends Item(r) {
+  override def toString: String = r.toString + ", " + item.toString
+}
+
+case class JoinedItem[T](override val r: ReferenceRegion, items: Iterable[T]) extends Item(r) {
+  override def toString: String = r.toString + ", (" + items.map(_.toString).reduce(_ + ", " + _) + ")"
+}
+
+case class RegionItem(override val r: ReferenceRegion, item: ReferenceRegion) extends Item(r) {
+  def flip: RegionItem = RegionItem(item, r)
+
+  override def toString: String = r.toString + ", " + item.toString
+}

--- a/adam-core/src/test/scala/org/bdgenomics/adam/models/ReferenceRegionSuite.scala
+++ b/adam-core/src/test/scala/org/bdgenomics/adam/models/ReferenceRegionSuite.scala
@@ -306,4 +306,15 @@ class ReferenceRegionSuite extends FunSuite {
     assert(ReferenceRegionWithOrientation("chr2", 200, 401, negativeStrand = false).width === 200)
     assert(ReferenceRegionWithOrientation("chr3", 399, 1000, negativeStrand = true).width === 600)
   }
+
+  test("can generate positions from a region") {
+    val rr = ReferenceRegion("chr1", 100, 201)
+    val rps = rr.toPositions
+
+    assert(rps.length === (rr.width + 1))
+    assert(rps.map(_.pos).distinct.length === rps.length)
+    assert(rps.map(_.pos).min === rr.start)
+    assert(rps.map(_.pos).max === rr.end - 1)
+    assert(rps.forall(_.referenceName == rr.referenceName))
+  }
 }

--- a/adam-core/src/test/scala/org/bdgenomics/adam/rdd/ParallelRegionMultijoinSuite.scala
+++ b/adam-core/src/test/scala/org/bdgenomics/adam/rdd/ParallelRegionMultijoinSuite.scala
@@ -1,0 +1,89 @@
+/**
+ * Licensed to Big Data Genomics (BDG) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The BDG licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.bdgenomics.adam.rdd
+
+import org.apache.spark.rdd.RDD
+import org.bdgenomics.adam.models.ReferenceRegion
+import org.bdgenomics.adam.rich.ReferenceMappingContext._
+import org.bdgenomics.adam.util.SparkFunSuite
+
+class ParallelRegionMultijoinSuite extends SparkFunSuite {
+
+  sparkTest("trying to join non-overlapping regions should result in no entries") {
+    val rdd1: RDD[ReferenceRegion] = sc.parallelize(Seq(ReferenceRegion("chr1", 100L, 200L),
+      ReferenceRegion("chr1", 400L, 600L)))
+    val rdd2: RDD[ReferenceRegion] = sc.parallelize(Seq(ReferenceRegion("chr2", 100L, 200L),
+      ReferenceRegion("chr2", 400L, 600L)))
+
+    assert(ParallelRegionMultijoin.overlapJoin(rdd1, rdd2).count === 0)
+  }
+
+  sparkTest("trivial join of perfectly overlapping regions should perform a 1-to-1 mapping") {
+    val rdd1: RDD[ReferenceRegion] = sc.parallelize(Seq(ReferenceRegion("chr1", 100L, 200L),
+      ReferenceRegion("chr1", 400L, 600L)))
+    val rdd2: RDD[ReferenceRegion] = sc.parallelize(Seq(ReferenceRegion("chr1", 100L, 200L),
+      ReferenceRegion("chr1", 400L, 600L)))
+
+    val j = ParallelRegionMultijoin.overlapJoin(rdd1, rdd2).collect
+
+    assert(j.size === 2)
+    assert(j.forall(p => p._2.size == 1))
+    assert(j.forall(p => p._1 == p._2.head))
+  }
+
+  sparkTest("test join with non-perfect overlapping regions") {
+    val rdd1: RDD[ReferenceRegion] = sc.parallelize(Seq(ReferenceRegion("chr1", 100L, 200L),
+      ReferenceRegion("chr1", 400L, 600L)))
+    val rdd2: RDD[ReferenceRegion] = sc.parallelize(Seq(ReferenceRegion("chr1", 150L, 250L),
+      ReferenceRegion("chr1", 300L, 500L)))
+
+    val j = ParallelRegionMultijoin.overlapJoin(rdd1, rdd2).collect
+
+    assert(j.size === 2)
+    assert(j.forall(p => p._2.size == 1))
+    assert(j.filter(p => p._1.start == 100L).size === 1)
+    assert(j.filter(p => p._1.start == 100L).head._2.size === 1)
+    assert(j.filter(p => p._1.start == 100L).head._2.head.start === 150L)
+    assert(j.filter(p => p._1.start == 400L).size === 1)
+    assert(j.filter(p => p._1.start == 400L).head._2.size === 1)
+    assert(j.filter(p => p._1.start == 400L).head._2.head.start === 300L)
+  }
+
+  sparkTest("basic multi-join") {
+    val rdd1: RDD[ReferenceRegion] = sc.parallelize(Seq(ReferenceRegion("chr1", 100L, 200L),
+      ReferenceRegion("chr1", 200L, 300L),
+      ReferenceRegion("chr1", 400L, 600L),
+      ReferenceRegion("chr1", 10000L, 20000L)))
+    val rdd2: RDD[ReferenceRegion] = sc.parallelize(Seq(ReferenceRegion("chr1", 150L, 250L),
+      ReferenceRegion("chr1", 300L, 500L),
+      ReferenceRegion("chr1", 500L, 700L),
+      ReferenceRegion("chr2", 100L, 200L)))
+
+    val j = ParallelRegionMultijoin.overlapJoin(rdd1, rdd2).collect
+
+    assert(j.size === 3)
+    assert(j.filter(p => p._1.start == 100L).size === 1)
+    assert(j.filter(p => p._1.start == 200L).size === 1)
+    assert(j.filter(p => p._1.start <= 200L).forall(p => p._2.size == 1))
+    assert(j.filter(p => p._1.start <= 200L).forall(p => p._2.head == ReferenceRegion("chr1", 150L, 250L)))
+    assert(j.filter(p => p._1.start == 400L).size === 1)
+    assert(j.filter(p => p._1.start == 400L).head._2.size === 2)
+    assert(j.filter(p => p._1.start == 400L).head._2.filter(_ == ReferenceRegion("chr1", 300L, 500L)).size === 1)
+    assert(j.filter(p => p._1.start == 400L).head._2.filter(_ == ReferenceRegion("chr1", 500L, 700L)).size === 1)
+  }
+}


### PR DESCRIPTION
This adds a region multi-join implementation that executes in parallel, as a possible replacement/accompaniment to #117. CC'ing @tdanford @carlyeks for review.

The parallel join implementation roughly follows the following process:
- We identify all regions that overlap across the two RDDs by projecting the regions down into positions. We keep the position that is the "lowest" point at which the two regions intersect. From this point, we then project the two intersecting regions as a key-value pair.
- From the KV pair RDD, we group-by with the right RDD in the join, which provides us with collections of elements that map to regions from the left RDD.
- We then union that RDD with the left RDD, and group-by the region that all points map to.
- From this RDD, for every region that has points from both the left and the right RDDs, we take a cartesian-ish product of the two sets.

This PR _could_ be merged in it's current state, but I'd like to refactor it a bit more. Specifically, it's sufficiently general to also support region contain multi-joins (e.g., we join all regions from the right RDD with regions from the left RDD that fully contain the region) with a small amount of refactoring. I'll take care of that in the next few days; just wanted to get this PR out there for comment.
