### PR TITLE
Add Region Join based on interval trees

### DIFF
--- a/adam-core/src/main/scala/org/bdgenomics/adam/rdd/RegionMultijoin/IntervalForest.scala
+++ b/adam-core/src/main/scala/org/bdgenomics/adam/rdd/RegionMultijoin/IntervalForest.scala
@@ -1,0 +1,132 @@
+/**
+ * Licensed to Big Data Genomics (BDG) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The BDG licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.bdgenomics.adam.rdd.regionMultiJoin
+
+import org.bdgenomics.adam.models.ReferenceRegion
+import scala.annotation.tailrec
+
+class IntervalForest[T](allRegions: List[(ReferenceRegion, T)]) extends Serializable {
+  private val chromosomes = allRegions.collect { case x => x._1.referenceName }.distinct //get all chromosome names and build a tree for each chromosome
+  private val intervalTrees = chromosomes.map(x => {
+    val sameChrRegions = allRegions.filter(_._1.referenceName.equals(x))
+    (x, new Node(sameChrRegions))
+  }).toMap
+
+  def getAllOverlappings(r: ReferenceRegion) = {
+    val root = intervalTrees.get(r.referenceName)
+    root match {
+      case None     => Nil
+      case Some(rt) => allOverlappingRegions(r, rt)
+    }
+
+  }
+
+  /*Return the number of tree nodes for the input chromosome*/
+  def getTreeNodeCount(chr: String) = {
+    val root = intervalTrees.get(chr)
+    root match {
+      case None     => 0
+      case Some(rt) => countNodes(rt)
+    }
+  }
+
+  /*Return the height of the tree of a particular chromosome*/
+  def getTreeHeight(chr: String) = {
+    val root = intervalTrees.get(chr)
+    root match {
+      case None     => 0
+      case Some(rt) => treeHeight(rt)
+    }
+  }
+
+  private def allOverlappingRegions(r: ReferenceRegion, rt: Node): List[(ReferenceRegion, T)] = {
+    if (rt == null)
+      return Nil
+    val resultFromThisNode = r match {
+      case x if (rt.inclusiveIntervals == Nil) => Nil //Sometimes a node can have zero intervals
+      case x if (x.end < rt.minPointOfCollection || x.start > rt.maxPointOfCollection) => Nil //Save unnecessary filtering
+      case _ => rt.inclusiveIntervals.filter(t => r.overlaps(t._1))
+    }
+
+    if (r.overlaps(ReferenceRegion(r.referenceName, rt.centerPoint, rt.centerPoint + 1)))
+      return resultFromThisNode ++ allOverlappingRegions(r, rt.leftChild) ++ allOverlappingRegions(r, rt.rightChild)
+    else if (r.end <= rt.centerPoint)
+      return resultFromThisNode ++ allOverlappingRegions(r, rt.leftChild)
+    else if (r.start > rt.centerPoint)
+      return resultFromThisNode ++ allOverlappingRegions(r, rt.rightChild)
+    else throw new NoSuchElementException("Interval Tree Exception. Illegal comparison for centerpoint " + rt.centerPoint)
+
+  }
+
+  class Node(allRegions: List[(ReferenceRegion, T)]) {
+
+    private val largestPoint = allRegions.maxBy(_._1.end)._1.end
+    private val smallestPoint = allRegions.minBy(_._1.start)._1.start
+    val centerPoint = smallestPoint + (largestPoint - smallestPoint) / 2
+
+    val (inclusiveIntervals, leftChild, rightChild) = distributeRegions()
+    val minPointOfCollection: Long = inclusiveIntervals match {
+      case Nil => -1
+      case _   => inclusiveIntervals.minBy(_._1.start)._1.start
+    }
+
+    val maxPointOfCollection: Long = inclusiveIntervals match {
+      case Nil => -1
+      case _   => inclusiveIntervals.maxBy(_._1.end)._1.end
+    }
+
+    def distributeRegions() = {
+      var leftRegions: List[(ReferenceRegion, T)] = Nil
+      var rightRegions: List[(ReferenceRegion, T)] = Nil
+      var centerRegions: List[(ReferenceRegion, T)] = Nil
+
+      allRegions.foreach(x => {
+        if (x._1.end < centerPoint) leftRegions ::= x
+        else if (x._1.start > centerPoint) rightRegions ::= x
+        else centerRegions ::= x
+      })
+
+      val leftChild: Node = leftRegions match {
+        case Nil => null
+        case _   => new Node(leftRegions)
+      }
+
+      val rightChild: Node = rightRegions match {
+        case Nil => null
+        case _   => new Node(rightRegions)
+      }
+      (centerRegions, leftChild, rightChild)
+    }
+
+  }
+
+  private def countNodes(root: Node): Int = {
+    root match {
+      case null => 0
+      case _    => 1 + countNodes(root.leftChild) + countNodes(root.rightChild)
+    }
+  }
+
+  private def treeHeight(root: Node): Int = {
+    root match {
+      case null => -1
+      case _    => 1 + math.max(treeHeight(root.leftChild), treeHeight(root.rightChild))
+    }
+  }
+
+}

