### PR TITLE
bump scalatest to 2.2.2

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -442,7 +442,7 @@
       <dependency>
         <groupId>org.scalatest</groupId>
         <artifactId>scalatest_${scala.artifact.suffix}</artifactId>
-        <version>1.9.2</version>
+        <version>2.2.2</version>
         <scope>test</scope>
       </dependency>
       <dependency>


### PR DESCRIPTION
mostly to pick up wildcard test-suite handling, e.g.:

```
$ mvn test -Dsuites="*MdTag*"
```

(hammerlab has a helper around this for even more convenience; see
https://github.com/hammerlab/internal-tools/blob/master/scripts/mvn-utils/mvn-test)
