### PR TITLE
[ADAM-401] Adding read error correction.

### DIFF
--- a/adam-core/pom.xml
+++ b/adam-core/pom.xml
@@ -112,6 +112,10 @@
 
   <dependencies>
     <dependency>
+      <groupId>org.apache.commons</groupId>
+      <artifactId>commons-math3</artifactId>
+    </dependency>
+    <dependency>
       <groupId>com.esotericsoftware.kryo</groupId>
       <artifactId>kryo</artifactId>
     </dependency>
@@ -154,6 +158,10 @@
     <dependency>
       <groupId>org.apache.spark</groupId>
       <artifactId>spark-core_${scala.artifact.suffix}</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.spark</groupId>
+      <artifactId>spark-mllib_${scala.artifact.suffix}</artifactId>
     </dependency>
     <dependency>
       <groupId>it.unimi.dsi</groupId>

--- a/adam-core/src/main/scala/org/bdgenomics/adam/algorithms/distributions/CategoricalDistribution.scala
+++ b/adam-core/src/main/scala/org/bdgenomics/adam/algorithms/distributions/CategoricalDistribution.scala
@@ -1,0 +1,45 @@
+/**
+ * Licensed to Big Data Genomics (BDG) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The BDG licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.bdgenomics.adam.algorithms.distributions
+
+import scala.math.abs
+
+object CategoricalDistribution {
+
+  def softmax(likelihoods: Array[Double]): CategoricalDistribution = {
+    val sum = likelihoods.sum
+    CategoricalDistribution(likelihoods.map(l => l / sum))
+  }
+}
+
+case class CategoricalDistribution(probabilities: Array[Double])
+    extends UnivariateDiscreteDistribution {
+
+  assert(abs(1.0 - probabilities.sum) < 1e-6, "Probabilities must sum to 1. Was given: " + probabilities.toString)
+  private val categories = probabilities.length
+
+  def probability(category: Int): Double = {
+    assert(category >= 0 && category < categories,
+      "Category out of range: " + category + ", only have " + categories + " categories.")
+    probabilities(category)
+  }
+
+  override def toString(): String = {
+    "categories: " + (0 until categories).map(i => i + ": " + probabilities(i)).reduce(_ + ", " + _)
+  }
+}

--- a/adam-core/src/main/scala/org/bdgenomics/adam/algorithms/distributions/GammaDistribution.scala
+++ b/adam-core/src/main/scala/org/bdgenomics/adam/algorithms/distributions/GammaDistribution.scala
@@ -1,0 +1,92 @@
+/**
+ * Licensed to Big Data Genomics (BDG) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The BDG licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.bdgenomics.adam.algorithms.distributions
+
+import org.apache.commons.math3.distribution.{ GammaDistribution => ApacheGammaDistribution }
+import org.apache.commons.math3.special.Gamma
+import scala.math.{ exp, pow }
+
+object GammaDistribution {
+
+  /**
+   * For a given mean and standard deviation (σ), we can build a Gamma
+   * distribution. This is because we know that the mean of a Gamma distribution
+   * equals α/β, and the standard deviation of a Gamma distribution equals
+   * sqrt(α)/β.
+   *
+   * @param mean Average of points in the distribution.
+   * @param sigma Standard deviation of points in the distribution.
+   * @return Returns a Gamma Distribution that maximizes the likelihood that
+   *         corresponds to this mean and sigma.
+   */
+  def fromMeanAndSigma(mean: Double, sigma: Double): GammaDistribution = {
+    val alpha = pow(2.0, mean / sigma)
+    GammaDistribution(alpha, alpha / mean)
+  }
+
+  def apply(alpha: Double, beta: Double): GammaDistribution = {
+    // if we can compute the fixed coefficients explicitly, use our lightweight implementation
+    if ((pow(beta, alpha) / Gamma.gamma(alpha)).isNaN) {
+      val aGamma = new ApacheGammaDistribution(alpha, 1.0 / beta)
+      new SerializableApacheGammaWrapper(aGamma)
+    } else {
+      new GammaDistribution(alpha, beta)
+    }
+  }
+}
+
+class GammaDistribution protected (val alpha: Double, val beta: Double)
+    extends UnivariateContinuousDistribution with Serializable {
+
+  // precalculate the denominator and invert, as the gamma function is expensive
+  val coefficient = pow(beta, alpha) / Gamma.gamma(alpha)
+
+  /**
+   * The probability density function of the Gamma distribution is:
+   *
+   * p(x | α, β) = \frac{x^{α - 1} exp(-xβ)}{\frac{1}{β}^α Γ(α)}
+   *
+   * For computational efficiency, we precompute the denominator.
+   *
+   * @param x Input value.
+   * @return The probability density of x in this distribution.
+   */
+  def probabilityDensity(x: Double): Double = {
+    coefficient * pow(x, alpha - 1.0) * exp(x * -beta)
+  }
+
+  override def toString(): String = {
+    "α: " + alpha + " β: " + beta
+  }
+}
+
+private class SerializableApacheGammaWrapper(aGamma: ApacheGammaDistribution)
+    extends GammaDistribution(aGamma.getShape, 1.0 / aGamma.getScale) {
+
+  /**
+   * The probability density function of the Gamma distribution is:
+   *
+   * p(x | α, β) = \frac{x^{α - 1} exp(-xβ)}{\frac{1}{β}^α Γ(α)}
+   *
+   * @param x Input value.
+   * @return The probability density of x in this distribution.
+   */
+  override def probabilityDensity(x: Double): Double = {
+    aGamma.density(x)
+  }
+}