--- a/adam-core/src/main/scala/org/bdgenomics/adam/rdd/RegionMultijoin/YetAnotherRegionJoin.scala
+++ b/adam-core/src/main/scala/org/bdgenomics/adam/rdd/RegionMultijoin/YetAnotherRegionJoin.scala
@@ -1,0 +1,65 @@
+/**
+ * Licensed to Big Data Genomics (BDG) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The BDG licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.bdgenomics.adam.rdd.regionMultiJoin
+
+import org.apache.spark.rdd.RDD
+import org.bdgenomics.adam.models.ReferenceMapping
+import scala.reflect.ClassTag
+import org.apache.spark.SparkContext
+import org.apache.spark.SparkContext._
+
+object YetAnotherRegionJoin extends Serializable {
+
+  /**
+   * Multi-joins together two RDDs that contain objects that map to reference regions.
+   * The elements from the first RDD become the key of the output RDD, and the value
+   * contains all elements from the second RDD which overlap the region of the key.
+   * This is a multi-join, so it preserves n-to-m relationships between regions.
+   *
+   * @tparam T1 Type of the objects in the first RDD.
+   * @tparam T2 Type of the objects in the second RDD.
+   *
+   * @param sc A spark context from the cluster that will perform the join
+   * @param rdd1 RDD of values on which we build an interval tree. Assume |rdd1| < |rdd2|
+   */
+  def overlapJoin[T1, T2](sc: SparkContext,
+                          rdd1: RDD[T1],
+                          rdd2: RDD[T2])(implicit t1Mapping: ReferenceMapping[T1],
+                                         t2Mapping: ReferenceMapping[T2],
+                                         t1Manifest: ClassTag[T1],
+                                         t2Manifest: ClassTag[T2]): RDD[(T1, Iterable[T2])] = {
+
+    val indexedRdd1 = rdd1.zipWithIndex().map(_.swap)
+
+    /*Collect only Reference regions and the index of indexedRdd1*/
+    val localIntervals = indexedRdd1.map(x => (t1Mapping.getReferenceRegion(x._2), x._1)).collect()
+    /*Create and broadcast an interval tree*/
+    val intervalForest = sc.broadcast(new IntervalForest[Long](localIntervals.toList))
+
+    val kvrdd2 = rdd2.map(x => (intervalForest.value.getAllOverlappings(t2Mapping.getReferenceRegion(x)), x)) //join entry with the intervals returned from the interval tree
+      .filter(x => x._1 != Nil) //filter out entries that do not join anywhere
+      .flatMap(t => t._1.map(s => (s._2, t._2))) //create pairs of (index1, rdd2Elem)
+      .groupByKey
+
+    val ret = indexedRdd1
+      .join(kvrdd2) //join produces RDD[(Long, (T1, Iterable[T2]))]
+      .map(_._2) //end up with RDD[(T1, Iterable[T2])]
+    ret
+  }
+
+}

