### PR TITLE
Fix the position of the jar path in the submit.

### DIFF
--- a/bin/adam-submit
+++ b/bin/adam-submit
@@ -48,8 +48,8 @@ fi
 
 # submit the job to Spark
 "$SPARK_SUBMIT" \
-  "$ADAM_CLI_JAR" \
   --class org.bdgenomics.adam.cli.ADAMMain \
   --properties-file "$ADAM_REPO"/bin/adam-spark-defaults.conf
   --jars "$ADAM_JARS" \
+  "$ADAM_CLI_JAR" \
   "$@"


### PR DESCRIPTION
This accordingly with the spark documentation: http://spark.apache.org/docs/latest/submitting-applications.html.

That is, the jar must come after the `options` like --master and so on, but mainly --class. Otherwise, no `main` can be found in the JAR.