--- a/adam-core/src/main/scala/org/bdgenomics/adam/algorithms/distributions/GammaMixtureModel.scala
+++ b/adam-core/src/main/scala/org/bdgenomics/adam/algorithms/distributions/GammaMixtureModel.scala
@@ -1,0 +1,89 @@
+/**
+ * Licensed to Big Data Genomics (BDG) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The BDG licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.bdgenomics.adam.algorithms.distributions
+
+import org.apache.commons.math3.special.Gamma
+import org.apache.spark.rdd.RDD
+import scala.annotation.tailrec
+import scala.math.{ log => mathLog, max, pow }
+import scala.reflect.ClassTag
+
+object GammaMixtureModel
+    extends MixtureOfUCDInitByKMeansFitByEM[GammaDistribution] {
+
+  override val quitEarly = true
+
+  protected def mStep(rdd: RDD[(Array[Double], Double)],
+                      distributions: Array[GammaDistribution],
+                      iter: Int): (Array[GammaDistribution], Array[Double]) = {
+    // persist rdd
+    rdd.cache()
+
+    // compute weighting
+    val weighting = rdd.map(kv => kv._1).aggregate(new Array[Double](distributions.length))(
+      aggregateArray, aggregateArray)
+    val count = rdd.count().toDouble
+
+    // collect trusted distribution
+    val newDistributions = update(rdd, weighting, distributions, 10.0 / (iter.toDouble + 10.0))
+
+    // unpersist rdd
+    rdd.unpersist()
+
+    // return distributions
+    (newDistributions, weighting.map(_ / count))
+  }
+
+  private def update(rdd: RDD[(Array[Double], Double)],
+                     weights: Array[Double],
+                     previousDistributions: Array[GammaDistribution],
+                     a: Double): Array[GammaDistribution] = {
+    val numDistributions = weights.length
+    val n = weights.sum
+
+    // compute coefficients to avoid recomputing them in map
+    val psiAlphas = previousDistributions.map(d => psi(d.alpha))
+    val logLambdas = previousDistributions.map(d => mathLog(d.beta))
+    val coeffs = (0 until numDistributions).map(i => logLambdas(i) - psiAlphas(i)).toArray
+
+    // map to collect sufficient statistics
+    val lambdaDenominators = rdd.map(kv => kv._1.map(_ * kv._2))
+      .aggregate(new Array[Double](numDistributions))(aggregateArray, aggregateArray)
+    val g = rdd.map(kv => (0 until numDistributions).map(i => kv._1(i) * (mathLog(kv._2) + coeffs(i))).toArray)
+      .aggregate(new Array[Double](numDistributions))(aggregateArray, aggregateArray)
+
+    // create new distribution
+    (0 until numDistributions).map(i => GammaDistribution(previousDistributions(i).alpha + a * (g(i) / n),
+      (previousDistributions(i).alpha * weights(i)) / lambdaDenominators(i)))
+      .toArray
+  }
+
+  protected def initializeDistribution(mean: Double, sigma: Double): GammaDistribution = {
+    GammaDistribution.fromMeanAndSigma(mean, sigma)
+  }
+
+  private def psi(x: Double): Double = {
+    // we have a reasonable approximation for x >= 2; else, call to apache which has a
+    // more precise but more expensive implementation
+    if (x >= 2.0) {
+      mathLog(x - 0.5) + 1.0 / (24 * pow(x - 0.5, 2.0))
+    } else {
+      Gamma.digamma(x)
+    }
+  }
+}

--- a/adam-core/src/main/scala/org/bdgenomics/adam/algorithms/distributions/MixtureOfUCDInitByKmeansFitByEM.scala
+++ b/adam-core/src/main/scala/org/bdgenomics/adam/algorithms/distributions/MixtureOfUCDInitByKmeansFitByEM.scala
@@ -1,0 +1,296 @@
+/**
+ * Licensed to Big Data Genomics (BDG) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The BDG licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.bdgenomics.adam.algorithms.distributions
+
+import org.apache.spark.Logging
+import org.apache.spark.rdd.RDD
+import org.apache.spark.mllib.clustering.KMeans
+import org.apache.spark.mllib.linalg.Vectors
+import scala.annotation.tailrec
+import scala.math.{ abs, log => mathLog, max, pow, sqrt }
+import scala.reflect.ClassTag
+
+/**
+ * A trait for mixtures of univariate continuous distributions whose initial
+ * values are chosen by running k-means, and whose distributions are fit by
+ * an EM algorithm.
+ */
+trait MixtureOfUCDInitByKMeansFitByEM[D <: UnivariateContinuousDistribution]
+    extends MixtureOfUnivariateContinuousDistributions[D] with Logging {
+
+  val quitEarly = false
+
+  /**
+   * Computes the assignment weights of a single point to the different
+   * distributions that we are fitting.
+   *
+   * @param value The value of this point.
+   * @param weighting An array containing the weights of all current distributions.
+   * @param distributions An array containing all distributions we have fit.
+   * @return Returns a tuple containing the per-point weights of all distributions,
+   *         and the expected complete log likelihood contribution of this point.
+   */
+  protected def classMembership(value: Double,
+                                weighting: Array[Double],
+                                distributions: Array[D]): (Array[Double], Double) = {
+    // find probability densities, then weight
+    val densities = distributions.map(_.probabilityDensity(value))
+    val weighted = densities.zip(weighting).map(p => p._1 * p._2)
+
+    // perform soft assignment
+    val weight = weighted.sum
+    val membership = weighted.map(_ / weight)
+
+    // calculate expected complete log likelihood contribution of this point
+    val pointEcll = weighted.map(safeLog(_))
+      .zip(membership)
+      .map(p => p._1 * p._2)
+      .reduce(_ + _)
+
+    // return soft assignment and ECLL contribution
+    (membership, pointEcll)
+  }
+
+  /**
+   * Runs an EM loop to fit a mixture model.
+   *
+   * @param rdd An RDD of doubles to fit the mixture model to.
+   * @param initialDistributions The intial distributions to start running EM from.
+   * @param maxIterations The maximum number of iterations to run.
+   * @param ecllThreshold We stop running the EM loop once the expected complete log
+   *                      likelihood increases by less than this threshold.
+   * @return Returns an array of fit distributions.
+   */
+  protected def em(rdd: RDD[Double],
+                   initialDistributions: Array[D],
+                   maxIterations: Int,
+                   initialWeights: Array[Double],
+                   ecllThreshold: Option[Double] = None)(
+                     implicit dTag: ClassTag[D]): Array[D] = {
+
+    // tail recursive helper function for running em loop
+    @tailrec def emLoopHelper(iteration: Int,
+                              lastEcll: Double,
+                              lastWeighting: Array[Double],
+                              lastDistributions: Array[D]): Array[D] = {
+
+      // run expectation stage - generates class assignments,
+      // and updates current expected complete log likelihood
+      val (classAssignments, ecll) = eStep(rdd,
+        lastDistributions,
+        lastWeighting)
+
+      if ((quitEarly && ecll < lastEcll) ||
+        (ecllThreshold.isDefined && ecll < lastEcll + ecllThreshold.get)) {
+        log.info("Quitting on iteration " + iteration + " due to insufficient improvement.")
+        lastDistributions
+      } else if (iteration > maxIterations) {
+        log.info("Quitting as have exceeded max iteration count.")
+        lastDistributions
+      } else {
+        // run maximization stage - updates distributions
+        val (distributions,
+          weighting) = mStep(classAssignments.zip(rdd), lastDistributions, iteration)
+
+        // print logging info
+        log.info("After iteration " + iteration + ":")
+        (0 until distributions.length).foreach(i => {
+          log.info("Distribution " + i + " has weight " + weighting(i) +
+            " and distribuion: " + distributions(i))
+        })
+
+        // recursively call next iteration
+        emLoopHelper(iteration + 1,
+          ecll,
+          weighting,
+          distributions)
+      }
+    }
+
+    // call em loop
+    val distributions = emLoopHelper(0,
+      Double.NegativeInfinity,
+      initialWeights,
+      initialDistributions)
+
+    // return our two distributions
+    distributions
+  }
+
+  /**
+   * Implements the basic expectation stage for most EM algorithms. Algorithms
+   * that diverge from the traditional E step should override this method.
+   *
+   * @param rdd An RDD of data points.
+   * @param distributions An array containing the distributions fit in the
+   *                      last iteration. This array should contain k distributions,
+   *                      where k is the number of components in the mixture.
+   * @param weighting The weights of the different distributions.
+   * @return Returns an RDD of assignments to classes, and the total ECLL.
+   */
+  protected def eStep(rdd: RDD[Double],
+                      distributions: Array[D],
+                      weighting: Array[Double]): (RDD[Array[Double]], Double) = {
+
+    // get class membership and expected complete log likelihood contribution per point
+    val classAndEcll = rdd.map(classMembership(_,
+      weighting,
+      distributions))
+    classAndEcll.cache()
+
+    // get class
+    val classM = classAndEcll.map(_._1)
+
+    // reduce down to get expected compute log likelihood contribution
+    val ecll = classAndEcll.map(_._2).reduce(_ + _)
+
+    // unpersist temp class & ecll rdd
+    classAndEcll.unpersist()
+
+    // return rdd of class assignments, and ecll
+    (classM, ecll)
+  }
+
+  // aggregation function for arrays which does not allocate a new array
+  protected def aggregateArray(a1: Array[Double], a2: Array[Double]): Array[Double] = {
+    (0 until a1.length).foreach(i => a1(i) += a2(i))
+    a1
+  }
+
+  // log function which never returns -infinity or NaN
+  protected def safeLog(v: Double, floor: Double = -100000.0): Double = {
+    val l = mathLog(v)
+    if (l.isNaN || l.isInfinite) {
+      floor
+    } else {
+      l
+    }
+  }
+
+  /**
+   * Initializes the models that we are going to train by EM by using K-means to
+   * divide the data points into subgroups with defined mean and standard deviation.
+   *
+   * @param rdd A RDD of data points.
+   * @param k The number of clusters to cut points into.
+   * @param maxIterations The maximum number of iterations to execute.
+   * @return Returns an array of initialized distributions.
+   */
+  private def initializeViaKmeans(rdd: RDD[Double],
+                                  k: Int,
+                                  maxIterations: Int)(implicit dTag: ClassTag[D]): (Array[D], Array[Double]) = {
+
+    // initialize distributions by running k-means
+    val clusters = KMeans.train(rdd.map(p => Vectors.dense(p)), k, maxIterations)
+
+    // get cluster centroids
+    val centroids = clusters.clusterCenters
+      .flatMap(c => c.toArray)
+      .toSeq
+      .sortWith(_ < _)
+    assert(centroids.length == k)
+    val pointsPerCentroid = new Array[Long](k)
+    val centroidSigmas = new Array[Double](k)
+
+    // collect standard deviations for clusters
+    // 0th distribution
+    val centroid0Points = if (k > 1) {
+      rdd.filter(v => abs(v - centroids(0)) <= abs(v - centroids(1)))
+    } else {
+      rdd
+    }
+
+    if (k > 1) centroid0Points.cache()
+
+    pointsPerCentroid(0) = centroid0Points.count
+    centroidSigmas(0) = sqrt(centroid0Points.map(p => pow(p - centroids(0), 2.0)).reduce(_ + _) / pointsPerCentroid(0))
+
+    if (k > 1) centroid0Points.unpersist()
+
+    if (k > 1) {
+      // get standard deviations for distributions 1...k - 2
+      (1 until (k - 1)).foreach(i => {
+        val centroidIPoints = rdd.filter(v => abs(v - centroids(i - 1)) > abs(v - centroids(i)) &&
+          abs(v - centroids(i)) <= abs(v - centroids(i + 1)))
+        centroidIPoints.cache()
+        pointsPerCentroid(i) = centroidIPoints.count
+        centroidSigmas(i) = sqrt(centroidIPoints.map(p => pow(p - centroids(i), 2.0)).reduce(_ + _) / pointsPerCentroid(i))
+        centroidIPoints.unpersist()
+      })
+
+      // (k - 1)th distribution
+      val centroidKPoints = rdd.filter(v => abs(v - centroids(k - 2)) > abs(v - centroids(k - 1)))
+      centroidKPoints.cache()
+      pointsPerCentroid(k - 1) = centroidKPoints.count
+      centroidSigmas(k - 1) = sqrt(centroidKPoints.map(p => pow(p - centroids(k - 1), 2.0)).reduce(_ + _) / pointsPerCentroid(k - 1))
+      centroidKPoints.unpersist()
+    }
+
+    // create distributions
+    val initialDistributions = new Array[D](k)
+    (0 until k).foreach(i => initialDistributions(i) = initializeDistribution(centroids(i), centroidSigmas(i)))
+
+    // create weights
+    val totalPoints = pointsPerCentroid.sum.toDouble
+    val weights = pointsPerCentroid.map(p => p.toDouble / totalPoints)
+
+    // print log info
+    log.info("After k-means initialization, have:")
+    (0 until k).foreach(i => log.info("Distribution " + i + ": " + initialDistributions(i)))
+
+    (initialDistributions, weights)
+  }
+
+  /**
+   * The maximization stage for the EM algorithm. Mst be implemented by user.
+   *
+   * @param rdd An RDD containing an array of weights and the value for the point.
+   * @param distributions The distributions fit by the last iteration of the EM algorithm.
+   * @param iter The number of the current iteration.
+   * @return Returns a tuple containing an array of updated distributions as well as
+   *         an array of distribution weights (should sum to one).
+   */
+  protected def mStep(rdd: RDD[(Array[Double], Double)],
+                      distributions: Array[D],
+                      iter: Int): (Array[D], Array[Double])
+
+  /**
+   * Initializes the distributions, given a mean and a sigma.
+   *
+   * @param mean Mean for an initial distribution.
+   * @param sigma Standard deviation for an initial distribution.
+   * @return Returns a distribution.
+   */
+  protected def initializeDistribution(mean: Double, sigma: Double): D
+
+  def fit(rdd: RDD[Double],
+          k: Int,
+          maxIterations: Int)(implicit dTag: ClassTag[D]): Array[D] = {
+    val (initialDistributions, initialWeights) = initializeViaKmeans(rdd, k, maxIterations)
+    em(rdd, initialDistributions, maxIterations, initialWeights)
+  }
+
+  def fit(rdd: RDD[Double],
+          k: Int,
+          maxEmIterations: Int,
+          maxKmeansIterations: Int,
+          ecllThreshold: Option[Double] = None)(implicit dTag: ClassTag[D]): Array[D] = {
+    val (initialDistributions, initialWeights) = initializeViaKmeans(rdd, k, maxKmeansIterations)
+    em(rdd, initialDistributions, maxEmIterations, initialWeights, ecllThreshold)
+  }
+}

