### PR TITLE
[ADAM-237] Migrate to Chill serialization libraries.

### DIFF
--- a/adam-core/pom.xml
+++ b/adam-core/pom.xml
@@ -116,6 +116,22 @@
       <artifactId>kryo</artifactId>
     </dependency>
     <dependency>
+      <groupId>com.twitter</groupId>
+      <artifactId>chill-avro</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>com.twitter</groupId>
+      <artifactId>chill-bijection_${scala.artifact.suffix}</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>com.twitter</groupId>
+      <artifactId>bijection-avro_${scala.artifact.suffix}</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>com.twitter</groupId>
+      <artifactId>chill_${scala.artifact.suffix}</artifactId>
+    </dependency>
+    <dependency>
       <groupId>org.scoverage</groupId>
       <artifactId>scalac-scoverage-plugin_${scala.artifact.suffix}</artifactId>
     </dependency>

--- a/adam-core/src/main/scala/org/bdgenomics/adam/models/ReadBucket.scala
+++ b/adam-core/src/main/scala/org/bdgenomics/adam/models/ReadBucket.scala
@@ -19,7 +19,7 @@ package org.bdgenomics.adam.models
 
 import com.esotericsoftware.kryo.{ Kryo, Serializer }
 import com.esotericsoftware.kryo.io.{ Input, Output }