--- a/adam-core/src/test/scala/org/bdgenomics/adam/rdd/RegionMultijoin/IntervalForestSuite.scala
+++ b/adam-core/src/test/scala/org/bdgenomics/adam/rdd/RegionMultijoin/IntervalForestSuite.scala
@@ -1,0 +1,97 @@
+/**
+ * Licensed to Big Data Genomics (BDG) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The BDG licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.bdgenomics.adam.rdd.regionMultiJoin
+
+import org.scalatest.FunSuite
+import org.bdgenomics.adam.models.ReferenceRegion
+
+class IntervalForestSuite extends FunSuite {
+  test("Two nested symmetric intervals should produce only one tree node") {
+    val regions = List((ReferenceRegion("chr1", 10, 20), 1), (ReferenceRegion("chr1", 12, 18), 2))
+    val forest = new IntervalForest[Int](regions)
+
+    assert(forest.getTreeNodeCount("chr1") == 1)
+
+  }
+
+  test("Three independent intervals that produce 3 tree nodes") {
+    val regions = List((ReferenceRegion("chr1", 10, 20), 1), (ReferenceRegion("chr1", 30, 40), 2), (ReferenceRegion("chr1", 50, 60), 3))
+    val forest = new IntervalForest[Int](regions)
+
+    assert(forest.getTreeHeight("chr1") == 1)
+    assert(forest.getTreeNodeCount("chr1") == 3)
+  }
+
+  test("Queries against a collection of intervals1") {
+    val regions = List(
+      (ReferenceRegion("chr1", 10, 100), 1),
+      (ReferenceRegion("chr1", 80, 95), 2),
+      (ReferenceRegion("chr1", 20, 30), 3),
+      (ReferenceRegion("chr1", 15, 18), 4))
+
+    val forest = new IntervalForest[Int](regions)
+    val successful_q = ReferenceRegion("chr1", 25, 40)
+    val unsuccessful_q = ReferenceRegion("chr1", 104, 2014)
+
+    val successful_ans = forest.getAllOverlappings(successful_q)
+    val unsuccessful_ans = forest.getAllOverlappings(unsuccessful_q)
+
+    assert(successful_ans.length == 2)
+    assert(unsuccessful_ans.length == 0)
+
+  }
+
+  test("Queries against a collection of intervals across mutliple chromosomes") {
+    val regions = List(
+      (ReferenceRegion("chr1", 100L, 199L), 1),
+      (ReferenceRegion("chr1", 200L, 299L), 2),
+      (ReferenceRegion("chr1", 400L, 600L), 3),
+      (ReferenceRegion("chr2", 1000L, 2000L), 4),
+      (ReferenceRegion("chr13", 100L, 199L), 5),
+      (ReferenceRegion("chr13", 200L, 299L), 6),
+      (ReferenceRegion("chr13", 400L, 600L), 7))
+
+    val forest = new IntervalForest[Int](regions)
+
+    val s1 = forest.getAllOverlappings(ReferenceRegion("chr1", 150L, 250L))
+    val s2 = forest.getAllOverlappings(ReferenceRegion("chr1", 300L, 500L))
+    val s3 = forest.getAllOverlappings(ReferenceRegion("chr1", 500L, 700L))
+    val s4 = forest.getAllOverlappings(ReferenceRegion("chr2", 1400L, 1600L))
+    val t1 = forest.getAllOverlappings(ReferenceRegion("chr13", 150L, 250L))
+    val t2 = forest.getAllOverlappings(ReferenceRegion("chr13", 300L, 500L))
+    val t3 = forest.getAllOverlappings(ReferenceRegion("chr13", 500L, 700L))
+    val noGo1 = forest.getAllOverlappings(ReferenceRegion("chr1", 1400L, 1600L))
+    val noGo2 = forest.getAllOverlappings(ReferenceRegion("chr14", 300L, 500L))
+    val noGo3 = forest.getAllOverlappings(ReferenceRegion("chr22", 500L, 700L))
+
+    assert(s1.length == 2)
+    assert(s2.length == 1)
+    assert(s3.length == 1)
+    assert(s4.length == 1)
+
+    assert(t1.length == 2)
+    assert(t2.length == 1)
+    assert(t3.length == 1)
+
+    assert(noGo1.length == 0)
+    assert(noGo2.length == 0)
+    assert(noGo3.length == 0)
+
+  }
+
+}

--- a/adam-core/src/test/scala/org/bdgenomics/adam/rdd/RegionMultijoin/YetAnotherRegionJoinSuite.scala
+++ b/adam-core/src/test/scala/org/bdgenomics/adam/rdd/RegionMultijoin/YetAnotherRegionJoinSuite.scala
@@ -1,0 +1,92 @@
+/**
+ * Licensed to Big Data Genomics (BDG) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The BDG licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.bdgenomics.adam.rdd.regionMultiJoin
+
+import org.bdgenomics.adam.util.SparkFunSuite
+import org.apache.spark.rdd.RDD
+import org.bdgenomics.adam.models.ReferenceRegion
+import org.bdgenomics.adam.rich.ReferenceMappingContext._
+
+class YetAnotherRegionJoinSuite extends SparkFunSuite {
+  sparkTest("joining non overlap regions results into no entries") {
+
+    val rdd1: RDD[ReferenceRegion] = sc.parallelize(Seq(
+      ReferenceRegion("chr1", 100L, 200L),
+      ReferenceRegion("chr1", 400L, 600L),
+      ReferenceRegion("chr1", 700L, 800L),
+      ReferenceRegion("chr1", 900L, 1000L)))
+
+    val rdd2: RDD[ReferenceRegion] = sc.parallelize(Seq(
+      ReferenceRegion("chr2", 100L, 200L),
+      ReferenceRegion("chr2", 400L, 600L),
+      ReferenceRegion("chr1", 1100L, 1200L),
+      ReferenceRegion("chr1", 1400L, 1600L)))
+
+    assert(YetAnotherRegionJoin.overlapJoin(sc, rdd1, rdd2).count == 0)
+  }
+
+  sparkTest("test join with non-perfect overlapping regions") {
+    val rdd1: RDD[ReferenceRegion] = sc.parallelize(Seq(
+      ReferenceRegion("chr1", 100L, 200L),
+      ReferenceRegion("chr1", 400L, 600L),
+      ReferenceRegion("chr1", 700L, 800L),
+      ReferenceRegion("chr1", 900L, 1000L)), 2)
+
+    val rdd2: RDD[ReferenceRegion] = sc.parallelize(Seq(
+      ReferenceRegion("chr1", 150L, 250L),
+      ReferenceRegion("chr1", 300L, 500L),
+      ReferenceRegion("chr1", 1100L, 1200L),
+      ReferenceRegion("chr1", 1400L, 1600L)), 2)
+
+    val j = YetAnotherRegionJoin.overlapJoin(sc, rdd1, rdd2).collect
+
+    assert(j.size === 2)
+    assert(j.forall(p => p._2.size == 1))
+    assert(j.filter(p => p._1.start == 100L).size === 1)
+    assert(j.filter(p => p._1.start == 100L).head._2.size === 1)
+    assert(j.filter(p => p._1.start == 100L).head._2.head.start === 150L)
+    assert(j.filter(p => p._1.start == 400L).size === 1)
+    assert(j.filter(p => p._1.start == 400L).head._2.size === 1)
+    assert(j.filter(p => p._1.start == 400L).head._2.head.start === 300L)
+  }
+
+  sparkTest("basic multi-join") {
+    val rdd1: RDD[ReferenceRegion] = sc.parallelize(Seq(ReferenceRegion("chr1", 100L, 199L),
+      ReferenceRegion("chr1", 200L, 299L),
+      ReferenceRegion("chr1", 400L, 600L),
+      ReferenceRegion("chr1", 10000L, 20000L)))
+
+    val rdd2: RDD[ReferenceRegion] = sc.parallelize(Seq(ReferenceRegion("chr1", 150L, 250L),
+      ReferenceRegion("chr1", 300L, 500L),
+      ReferenceRegion("chr1", 500L, 700L),
+      ReferenceRegion("chr2", 100L, 200L)))
+
+    val j = YetAnotherRegionJoin.overlapJoin(sc, rdd1, rdd2).collect
+
+    assert(j.size === 3)
+    assert(j.filter(p => p._1.start == 100L).size === 1)
+    assert(j.filter(p => p._1.start == 200L).size === 1)
+    assert(j.filter(p => p._1.start <= 200L).forall(p => p._2.size == 1))
+    assert(j.filter(p => p._1.start <= 200L).forall(p => p._2.head == ReferenceRegion("chr1", 150L, 250L)))
+    assert(j.filter(p => p._1.start == 400L).size === 1)
+    assert(j.filter(p => p._1.start == 400L).head._2.size === 2)
+    assert(j.filter(p => p._1.start == 400L).head._2.filter(_ == ReferenceRegion("chr1", 300L, 500L)).size === 1)
+    assert(j.filter(p => p._1.start == 400L).head._2.filter(_ == ReferenceRegion("chr1", 500L, 700L)).size === 1)
+  }
+
+}


### PR DESCRIPTION
This is an interval tree based join in the spirit of #366. I haven't tested it at scale yet so I don't know as of now which one is more efficient... Just I bring this implementation for your consideration. 

I create an interval tree from all regions of rdd1 which I broadcast to all nodes and I query the tree with all entries of rdd2. 

Note that the interval tree uses metadata only, not all contents of rdd1. I keep track of the correspondence between the contents of interval tree and rdd1 through a collection of keys that I zipped with rdd1.