--- a/adam-core/src/main/scala/org/bdgenomics/adam/algorithms/distributions/MixtureOfUnivariateContinuousDistributions.scala
+++ b/adam-core/src/main/scala/org/bdgenomics/adam/algorithms/distributions/MixtureOfUnivariateContinuousDistributions.scala
@@ -1,0 +1,30 @@
+/**
+ * Licensed to Big Data Genomics (BDG) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The BDG licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.bdgenomics.adam.algorithms.distributions
+
+import org.apache.spark.Logging
+import org.apache.spark.mllib.clustering.KMeans
+import org.apache.spark.mllib.linalg.Vectors
+import org.apache.spark.rdd.RDD
+import scala.math.{ abs, pow, sqrt }
+import scala.reflect.ClassTag
+
+trait MixtureOfUnivariateContinuousDistributions[D <: UnivariateContinuousDistribution] extends Serializable {
+
+  def fit(rdd: RDD[Double], k: Int, maxIterations: Int)(implicit dTag: ClassTag[D]): Array[D]
+}

--- a/adam-core/src/main/scala/org/bdgenomics/adam/algorithms/distributions/UnivariateContinuousDistribution.scala
+++ b/adam-core/src/main/scala/org/bdgenomics/adam/algorithms/distributions/UnivariateContinuousDistribution.scala
@@ -1,0 +1,29 @@
+/**
+ * Licensed to Big Data Genomics (BDG) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The BDG licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.bdgenomics.adam.algorithms.distributions
+
+trait UnivariateContinuousDistribution {
+
+  /**
+   * @param x Input point.
+   * @return The probability density assigned to x by this distribution.
+   */
+  def probabilityDensity(x: Double): Double
+
+  def pString(x: Double): String = ""
+}

--- a/adam-core/src/main/scala/org/bdgenomics/adam/algorithms/distributions/UnivariateDiscreteDistribution.scala
+++ b/adam-core/src/main/scala/org/bdgenomics/adam/algorithms/distributions/UnivariateDiscreteDistribution.scala
@@ -1,0 +1,27 @@
+/**
+ * Licensed to Big Data Genomics (BDG) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The BDG licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.bdgenomics.adam.algorithms.distributions
+
+trait UnivariateDiscreteDistribution {
+
+  /**
+   * @param x Input point.
+   * @return The probability assigned to x by this distribution.
+   */
+  def probability(x: Int): Double
+}

