### PR TITLE
Make Mdtags handle '=' and 'X' cigar operators

### DIFF
--- a/adam-core/src/main/scala/org/bdgenomics/adam/util/MdTag.scala
+++ b/adam-core/src/main/scala/org/bdgenomics/adam/util/MdTag.scala
@@ -262,7 +262,7 @@ object MdTag {
     // loop over all cigar elements
     cigar.getCigarElements.foreach(cigarElement => {
       cigarElement.getOperator match {
-        case CigarOperator.M => {
+        case CigarOperator.M | CigarOperator.EQ | CigarOperator.X => {
           for (i <- 0 until cigarElement.getLength) {
             if (read(readPos) == reference(refPos)) {
               matchCount += 1
@@ -416,19 +416,13 @@ class MdTag(
     // loop over all cigar elements
     cigar.getCigarElements.foreach(cigarElement => {
       cigarElement.getOperator match {
-        case CigarOperator.M => {
+        case CigarOperator.M | CigarOperator.EQ | CigarOperator.X => {
           // if we are a match, loop over bases in element
           for (i <- 0 until cigarElement.getLength) {
             // if a mismatch, get from the mismatch set, else pull from read
-            if (mismatches.contains(referencePos)) {
-              reference += {
-                mismatches.get(referencePos) match {
-                  case Some(base) => base
-                  case _          => throw new IllegalStateException("Could not find mismatching base at cigar offset" + i)
-                }
-              }
-            } else {
-              reference += readSequence(readPos)
+            mismatches.get(referencePos) match {
+              case Some(base) => reference += base
+              case _          => reference += readSequence(readPos)
             }
 
             readPos += 1

--- a/adam-core/src/test/scala/org/bdgenomics/adam/util/MdTagSuite.scala
+++ b/adam-core/src/test/scala/org/bdgenomics/adam/util/MdTagSuite.scala
@@ -367,43 +367,32 @@ class MdTagSuite extends FunSuite {
     assert(tag.toString === "8")
   }
 
+  def testTag(read: String,
+              reference: String,
+              cigarStr: String,
+              start: Long,
+              expectedTag: String,
+              expectedStart: Long,
+              expectedEnd: Long): Unit = {
+    val tag = MdTag(read, reference, CIGAR_CODEC.decode(cigarStr), start)
+    assert(tag.toString == expectedTag)
+    assert(tag.start == expectedStart)
+    assert(tag.end == expectedEnd)
+  }
+
   test("create new md tag from read vs. reference, perfect alignment match, 1 mismatch") {
-    val read = "ACCATAGA"
-    val reference = "ACAATAGA"
-    val cigar = CIGAR_CODEC.decode("8M")
-    val start = 0L
-
-    val tag = MdTag(read, reference, cigar, start)
-
-    assert(tag.toString === "2A5")
-    assert(tag.start === 0L)
-    assert(tag.end === 7L)
+    testTag("ACCATAGA", "ACAATAGA", "8M", 0, "2A5", 0, 7)
   }
 
   test("create new md tag from read vs. reference, alignment with deletion") {
-    val read = "ACCATAGA"
-    val reference = "ACCATTTAGA"
-    val cigar = CIGAR_CODEC.decode("5M2D3M")
-    val start = 5L
-
-    val tag = MdTag(read, reference, cigar, start)
-
-    assert(tag.toString === "5^TT3")
-    assert(tag.start === 5L)
-    assert(tag.end === 14L)
+    testTag("ACCATAGA", "ACCATTTAGA", "5M2D3M", 5, "5^TT3", 5, 14L)
   }
 
   test("create new md tag from read vs. reference, alignment with insert") {
-    val read = "ACCCATAGA"
-    val reference = "ACCATAGA"
-    val cigar = CIGAR_CODEC.decode("3M1I5M")
-    val start = 10L
-
-    val tag = MdTag(read, reference, cigar, start)
-
-    assert(tag.toString === "8")
-    assert(tag.start === 10L)
-    assert(tag.end === 17L)
+    testTag("ACCCATAGA", "ACCATAGA", "3M1I5M", 10, "8", 10, 17)
   }
 
+  test("handle '=' and 'X' operators") {
+    testTag("ACCCAAGT", "ACCATAGA", "3=2X2=1X", 0, "3A0T2A0", 0, 7)
+  }
 }


### PR DESCRIPTION
I'm getting some crashes downstream in Guacamole related to reconstructing a reference sequence from cigar+md tag strings where the cigar contains the '=' and 'X' operators; I assume they are currently not handled because it hasn't been necessary, as opposed to due to a conscious decision not to support them, so this adds support for them.
