### PR TITLE
[ADAM-360] Upgrade to Spark 1.1.0.

### DIFF
--- a/adam-core/src/test/scala/org/bdgenomics/adam/parquet_reimpl/AvroParquetRDDSuite.scala
+++ b/adam-core/src/test/scala/org/bdgenomics/adam/parquet_reimpl/AvroParquetRDDSuite.scala
@@ -204,7 +204,7 @@ class AvroParquetRDDSuite extends SparkFunSuite {
 
     val value = rdd.first()
     assert(value != null)
-    assert(value.getReadName === "simread:1:26472783:false")
+    assert(value.getReadName.toString === "simread:1:26472783:false")
     assert(value.getStart === 26472783L)
 
     assert(rdd.count() === 200)
@@ -220,7 +220,7 @@ class AvroParquetRDDSuite extends SparkFunSuite {
 
     val value = rdd.first()
     assert(value != null)
-    assert(value.getReadName === "simread:1:26472783:false")
+    assert(value.getReadName.toString === "simread:1:26472783:false")
     assert(value.getStart === 26472783L)
 
     assert(rdd.count() === 200)
@@ -237,7 +237,7 @@ class AvroParquetRDDSuite extends SparkFunSuite {
 
     val value = rdd.first()
     assert(value != null)
-    assert(value.getReadName === "simread:1:26472783:false")
+    assert(value.getReadName.toString === "simread:1:26472783:false")
     assert(value.getStart === 26472783L)
 
     assert(rdd.count() === 200)
@@ -258,7 +258,7 @@ class AvroParquetRDDSuite extends SparkFunSuite {
 
     val value = rdd.first()
     assert(value != null)
-    assert(value.getReadName === "simread:1:26472783:false")
+    assert(value.getReadName.toString === "simread:1:26472783:false")
     assert(value.getStart === 26472783L)
 
     assert(rdd.count() === 200)
@@ -279,7 +279,7 @@ class AvroParquetRDDSuite extends SparkFunSuite {
 
     val value = rdd.first()
     assert(value != null)
-    assert(value.getReadName === "simread:1:26472783:false")
+    assert(value.getReadName.toString === "simread:1:26472783:false")
     assert(value.getStart === 26472783L)
 
     assert(rdd.count() === 200)
@@ -300,7 +300,7 @@ class AvroParquetRDDSuite extends SparkFunSuite {
 
     val value = rdd.first()
     assert(value != null)
-    assert(value.getReadName === "simread:1:26472783:false")
+    assert(value.getReadName.toString === "simread:1:26472783:false")
     assert(value.getStart === 26472783L)
 
     assert(rdd.count() === 200)
@@ -322,7 +322,7 @@ class AvroParquetRDDSuite extends SparkFunSuite {
 
     val value = rdd.first()
     assert(value != null)
-    assert(value.getReadName === "simread:1:189606653:true")
+    assert(value.getReadName.toString === "simread:1:189606653:true")
     assert(value.getStart === 189606653L)
 
     assert(rdd.collect().length === 1)
@@ -345,7 +345,7 @@ class AvroParquetRDDSuite extends SparkFunSuite {
 
     val value = rdd.first()
     assert(value != null)
-    assert(value.getReadName === "simread:1:189606653:true")
+    assert(value.getReadName.toString === "simread:1:189606653:true")
     assert(value.getStart === 189606653L)
 
     assert(rdd.collect().length === 1)
@@ -368,7 +368,7 @@ class AvroParquetRDDSuite extends SparkFunSuite {
 
     val value = rdd.first()
     assert(value != null)
-    assert(value.getReadName === "simread:1:189606653:true")
+    assert(value.getReadName.toString === "simread:1:189606653:true")
     assert(value.getStart === 189606653L)
 
     assert(rdd.collect().length === 1)

--- a/adam-core/src/test/scala/org/bdgenomics/adam/projections/FieldEnumerationSuite.scala
+++ b/adam-core/src/test/scala/org/bdgenomics/adam/projections/FieldEnumerationSuite.scala
@@ -80,7 +80,7 @@ class FieldEnumerationSuite extends SparkFunSuite with BeforeAndAfter {
     assert(reads1.count() === 200)
 
     val first1 = reads1.first()
-    assert(first1.getReadName === "simread:1:26472783:false")
+    assert(first1.getReadName.toString === "simread:1:26472783:false")
     assert(first1.getReadMapped === false)
 
     val p2 = Projection(AlignmentRecordField.readName, AlignmentRecordField.readMapped)
@@ -90,7 +90,7 @@ class FieldEnumerationSuite extends SparkFunSuite with BeforeAndAfter {
     assert(reads2.count() === 200)
 
     val first2 = reads2.first()
-    assert(first2.getReadName === "simread:1:26472783:false")
+    assert(first2.getReadName.toString === "simread:1:26472783:false")
     assert(first2.getReadMapped === true)
   }
 }

--- a/pom.xml
+++ b/pom.xml
@@ -21,7 +21,7 @@
     <scala.version>2.10.3</scala.version>
     <scala.artifact.suffix>2.10</scala.artifact.suffix>
     <avro.version>1.7.6</avro.version>
-    <spark.version>1.0.1</spark.version>
+    <spark.version>1.1.0</spark.version>
     <parquet.version>1.4.3</parquet.version>
     <!-- Edit the following line to configure the Hadoop (HDFS) version. -->
     <hadoop.version>2.2.0</hadoop.version>


### PR DESCRIPTION
Fixes #360.

Upgrades to Spark 1.1.0. This is API compatible with Spark 1.0.1, so no major changes were needed. The changes were restricted to our unit tests:
- Several unit tests were comparing the CharSequences that came out of Avro with Strings, and these tests started failing.
- Spark's [RangePartitioner](https://spark.apache.org/docs/1.1.0/api/scala/index.html#org.apache.spark.RangePartitioner) functionality changed slightly, such that you may not receive the full number of requested partitions, so I changed our test to acknowledge this.