--- a/adam-core/src/main/scala/org/bdgenomics/adam/algorithms/distributions/UnivariateNormalDistribution.scala
+++ b/adam-core/src/main/scala/org/bdgenomics/adam/algorithms/distributions/UnivariateNormalDistribution.scala
@@ -1,0 +1,37 @@
+/**
+ * Licensed to Big Data Genomics (BDG) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The BDG licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.bdgenomics.adam.algorithms.distributions
+
+import scala.math.{ exp, Pi, pow, sqrt }
+
+case class UnivariateNormalDistribution(mu: Double, sigma: Double)
+    extends UnivariateContinuousDistribution {
+
+  assert(sigma > 0.0, "Sigma must be strictly greater than 0. Was provided: " + toString())
+
+  val norm = sigma * sqrt(2.0 * Pi)
+  val sigma2 = 2 * pow(sigma, 2.0)
+
+  def probabilityDensity(point: Double): Double = {
+    exp(-pow(point - mu, 2.0) / sigma2) / norm
+  }
+
+  override def toString(): String = {
+    "µ: " + mu + " σ: " + sigma
+  }
+}

--- a/adam-core/src/main/scala/org/bdgenomics/adam/algorithms/distributions/UnivariateNormalMixtureModel.scala
+++ b/adam-core/src/main/scala/org/bdgenomics/adam/algorithms/distributions/UnivariateNormalMixtureModel.scala
@@ -1,0 +1,70 @@
+/**
+ * Licensed to Big Data Genomics (BDG) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The BDG licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.bdgenomics.adam.algorithms.distributions
+
+import org.apache.spark.rdd.RDD
+import scala.annotation.tailrec
+import scala.math.{ log => mathLog, max, pow, sqrt }
+import scala.reflect.ClassTag
+
+object UnivariateNormalMixtureModel
+    extends MixtureOfUCDInitByKMeansFitByEM[UnivariateNormalDistribution] {
+
+  protected def mStep(rdd: RDD[(Array[Double], Double)],
+                      distributions: Array[UnivariateNormalDistribution],
+                      iter: Int): (Array[UnivariateNormalDistribution], Array[Double]) = {
+    // persist rdd
+    rdd.cache()
+
+    // compute weighting
+    val weighting = rdd.map(kv => kv._1).aggregate(new Array[Double](distributions.length))(
+      aggregateArray, aggregateArray)
+    val count = rdd.count().toDouble
+
+    // collect trusted distribution
+    val newDistributions = update(rdd, weighting)
+
+    // unpersist rdd
+    rdd.unpersist()
+
+    // return distributions
+    (newDistributions, weighting.map(_ / count))
+  }
+
+  protected def initializeDistribution(mean: Double, sigma: Double): UnivariateNormalDistribution = {
+    UnivariateNormalDistribution(mean, sigma)
+  }
+
+  protected def update(rdd: RDD[(Array[Double], Double)],
+                       weights: Array[Double]): Array[UnivariateNormalDistribution] = {
+    val numDistributions = weights.length
+
+    // map to collect sufficient statistics
+    val mus = rdd.map(kv => kv._1.map(_ * kv._2))
+      .aggregate(new Array[Double](numDistributions))(aggregateArray, aggregateArray)
+    (0 until mus.length).foreach(i => mus(i) /= weights(i))
+
+    val sigmas = rdd.map(kv => (0 until numDistributions).map(i => kv._1(0) * pow(kv._2 - mus(0), 2.0)).toArray)
+      .aggregate(new Array[Double](numDistributions))(aggregateArray, aggregateArray)
+
+    // create new distribution
+    (0 until numDistributions).map(i => UnivariateNormalDistribution(mus(i),
+      sqrt(sigmas(i) / weights(i))))
+      .toArray
+  }
+}

--- a/adam-core/src/main/scala/org/bdgenomics/adam/models/ProbabilisticSequence.scala
+++ b/adam-core/src/main/scala/org/bdgenomics/adam/models/ProbabilisticSequence.scala
@@ -1,0 +1,89 @@
+/**
+ * Licensed to Big Data Genomics (BDG) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The BDG licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.bdgenomics.adam.models
+
+import org.bdgenomics.adam.util.PhredUtils
+import scala.annotation.tailrec
+
+/**
+ * This class represents a sequence of bases where the sequence is as yet
+ * undetermined, but probabilities are available for the base-wise composition
+ * of each position in the sequence.
+ */
+case class ProbabilisticSequence(sequence: Array[Array[Double]]) {
+
+  private[models] def maxOf(idx: Int): Int = {
+    @tailrec def getMaxIdx(currMax: Double, currMaxIdx: Int, currIdx: Int): Int = {
+      // return if we pass 3
+      if (currIdx >= 3) {
+        currMaxIdx
+      } else {
+        // update idx
+        val newIdx = currIdx + 1
+
+        // do we have a new max?
+        val (newMax, newMaxIdx) = if (sequence(idx)(newIdx) > currMax) {
+          (sequence(idx)(newIdx), newIdx)
+        } else {
+          (currMax, currMaxIdx)
+        }
+
+        // recurse
+        getMaxIdx(newMax, newMaxIdx, newIdx)
+      }
+    }
+
+    getMaxIdx(sequence(idx)(0), 0, 0)
+  }
+
+  private[models] def idxToBase(idx: Int): Char = idx match {
+    case 0 => 'A'
+    case 1 => 'C'
+    case 2 => 'G'
+    case 3 => 'T'
+    case _ => throw new IllegalArgumentException("Index out of range.")
+  }
+
+  def softMax() {
+    (0 until sequence.length).foreach(i => {
+      val normalizeFactor = sequence(i).sum
+
+      // normalize all values
+      (0 to 3).foreach(j => sequence(i)(j) = sequence(i)(j) / normalizeFactor)
+    })
+  }
+
+  def toSequence(): (String, Array[Int]) = {
+    val sb = new StringBuilder
+    val phredArray = new Array[Int](sequence.length)
+
+    // loop over bases and pick the best
+    (0 until sequence.length).foreach(i => {
+      // get max index at position
+      val maxIdx = maxOf(i)
+
+      // append base to string builder
+      sb += idxToBase(maxIdx)
+
+      // set phred score at position
+      phredArray(i) = PhredUtils.successProbabilityToPhred(sequence(i)(maxIdx))
+    })
+
+    (sb.toString, phredArray)
+  }
+}

--- a/adam-core/src/main/scala/org/bdgenomics/adam/rdd/read/correction/ErrorCorrection.scala
+++ b/adam-core/src/main/scala/org/bdgenomics/adam/rdd/read/correction/ErrorCorrection.scala
@@ -20,9 +20,20 @@ package org.bdgenomics.adam.rdd.read.correction
 import org.apache.spark.SparkContext._
 import org.apache.spark.Logging
 import org.apache.spark.rdd.RDD
+import org.bdgenomics.adam.algorithms.distributions.{
+  CategoricalDistribution,
+  GammaMixtureModel,
+  GammaDistribution
+}
+import org.bdgenomics.adam.algorithms.prefixtrie.DNAPrefixTrie
 import org.bdgenomics.adam.rdd.ADAMContext._
+import org.bdgenomics.adam.models.ProbabilisticSequence
 import org.bdgenomics.adam.util.PhredUtils
 import org.bdgenomics.formats.avro.AlignmentRecord