-import org.bdgenomics.adam.serialization.AvroSerializer
+import com.twitter.chill.avro.AvroSerializer
 import org.bdgenomics.formats.avro.AlignmentRecord
 
 /**
@@ -48,7 +48,7 @@ case class ReadBucket(unpairedPrimaryMappedReads: Iterable[AlignmentRecord] = Se
 }
 
 class ReadBucketSerializer extends Serializer[ReadBucket] {
-  val recordSerializer = new AvroSerializer[AlignmentRecord]()
+  val recordSerializer = AvroSerializer.SpecificRecordSerializer[AlignmentRecord]
 
   def writeArray(kryo: Kryo, output: Output, reads: Iterable[AlignmentRecord]): Unit = {
     output.writeInt(reads.size, true)

--- a/adam-core/src/main/scala/org/bdgenomics/adam/models/SingleReadBucket.scala
+++ b/adam-core/src/main/scala/org/bdgenomics/adam/models/SingleReadBucket.scala
@@ -21,7 +21,7 @@ import org.bdgenomics.formats.avro.AlignmentRecord
 
 import com.esotericsoftware.kryo.{ Kryo, Serializer }
 import com.esotericsoftware.kryo.io.{ Output, Input }
-import org.bdgenomics.adam.serialization.AvroSerializer
+import com.twitter.chill.avro.AvroSerializer
 import org.apache.spark.Logging
 import org.apache.spark.rdd.RDD
 
@@ -51,7 +51,7 @@ case class SingleReadBucket(primaryMapped: Iterable[AlignmentRecord] = Seq.empty
 }
 
 class SingleReadBucketSerializer extends Serializer[SingleReadBucket] {
-  val recordSerializer = new AvroSerializer[AlignmentRecord]()
+  val recordSerializer = AvroSerializer.SpecificRecordSerializer[AlignmentRecord]
 
   def writeArray(kryo: Kryo, output: Output, reads: Seq[AlignmentRecord]): Unit = {
     output.writeInt(reads.size, true)

--- a/adam-core/src/main/scala/org/bdgenomics/adam/serialization/ADAMKryoRegistrator.scala
+++ b/adam-core/src/main/scala/org/bdgenomics/adam/serialization/ADAMKryoRegistrator.scala
@@ -19,61 +19,23 @@ package org.bdgenomics.adam.serialization
 
 import com.esotericsoftware.kryo.{ Kryo, Serializer }
 import com.esotericsoftware.kryo.io.{ Input, Output }
-import it.unimi.dsi.fastutil.io.{ FastByteArrayInputStream, FastByteArrayOutputStream }
-import org.apache.avro.io.{ BinaryDecoder, DecoderFactory, BinaryEncoder, EncoderFactory }
-import org.apache.avro.specific.{ SpecificDatumWriter, SpecificDatumReader, SpecificRecord }
+import com.twitter.chill.avro.AvroSerializer
 import org.apache.spark.serializer.KryoRegistrator
 import org.bdgenomics.formats.avro._
 import org.bdgenomics.adam.models._
 import org.bdgenomics.adam.rdd.read.realignment._
 import scala.reflect.ClassTag
 
-case class InputStreamWithDecoder(size: Int) {
-  val buffer = new Array[Byte](size)
-  val stream = new FastByteArrayInputStream(buffer)
-  val decoder = DecoderFactory.get().directBinaryDecoder(stream, null.asInstanceOf[BinaryDecoder])
-}
-
-// NOTE: This class is not thread-safe; however, Spark guarantees that only a single thread will access it.
-class AvroSerializer[T <: SpecificRecord: ClassTag] extends Serializer[T] {
-  val reader = new SpecificDatumReader[T](scala.reflect.classTag[T].runtimeClass.asInstanceOf[Class[T]])
-  val writer = new SpecificDatumWriter[T](scala.reflect.classTag[T].runtimeClass.asInstanceOf[Class[T]])
-  var in = InputStreamWithDecoder(1024)
-  val outstream = new FastByteArrayOutputStream()
-  val encoder = EncoderFactory.get().directBinaryEncoder(outstream, null.asInstanceOf[BinaryEncoder])
-
-  setAcceptsNull(false)
-
-  def write(kryo: Kryo, kryoOut: Output, record: T) = {
-    outstream.reset()
-    writer.write(record, encoder)
-    kryoOut.writeInt(outstream.array.length, true)
-    kryoOut.write(outstream.array)
-  }
-
-  def read(kryo: Kryo, kryoIn: Input, klazz: Class[T]): T = this.synchronized {
-    val len = kryoIn.readInt(true)
-    if (len > in.size) {
-      in = InputStreamWithDecoder(len + 1024)
-    }
-    in.stream.reset()
-    // Read Kryo bytes into input buffer
-    kryoIn.readBytes(in.buffer, 0, len)
-    // Read the Avro object from the buffer
-    reader.read(null.asInstanceOf[T], in.decoder)
-  }
-}
-
 class ADAMKryoRegistrator extends KryoRegistrator {
   override def registerClasses(kryo: Kryo) {
-    kryo.register(classOf[AlignmentRecord], new AvroSerializer[AlignmentRecord]())
-    kryo.register(classOf[Pileup], new AvroSerializer[Pileup]())
-    kryo.register(classOf[Genotype], new AvroSerializer[Genotype]())
-    kryo.register(classOf[Variant], new AvroSerializer[Variant]())
-    kryo.register(classOf[FlatGenotype], new AvroSerializer[FlatGenotype]())
-    kryo.register(classOf[DatabaseVariantAnnotation], new AvroSerializer[DatabaseVariantAnnotation]())
-    kryo.register(classOf[NucleotideContigFragment], new AvroSerializer[NucleotideContigFragment]())
-    kryo.register(classOf[Feature], new AvroSerializer[Feature]())
+    kryo.register(classOf[AlignmentRecord], AvroSerializer.SpecificRecordSerializer[AlignmentRecord])
+    kryo.register(classOf[Pileup], AvroSerializer.SpecificRecordSerializer[Pileup])
+    kryo.register(classOf[Genotype], AvroSerializer.SpecificRecordSerializer[Genotype])
+    kryo.register(classOf[Variant], AvroSerializer.SpecificRecordSerializer[Variant])
+    kryo.register(classOf[FlatGenotype], AvroSerializer.SpecificRecordSerializer[FlatGenotype])
+    kryo.register(classOf[DatabaseVariantAnnotation], AvroSerializer.SpecificRecordSerializer[DatabaseVariantAnnotation])
+    kryo.register(classOf[NucleotideContigFragment], AvroSerializer.SpecificRecordSerializer[NucleotideContigFragment])
+    kryo.register(classOf[Feature], AvroSerializer.SpecificRecordSerializer[Feature])
     kryo.register(classOf[ReferencePositionWithOrientation], new ReferencePositionWithOrientationSerializer)
     kryo.register(classOf[ReferencePosition], new ReferencePositionSerializer)
     kryo.register(classOf[ReferencePositionPair], new ReferencePositionPairSerializer)

--- a/pom.xml
+++ b/pom.xml
@@ -18,7 +18,7 @@
 
   <properties>
     <java.version>1.7</java.version>
-    <scala.version>2.10.3</scala.version>
+    <scala.version>2.10.4</scala.version>
     <scala.artifact.suffix>2.10</scala.artifact.suffix>
     <avro.version>1.7.6</avro.version>
     <spark.version>1.1.0</spark.version>
@@ -26,6 +26,7 @@
     <!-- Edit the following line to configure the Hadoop (HDFS) version. -->
     <hadoop.version>2.2.0</hadoop.version>
     <scoverage.version>0.99.2</scoverage.version>
+    <chill.version>0.5.0</chill.version>
   </properties>
   
   <modules>
@@ -297,6 +298,40 @@
         <version>2.21</version>
       </dependency>
       <dependency>
+        <groupId>com.twitter</groupId>
+        <artifactId>chill-avro</artifactId>
+        <version>${chill.version}</version>
+        <exclusions>
+          <exclusion>
+            <groupId>com.twitter</groupId>
+            <artifactId>chill_2.11</artifactId>
+          </exclusion>
+          <exclusion>
+            <groupId>com.twitter</groupId>
+            <artifactId>chill-bijection_2.11</artifactId>
+          </exclusion>
+          <exclusion>
+            <groupId>com.twitter</groupId>
+            <artifactId>bijection-avro_2.11</artifactId>
+          </exclusion>
+        </exclusions>
+      </dependency>
+      <dependency>
+        <groupId>com.twitter</groupId>
+        <artifactId>bijection-avro_${scala.artifact.suffix}</artifactId>
+        <version>0.7.0</version>
+      </dependency>
+      <dependency>
+        <groupId>com.twitter</groupId>
+        <artifactId>chill-bijection_${scala.artifact.suffix}</artifactId>
+        <version>${chill.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>com.twitter</groupId>
+        <artifactId>chill_${scala.artifact.suffix}</artifactId>
+        <version>${chill.version}</version>
+      </dependency>
+      <dependency>
         <groupId>org.scoverage</groupId>
         <artifactId>scalac-scoverage-plugin_${scala.artifact.suffix}</artifactId>
         <version>${scoverage.version}</version>
@@ -380,6 +415,10 @@
           <exclusion>
             <groupId>org.apache.hadoop</groupId>
             <artifactId>hadoop-client</artifactId>
+          </exclusion>
+          <exclusion>
+            <groupId>org.twitter</groupId>
+            <artifactId>chill_${scala.artifact.suffix}</artifactId>
           </exclusion>
           <exclusion>
             <groupId>org.apache.hadoop</groupId>


### PR DESCRIPTION
Fixes #237 by migrating to Chill's avro serializers. Also bumps the Scala version to 2.10.4, which is used by Spark 1.1.0 and Chill 0.5.0. Ironically enough, it seems that our original serializers were actually the inspiration for adding Avro to Chill! See https://github.com/twitter/chill/issues/171 ;).