+import org.apache.spark.rdd.RDD
+import scala.annotation.tailrec
+import scala.collection.immutable.StringOps
+import scala.math.{ abs, exp, log => mathLog, max, min, Pi, pow, sqrt }
 
 private[rdd] object ErrorCorrection extends Logging {
 
@@ -34,7 +45,7 @@ private[rdd] object ErrorCorrection extends Logging {
    * Kelley, David R., Michael C. Schatz, and Steven L. Salzberg. "Quake: quality-aware detection
    * and correction of sequencing errors." Genome Biol 11.11 (2010): R116.
    *
-   * _Q_-mers are _k_-mers weighted by the quality score of the bases in the _k_-mer.
+   * _q_-mers are _k_-mers weighted by the quality score of the bases in the _k_-mer.
    *
    * @param rdd RDD to count q-mers on.
    * @param qmerLength The value of _q_ to use for cutting _q_-mers.
@@ -46,6 +57,158 @@ private[rdd] object ErrorCorrection extends Logging {
     rdd.flatMap(ec.readToQmers(_, qmerLength))
       .reduceByKey(_ + _)
   }
+
+  /**
+   * For an RDD of read data, performs read error correction.
+   *
+   * @param rdd The RDD of reads to correct.
+   * @param qmerLength The length of the q-mers to create. The default value is 20.
+   * @return Returns a corrected RDD of reads.
+   */
+  def apply(rdd: RDD[AlignmentRecord],
+            qmerLength: Int = 20,
+            maxIterations: Int = 10,
+            fixingThreshold: Int = 20,
+            emThreshold: Double = mathLog(0.5),
+            missingKmerProbability: Double = 0.05,
+            ploidy: Int = 2): RDD[AlignmentRecord] = {
+
+    // trim N's
+    val trimmedReads = TrimReads.trimNs(rdd)
+      .cache()
+
+    // generate qmer counts
+    val qmerCounts: RDD[(String, Double)] = trimmedReads.flatMap(ec.readToQmers(_, qmerLength))
+      .reduceByKey(_ + _)
+      .cache()
+
+    val counts = qmerCounts.map(kv => kv._2)
+      .cache()
+
+    // run em to fit distributions
+    val distributions = GammaMixtureModel.fit(counts,
+      ploidy + 1,
+      maxIterations,
+      maxIterations,
+      Some(emThreshold))
+    val errorDistribution = distributions.head
+    val trustedDistributions = distributions.drop(1)
+
+    // determine if kmers are trusted
+    val qmerLikelihoods: RDD[(String, Double, Double)] = qmerCounts.map(p => {
+      val (qmer, count) = p
+
+      // apply distributions
+      (qmer,
+        errorDistribution.probabilityDensity(count),
+        trustedDistributions.map(_.probabilityDensity(count)).sum)
+    })
+
+    // unpersist counts
+    qmerCounts.unpersist()
+
+    // filter and collect trusted kmers
+    val trustedKmers = qmerLikelihoods.filter(t => t._2 <= t._3 &&
+      // normally, i wouldn't create a "new StringOps", but there is a collision between implicits
+      new StringOps(t._1).find(c => c == 'n' || c == 'N').isEmpty)
+      .map(t => (t._1, t._3 / (t._2 + t._3)))
+      .collect
+
+    // build prefix trie out of trusted kmers
+    val kmerTrie = DNAPrefixTrie(trustedKmers.toMap)
+
+    // fix reads
+    val fixedReads = fixReads(trimmedReads,
+      kmerTrie,
+      qmerLength,
+      PhredUtils.successProbabilityToPhred(fixingThreshold),
+      missingKmerProbability)
+
+    // unpersist original trimmed reads and return
+    trimmedReads.unpersist()
+
+    fixedReads
+  }
+
+  /**
+   * Measures base transition probabilities. Each record contains the relative likelihoods of
+   * an A/C/G/T at each position. We collect a map which contains the prior probablities of
+   * a base read with a given phred score at a given index transitioning to another base.
+   *
+   * @param rdd An RDD containing tuples of probabilistic sequences and sequence records.
+   * @return Returns a map of error covariates to transition probabilities.
+   */
+  private[correction] def measureTransitions(rdd: RDD[(ProbabilisticSequence, AlignmentRecord)]): Map[ErrorCovariate, CategoricalDistribution] = {
+
+    // cut read into covariate slices
+    val covariates = rdd.flatMap(rp => {
+      val (seq, read) = rp
+
+      // loop over and emit
+      (0 until seq.sequence.length).map(i => {
+        (ErrorCovariate(read.getSequence.charAt(i), i, read.getQual.charAt(i)), seq.sequence(i))
+      })
+    })
+
+    def aggregateArray(a1: Array[Double], a2: Array[Double]): Array[Double] = {
+      (0 until a1.length).foreach(i => {
+        a1(i) += a2(i)
+      })
+      a1
+    }
+
+    // compute MLE
+    covariates.aggregateByKey(Array(0.0, 0.0, 0.0, 0.0))(aggregateArray, aggregateArray)
+      .map(kv => (kv._1, CategoricalDistribution.softmax(kv._2)))
+      .collect()
+      .toMap
+  }
+
+  /**
+   * Uses a probabilistic model for base transitions to fix errors in reads.
+   *
+   * @param rdd An RDD of reads to correct.
+   * @param kmerTrie A prefix trie populated with the probability of a kmer being
+   *                 a "correct" kmer.
+   * @param qmerLength The length of k to use when cutting q-mers.
+   * @param fixingThreshold The minimum probability to require for allowing a base to be fixed.
+   * @param missingProbability The assumed (upper bound) probability for a k-mer that is not
+   *                           resident in the prefix trie.
+   * @return Returns an RDD of fixed reads.
+   */
+  private[correction] def fixReads(rdd: RDD[AlignmentRecord],
+                                   kmerTrie: DNAPrefixTrie[Double],
+                                   qmerLength: Int,
+                                   fixingThreshold: Double,
+                                   missingProbability: Double): RDD[AlignmentRecord] = {
+    // cut reads into k-mers and get probabilities
+    val cutReads = rdd.map(ec.cutRead(_, kmerTrie, qmerLength, missingProbability))
+      .cache()
+
+    // measure the transition probabilities
+    val transitionDistributions = measureTransitions(cutReads)
+
+    // correct the reads
+    val fixPhred = (PhredUtils.successProbabilityToPhred(fixingThreshold) + 33).toChar
+    val correctedReads = cutReads.map(ec.correctRead(_,
+      fixingThreshold,
+      fixPhred,
+      transitionDistributions,
+      kmerTrie,
+      qmerLength,
+      missingProbability))
+
+    // unpersist cut reads
+    cutReads.unpersist()
+
+    correctedReads
+  }
+}
+
+/**
+ * This case class is used as a key for tracking transition probabilities of bases.
+ */
+private[correction] case class ErrorCovariate(base: Char, cycle: Int, phred: Char) {
 }
 
 private[correction] class ErrorCorrection extends Serializable with Logging {
@@ -62,7 +225,7 @@ private[correction] class ErrorCorrection extends Serializable with Logging {
     // get read bases and quality scores
     val bases = read.getSequence.toSeq
     val scores = read.getQual.toString.toCharArray.map(q => {
-      PhredUtils.phredToSuccessProbability(q - 33)
+      PhredUtils.phredToSuccessProbability(q.toInt - 33)
     })
 
     // zip and put into sliding windows to get qmers
@@ -80,4 +243,315 @@ private[correction] class ErrorCorrection extends Serializable with Logging {
       })
   }
 
+  /**
+   * Cuts a read into q-mers and then generates base likelihoods.
+   *
+   * @param read Read to cut.
+   * @param trie A trie containing the probability that a q-mer is "true".
+   * @param kmerLength The length of k to use when cutting q-mers.
+   * @param missingKmerProbability The upper bound probability to assign to a
+   *                               k-mer not found in the trie.
+   * @return Returns a probabilistic sequence and the original read.
+   */
+  def cutRead(read: AlignmentRecord,
+              trie: DNAPrefixTrie[Double],
+              kmerLength: Int,
+              missingKmerProbability: Double): (ProbabilisticSequence, AlignmentRecord) = {
+
+    // cut sequence into k-mers
+    val readSequence = read.getSequence.toString
+
+    // call to cut string
+    (cutString(readSequence, trie, kmerLength, missingKmerProbability), read)
+  }
+
+  /**
+   * Cuts a string into q-mers and then generates base likelihoods. Helper function.
+   *
+   * @see cutRead
+   * @see correctRead
+   *
+   * @param readSequence String to cut.
+   * @param trie A trie containing the probability that a q-mer is "true".
+   * @param kmerLength The length of k to use when cutting q-mers.
+   * @param missingKmerProbability The upper bound probability to assign to a
+   *                               k-mer not found in the trie.
+   * @return Returns a probabilistic sequence and the original read.
+   */
+  private[correction] def cutString(readSequence: String,
+                                    trie: DNAPrefixTrie[Double],
+                                    kmerLength: Int,
+                                    missingKmerProbability: Double,
+                                    start: Int = 0,
+                                    end: Int = Int.MaxValue): ProbabilisticSequence = {
+
+    // cut sequence into kmers
+    val kmers = readSequence.sliding(kmerLength).toArray
+
+    // loop over sequence and get probabilities
+    val readLength = readSequence.length
+    val kmersLength = kmers.length
+    val readProbabilities = new Array[Array[Double]](readLength)
+
+    (0 until readLength).foreach(i => {
+      readProbabilities(i) = Array(1.0, 1.0, 1.0, 1.0)
+
+      // we only do a probability update if requested
+      if (i >= start && i <= end) {
+        val startIdx = if (i == 0) {
+          0
+        } else {
+          max(i - kmerLength + 1, 0)
+        }
+        val endIdx = min(i, kmersLength - 1)
+
+        (startIdx to endIdx).foreach(j => {
+          val kmer = kmers(j)
+          val kIdx = i - j
+          (0 to 3).foreach(b => {
+            val testKmer = kmer.take(kIdx) + intToBase(b) + kmer.drop(kIdx + 1)
+            readProbabilities(i)(b) *= trie.getOrElse(testKmer, missingKmerProbability)
+          })
+        })
+      }
+    })
+
+    // build probabilistic sequence and return
+    ProbabilisticSequence(readProbabilities)
+  }
+
+  def intToBase(i: Int): String = i match {
+    case 0 => "A"
+    case 1 => "C"
+    case 2 => "G"
+    case _ => "T"
+  }
+
+  def baseToInt(c: Char): Int = c match {
+    case 'A' | 'a' => 0
+    case 'C' | 'c' => 1
+    case 'G' | 'g' => 2
+    case 'T' | 't' => 3
+    case _         => 4
+  }
+
+  /**
+   * Performs the read correction step, after transition probabilities have been
+   * estimated. This is done via a coordinate descent process, where the read is
+   * considered to have a different coordinate at each position. We continue as
+   * long as the probability of the read is increasing, and only touch each base
+   * once.
+   *
+   * @param read Tuple of probabilistic sequence and original read.
+   * @param fixingThreshold The threshold to use for correcting a read.
+   * @param fixingThresholdAsPhred The phred score corresponding to the fixing threshold.
+   * @param compensation The covariate prior probability table.
+   * @param kmerTrie Trie containing k-mer "trueness" probabilities.
+   * @param kmerLength Length k to use when cutting k-mers.
+   * @param missingKmerProbability The upper bound probability to assign to any k-mer
+   *                               not in the trie.
+   * @return Returns a fixed read.
+   */
+  private[correction] def correctRead(read: (ProbabilisticSequence, AlignmentRecord),
+                                      fixingThreshold: Double,
+                                      fixingThresholdAsPhred: Char,
+                                      compensation: Map[ErrorCovariate, CategoricalDistribution],
+                                      kmerTrie: DNAPrefixTrie[Double],
+                                      kmerLength: Int,
+                                      missingKmerProbability: Double): AlignmentRecord = {
+
+    @tailrec def tryFix(checkablePositions: Array[((Array[Double], Char), Int)],
+                        pSeq: ProbabilisticSequence,
+                        seq: String,
+                        pRead: Double,
+                        substitutedPositions: Set[Int]): ProbabilisticSequence = {
+      // if there are no further positions we can check, then we are done
+      if (checkablePositions.isEmpty) {
+        pSeq
+      } else {
+        // check the position with the highest probability of a change
+        val toCheck = checkablePositions.minBy(vk => {
+          val ((probabilities, originalBase), _) = vk
+          probabilities(baseToInt(originalBase))
+        })
+
+        // unpack this position
+        val ((probabilities, originalBase), position) = toCheck
+
+        // we want to try the highest probability base
+        val maxIdx = probabilities.indexOf(probabilities.max)
+
+        // if this base is greater than the substitution probability,
+        // we try the change
+        if (probabilities(maxIdx) < fixingThreshold) {
+          // if our current top probability doesn't meet the fixing threshold, we can return
+          pSeq
+        } else {
+          // build the new sequence
+          val newBase = intToBase(maxIdx)
+          val testSequence = seq.take(position) + newBase + seq.drop(position + 1)
+
+          // chop up the new read
+          val testPSeq = cutString(testSequence, kmerTrie, kmerLength, missingKmerProbability, position - kmerLength, position + kmerLength)
+
+          // use the last probabilistic sequence as a prior for the new probablistic sequence
+          // then apply a softmax in place
+          (0 until testPSeq.sequence.length).foreach(i => {
+            (0 to 3).foreach(j => {
+              testPSeq.sequence(i)(j) *= pSeq.sequence(i)(j)
+            })
+          })
+          testPSeq.softMax()
+
+          // is this an improvement?
+          val testPRead = readProbability(testPSeq, testSequence)
+          val (newCPos, newPSeq, newSeq, newPRead, newSub) = if (testPRead > pRead) {
+            // recompute the positions to check
+            val newPositionsToCheck = checkablePositions.flatMap(vk => {
+              val ((_, base), idx) = vk
+
+              // if this site is the site we just evaluated, we can filter it out
+              if (idx == position) {
+                None
+              } else {
+                // collect probabilities for this position from the current probabilistic read
+                val newProbabilities = testPSeq.sequence(idx)
+
+                // what is the max probability at this site?
+                val maxProbability = newProbabilities.max
+
+                // if the current base is the max probability base, we can filter,
+                // else return updated probabilities
+                if (maxProbability == newProbabilities(baseToInt(base))) {
+                  None
+                } else {
+                  Some(((newProbabilities, base), idx))
+                }
+              }
+            })
+
+            // emit new artifacts
+            (newPositionsToCheck, testPSeq, testSequence, testPRead, substitutedPositions + maxIdx)
+          } else {
+            // if we don't have an improvement in probability, we don't make a
+            // change, just filter out the position we just checked
+            (checkablePositions.filter(vk => vk._2 != position), pSeq, seq, pRead, substitutedPositions)
+          }
+
+          // recurse, and try the next fix candidate
+          tryFix(newCPos, newPSeq, newSeq, newPRead, newSub)
+        }
+      }
+    }
+
+    def readProbability(pSeq: ProbabilisticSequence,
+                        read: String): Double = {
+      pSeq.sequence
+        .zip(read)
+        .map(p => {
+          val (pArray, base) = p
+          pArray(baseToInt(base))
+        }).reduce(_ * _)
+    }
+
+    // unpack probabilities and read sequence
+    val (pSeq, oldRead) = read
+    val sequence = oldRead.getSequence.toString
+    val phred = oldRead.getQual.toString
+
+    // compensate all read bases by their transition probabilities
+    val compensatedQualities = pSeq.sequence
+      .zip(sequence.zip(phred))
+      .zipWithIndex
+      .map(vk => {
+        val ((probabilities, (base, qual)), idx) = vk
+
+        // look up prior for this base in the compensation table
+        val priors = compensation(ErrorCovariate(base, idx, qual))
+
+        // compensate by transition probabilities
+        (0 to 3).foreach(i => probabilities(i) *= priors.probability(i))
+
+        // find factor to normalize by
+        val normFactor = 1.0 / probabilities.sum
+
+        // normalize all possibilities
+        (0 to 3).foreach(i => probabilities(i) *= normFactor)
+
+        // return tuple of ((probabilities, base), idx)
+        ((probabilities, base), idx)
+      })
+
+    // create probabilistic sequence by mapping down to probabilities
+    val startPSeq = ProbabilisticSequence(compensatedQualities.map(v => v._1._1).toArray)
+    val pRead = readProbability(startPSeq, sequence)
+
+    // filter out bases that are already over the fixing threshold
+    val positions = compensatedQualities.filter(vk => {
+      val ((probabilities, base), _) = vk
+
+      probabilities(baseToInt(base)) < fixingThreshold
+    })
+
+    // try to fix the read
+    val newPSeq = tryFix(positions,
+      startPSeq,
+      sequence,
+      pRead,
+      Set[Int]())
+    val (newSequence, newQuals) = newPSeq.toSequence
+
+    // finalize the fix and return
+    finalizeFix(oldRead, newSequence, newQuals, fixingThresholdAsPhred)
+  }
+
+  /**
+   * Finalizes a fixed read by trimming low quality bases off of the end of
+   * the read, and converting quals to phred.
+   *
+   * @param oldRead Initial read with all structural information.
+   * @param newSequence The new, error corrected sequence.
+   * @param newQuals The integer phred quality of all bases in the read.
+   * @param fixPhred The phred score limit for accepting a base.
+   * @return Returns a fixed read.
+   */
+  def finalizeFix(oldRead: AlignmentRecord,
+                  newSequence: String,
+                  newQuals: Array[Int],
+                  fixPhred: Char): AlignmentRecord = {
+
+    val phredAsInt = fixPhred.toInt - 33
+
+    def dropLength(array: Array[Int],
+                   reverse: Boolean): Int = {
+      val (startIdx, increment) = if (reverse) {
+        (array.length - 1, -1)
+      } else {
+        (0, 1)
+      }
+
+      @tailrec def dropTest(idx: Int,
+                            dropCount: Int): Int = {
+        if (array(idx) >= phredAsInt) {
+          dropCount
+        } else {
+          dropTest(idx + increment, dropCount + 1)
+        }
+      }
+
+      dropTest(startIdx, 0)
+    }
+
+    // trim ends off of read, if they are below the fixing threshold
+    val trimStart = dropLength(newQuals, false)
+    val trimEnd = dropLength(newQuals, true)
+
+    // rebuild read with trimmed ends
+    AlignmentRecord.newBuilder(oldRead)
+      .setSequence(newSequence.drop(trimStart).dropRight(trimEnd))
+      .setQual(newQuals.drop(trimStart).dropRight(trimEnd).mkString)
+      .setBasesTrimmedFromStart(trimStart)
+      .setBasesTrimmedFromEnd(trimEnd)
+      .build()
+  }
 }

--- a/adam-core/src/test/scala/org/bdgenomics/adam/algorithms/distributions/GammaMixtureModelSuite.scala
+++ b/adam-core/src/test/scala/org/bdgenomics/adam/algorithms/distributions/GammaMixtureModelSuite.scala
@@ -1,0 +1,87 @@
+/**
+ * Licensed to Big Data Genomics (BDG) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The BDG licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.bdgenomics.adam.algorithms.distributions
+
+import org.apache.commons.math3.distribution.{ GammaDistribution => ApacheGammaDistribution }
+import org.apache.commons.math3.random.MersenneTwister
+import org.apache.spark.rdd.RDD
+import org.bdgenomics.adam.util.SparkFunSuite
+import scala.math.abs
+
+class GammaMixtureModelSuite extends SparkFunSuite {
+
+  def fpCompare(a: Double, b: Double, epsilon: Double = 1e-3): Boolean = {
+    abs(a - b) <= epsilon
+  }
+
+  sparkTest("fit a single gamma") {
+    // give a random seed to avoid non-determinism between different runs
+    val rv = new MersenneTwister(1111L)
+    val gamma = new ApacheGammaDistribution(rv, 2.0, 0.5)
+
+    val randomValues = (0 until 10000).map(i => gamma.sample)
+
+    val rdd = sc.parallelize(randomValues)
+
+    val distributions = GammaMixtureModel.fit(rdd, 1, 100)
+
+    assert(distributions.length === 1)
+    assert(fpCompare(distributions(0).alpha, 2.0, 0.1))
+    assert(fpCompare(distributions(0).beta, 2.0, 0.05))
+  }
+
+  sparkTest("fit two gaussians with same beta") {
+    // give a random seed to avoid non-determinism between different runs
+    val rv = new MersenneTwister(1234L)
+    val gamma0 = new ApacheGammaDistribution(rv, 2.0, 0.5)
+    val gamma1 = new ApacheGammaDistribution(rv, 8.0, 2.0)
+
+    val randomValues0 = (0 until 5000).map(i => gamma0.sample)
+    val randomValues1 = (0 until 5000).map(i => gamma1.sample)
+
+    val rdd = sc.parallelize(randomValues0 ++ randomValues1)
+
+    val distributions = GammaMixtureModel.fit(rdd, 2, 100)
+
+    assert(distributions.length === 2)
+    assert(fpCompare(distributions(0).alpha, 2.0, 0.2))
+    assert(fpCompare(distributions(0).beta, 2.0, 0.2))
+    assert(fpCompare(distributions(1).alpha, 8.0, 1.6))
+    assert(fpCompare(distributions(1).beta, 0.5, 0.1))
+  }
+
+  sparkTest("fit two overlapping gammas") {
+    // give a random seed to avoid non-determinism between different runs
+    val rv = new MersenneTwister(4321L)
+    val gamma0 = new ApacheGammaDistribution(rv, 1.0, 0.5)
+    val gamma1 = new ApacheGammaDistribution(rv, 9.0, 2.0)
+
+    val randomValues0 = (0 until 5000).map(i => gamma0.sample)
+    val randomValues1 = (0 until 5000).map(i => gamma1.sample)
+
+    val rdd = sc.parallelize(randomValues0 ++ randomValues1)
+
+    val distributions = GammaMixtureModel.fit(rdd, 2, 100)
+
+    assert(distributions.length === 2)
+    assert(fpCompare(distributions(0).alpha, 1.0, 0.05))
+    assert(fpCompare(distributions(0).beta, 2.0, 0.05))
+    assert(fpCompare(distributions(1).alpha, 9.0, 0.7))
+    assert(fpCompare(distributions(1).beta, 0.5, 0.05))
+  }
+}

--- a/adam-core/src/test/scala/org/bdgenomics/adam/algorithms/distributions/UnivariateNormalMixtureModelSuite.scala
+++ b/adam-core/src/test/scala/org/bdgenomics/adam/algorithms/distributions/UnivariateNormalMixtureModelSuite.scala
@@ -1,0 +1,81 @@
+/**
+ * Licensed to Big Data Genomics (BDG) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The BDG licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.bdgenomics.adam.algorithms.distributions
+
+import org.apache.spark.rdd.RDD
+import org.bdgenomics.adam.util.SparkFunSuite
+import scala.math.abs
+import scala.util.Random
+
+class UnivariateNormalMixtureModelSuite extends SparkFunSuite {
+
+  def fpCompare(a: Double, b: Double, epsilon: Double = 1e-3): Boolean = {
+    abs(a - b) <= epsilon
+  }
+
+  sparkTest("fit a single gaussian") {
+    // give a random seed to avoid non-determinism between different runs
+    val rv = new Random(1111L)
+
+    val randomValues0 = (0 until 10000).map(i => rv.nextGaussian)
+
+    val rdd = sc.parallelize(randomValues0)
+
+    val distributions = UnivariateNormalMixtureModel.fit(rdd, 1, 100)
+
+    assert(distributions.length === 1)
+    assert(fpCompare(distributions(0).mu, 0.0, 0.05))
+    assert(fpCompare(distributions(0).sigma, 1.0, 0.05))
+  }
+
+  sparkTest("fit two gaussians with same standard deviation") {
+    // give a random seed to avoid non-determinism between different runs
+    val rv = new Random(1234L)
+
+    val randomValues0 = (0 until 5000).map(i => rv.nextGaussian)
+    val randomValues2 = (0 until 5000).map(i => 2.0 + rv.nextGaussian)
+
+    val rdd = sc.parallelize(randomValues0 ++ randomValues2)
+
+    val distributions = UnivariateNormalMixtureModel.fit(rdd, 2, 100)
+
+    assert(distributions.length === 2)
+    assert(fpCompare(distributions(0).mu, 0.0, 0.05))
+    assert(fpCompare(distributions(0).sigma, 1.0, 0.05))
+    assert(fpCompare(distributions(1).mu, 2.0, 0.05))
+    assert(fpCompare(distributions(1).sigma, 1.0, 0.05))
+  }
+
+  sparkTest("fit two overlapping gaussians") {
+    // give a random seed to avoid non-determinism between different runs
+    val rv = new Random(4321L)
+
+    val randomValues0p5 = (0 until 5000).map(i => rv.nextGaussian)
+    val randomValues2 = (0 until 5000).map(i => 1.0 + rv.nextGaussian)
+
+    val rdd = sc.parallelize(randomValues0p5 ++ randomValues2)
+
+    val distributions = UnivariateNormalMixtureModel.fit(rdd, 2, 100)
+
+    assert(distributions.length === 2)
+    assert(fpCompare(distributions(0).mu, 0.0, 0.1))
+    assert(fpCompare(distributions(0).sigma, 1.0, 0.1))
+    assert(fpCompare(distributions(1).mu, 1.0, 0.1))
+    assert(fpCompare(distributions(1).sigma, 1.0, 0.1))
+  }
+}

--- a/adam-core/src/test/scala/org/bdgenomics/adam/rdd/read/correction/ErrorCorrectionSuite.scala
+++ b/adam-core/src/test/scala/org/bdgenomics/adam/rdd/read/correction/ErrorCorrectionSuite.scala
@@ -17,11 +17,14 @@
  */
 package org.bdgenomics.adam.rdd.read.correction
 
+import org.bdgenomics.adam.algorithms.distributions.CategoricalDistribution
+import org.bdgenomics.adam.algorithms.prefixtrie.DNAPrefixTrie
+import org.bdgenomics.adam.util.{ PhredUtils, SparkFunSuite }
 import org.bdgenomics.formats.avro.AlignmentRecord
-import org.scalatest.FunSuite
-import scala.math.abs
+import scala.math.{ abs, pow, log }
+import scala.util.Random
 
-class ErrorCorrectionSuite extends FunSuite {
+class ErrorCorrectionSuite extends SparkFunSuite {
 
   val ec = new ErrorCorrection
 
@@ -44,5 +47,138 @@ class ErrorCorrectionSuite extends FunSuite {
     assert(fpCompare(qmers("TCA"), 0.983))
     assert(fpCompare(qmers("CAT"), 0.979))
     assert(fpCompare(qmers("ATG"), 0.980))
+  }
+
+  test("correct an error in a single read") {
+    val ec = new ErrorCorrection
+
+    // seed a random variable
+    val rv = new Random(432112344321L)
+
+    // build a reference string
+    val ref = (0 until 100).map(i => {
+      // generate a base
+      rv.nextInt(4) match {
+        case 0 => 'A'
+        case 1 => 'C'
+        case 2 => 'G'
+        case _ => 'T'
+      }
+    }).mkString
+
+    // select a base to change into an error
+    val errorBase = rv.nextInt(100)
+
+    var base: Char = 'N'
+    do {
+      base = rv.nextInt(4) match {
+        case 0 => 'A'
+        case 1 => 'C'
+        case 2 => 'G'
+        case _ => 'T'
+      }
+    } while (base == ref(errorBase))
+
+    // build read string
+    val readString = ref.take(errorBase) + base + ref.drop(errorBase + 1)
+    val readQual = "." * 100
+
+    // build prefix trie
+    val pt = DNAPrefixTrie(ref.sliding(20)
+      .map(s => (s, 0.99))
+      .toSeq
+      .toMap)
+
+    // build error covariate map
+    val ecMap = (0 until 100).map(i => {
+      (ErrorCovariate(readString(i), i, '.'), CategoricalDistribution(Array(0.25, 0.25, 0.25, 0.25)))
+    }).toMap
+
+    // start chopping things
+    val cutRead = ec.cutRead(AlignmentRecord.newBuilder()
+      .setSequence(readString)
+      .setQual(readQual)
+      .build(), pt, 20, 0.05)
+
+    // correct things
+    val correctedRead = ec.correctRead(cutRead, 0.5, '$', ecMap, pt, 20, 0.05)
+
+    assert(correctedRead.getSequence.toString === ref)
+  }
+
+  def createReferenceAndReads(rv: Random,
+                              errorRate: Double,
+                              referenceLength: Int,
+                              skipDistance: Int,
+                              readLength: Int): (Seq[AlignmentRecord], String) = {
+    // generate reference string
+    val refString = (0 until referenceLength).map(i => {
+      // generate a base
+      rv.nextInt(4) match {
+        case 0 => 'A'
+        case 1 => 'C'
+        case 2 => 'G'
+        case _ => 'T'
+      }
+    }).mkString
+
+    // generate read strings
+    val reads = refString.sliding(readLength, skipDistance)
+      .zipWithIndex
+      .map(kv => {
+        val (s, i) = kv
+
+        // "mutate" string
+        val (sequence, qual) = s.map(b => {
+          if (rv.nextDouble >= errorRate) {
+            (b, (PhredUtils.errorProbabilityToPhred(errorRate) + 29 + rv.nextInt(10)).toChar)
+          } else {
+            (rv.nextInt(4) match {
+              case 0 => 'A'
+              case 1 => 'C'
+              case 2 => 'G'
+              case _ => 'T'
+            }, (rv.nextInt(8) + 35).toChar)
+          }
+        }).unzip(p => (p._1, p._2))
+
+        AlignmentRecord.newBuilder()
+          .setSequence(sequence.mkString)
+          .setQual(qual.mkString)
+          .setStart(i * skipDistance)
+          .build()
+      }).toSeq
+
+    (reads, refString)
+  }
+
+  sparkTest("correct errors for 50x coverage at 100bp, 2% errors") {
+    // create a seeded (deterministic) random variable
+    val rv = new Random(123321L)
+
+    // create reads and reference
+    val (reads, reference) = createReferenceAndReads(rv, 0.02, 1000, 2, 100)
+
+    // correct read errors
+    val correctedReads = ErrorCorrection(sc.parallelize(reads), 20, 50, 10, 0.5, 0.02, 1)
+    correctedReads.cache()
+
+    // loop and check reads
+    val errorRate = correctedReads.map(r => {
+      r.getSequence
+        .toString
+        .zip(reference.drop(r.getStart.toInt).take(100))
+        .map(p => {
+          if (p._1 == p._2) {
+            0.0
+          } else {
+            1.0
+          }
+        }).reduce(_ + _) / 100.0
+    }).reduce(_ + _) / correctedReads.count().toDouble
+
+    // we should reduce the error rate by about an order of magnitude
+    assert(errorRate < 0.003)
+    correctedReads.unpersist()
   }
 }

--- a/adam-core/src/test/scala/org/bdgenomics/adam/rdd/read/correction/TrimReadsSuite.scala
+++ b/adam-core/src/test/scala/org/bdgenomics/adam/rdd/read/correction/TrimReadsSuite.scala
@@ -154,4 +154,47 @@ class TrimReadsSuite extends SparkFunSuite {
     })
   }
 
+  test("trim N's from reads") {
+    val tr = new TrimReads
+
+    val r1 = AlignmentRecord.newBuilder()
+      .setSequence("NNNACAC")
+      .setQual("...,,,,")
+      .build()
+
+    val t1 = ec.trimNs(r1)
+
+    assert(t1.getSequence === "ACAC")
+    assert(t1.getQual === ",,,,")
+    assert(t1.getBasesTrimmedFromStart === 3)
+    assert(t1.getBasesTrimmedFromEnd === 0)
+
+    val r2 = AlignmentRecord.newBuilder()
+      .setSequence("NACACN")
+      .setQual(".,,,,.")
+      .setBasesTrimmedFromStart(0)
+      .setBasesTrimmedFromEnd(0)
+      .build()
+
+    val t2 = ec.trimNs(r2)
+
+    assert(t2.getSequence === "ACAC")
+    assert(t2.getQual === ",,,,")
+    assert(t2.getBasesTrimmedFromStart === 1)
+    assert(t2.getBasesTrimmedFromEnd === 1)
+
+    val r3 = AlignmentRecord.newBuilder()
+      .setSequence("ACACGGGACTTAACnnnn")
+      .setQual(",,,,,,,,,,,,,,....")
+      .setBasesTrimmedFromStart(6)
+      .setBasesTrimmedFromEnd(0)
+      .build()
+
+    val t3 = ec.trimNs(r3)
+
+    assert(t3.getSequence === "ACACGGGACTTAAC")
+    assert(t3.getQual === ",,,,,,,,,,,,,,")
+    assert(t3.getBasesTrimmedFromStart === 6)
+    assert(t3.getBasesTrimmedFromEnd === 4)
+  }
 }

--- a/bin/adam-submit
+++ b/bin/adam-submit
@@ -53,6 +53,8 @@ fi
   --conf spark.kryo.registrator=org.bdgenomics.adam.serialization.ADAMKryoRegistrator \
   --conf spark.kryoserializer.buffer.mb=4 \
   --conf spark.kryo.referenceTracking=true \
+  --conf spark.executor.memory=4g \
+  --driver-memory 4g \
   --jars "$ADAM_JARS" \
   "$ADAM_CLI_JAR" \
   "$@"

--- a/pom.xml
+++ b/pom.xml
@@ -24,7 +24,7 @@
     <spark.version>1.1.0</spark.version>
     <parquet.version>1.4.3</parquet.version>
     <!-- Edit the following line to configure the Hadoop (HDFS) version. -->
-    <hadoop.version>2.2.0</hadoop.version>
+    <hadoop.version>1.0.4</hadoop.version>
     <scoverage.version>0.99.2</scoverage.version>
     <chill.version>0.5.0</chill.version>
   </properties>
@@ -347,6 +347,11 @@
         <version>1.3.2</version>
       </dependency>
       <dependency>
+        <groupId>org.apache.commons</groupId>
+        <artifactId>commons-math3</artifactId>
+        <version>3.3</version>
+      </dependency>
+      <dependency>
         <groupId>it.unimi.dsi</groupId>
         <artifactId>fastutil</artifactId>
         <version>6.4.4</version>
@@ -425,6 +430,11 @@
             <artifactId>hadoop-mapreduce</artifactId>
           </exclusion>
         </exclusions>
+      </dependency>
+      <dependency>
+        <groupId>org.apache.spark</groupId>
+        <artifactId>spark-mllib_${scala.artifact.suffix}</artifactId>
+        <version>${spark.version}</version>
       </dependency>
       <dependency>
         <groupId>org.apache.avro</groupId>


### PR DESCRIPTION
Fixes #401, by adding a read error correction. This algorithm follows the following general approach:
1. Reads are cut into _q_-mers, which are quality score weighted _k_-mers
2. A mixture of gammas is fit to the data, where the mixture contains _m_ + 1 components (_m_ = ploidy). These components include an "error" class, _m_ - 1 heterozygous classes, and 1 homozygous class.
3. To each _q_-mer, we assign a probability that it _is_ a "true" _q_-mer, given the above mixture model.
4. To each read, we assign base probabilities by looking at the truth probabilities of all _k_-mers that cover the base.
5. From this, we collect MLEs for the transition probabilities of each base. Our covariates include the measured quality score of the base, the position of the base in the read, and the sequenced base.
6. These transition probabilities are used as priors for the fixing process. For each read, we compute the likelihoods of each base using the _q_-mer "truth" probabilities from step 3. We first compensate by the priors. After this, we try to fix bases in the read. We employ a coordinate ascent method, using the probabilities we calculate at each step as conjugate priors for each new fixing step.

On a small test, this appears to reduce the error rate by about an order of magnitude, as is expected. I'll be doing more tests this week, and will be putting together a writeup describing the method.
