### PR TITLE
[ADAM-416] Removing 'ADAM' prefix

### DIFF
--- a/adam-apis/src/main/scala/org/bdgenomics/adam/apis/java/JavaAlignmentRecordRDD.scala
+++ b/adam-apis/src/main/scala/org/bdgenomics/adam/apis/java/JavaAlignmentRecordRDD.scala
@@ -19,7 +19,7 @@ package org.bdgenomics.adam.apis.java
 
 import org.apache.spark.api.java.JavaRDD
 import org.bdgenomics.adam.rdd.ADAMContext._
-import org.bdgenomics.adam.rdd.read.ADAMAlignmentRecordContext._
+import org.bdgenomics.adam.rdd.read.AlignmentRecordContext._
 import org.bdgenomics.formats.avro._
 import parquet.hadoop.metadata.CompressionCodecName
 

--- a/adam-cli/src/main/scala/org/bdgenomics/adam/cli/ADAM2Vcf.scala
+++ b/adam-cli/src/main/scala/org/bdgenomics/adam/cli/ADAM2Vcf.scala
@@ -19,7 +19,7 @@ package org.bdgenomics.adam.cli
 
 import org.bdgenomics.formats.avro.Genotype
 import org.bdgenomics.adam.rdd.ADAMContext._
-import org.bdgenomics.adam.rdd.variation.ADAMVariationContext._
+import org.bdgenomics.adam.rdd.variation.VariationContext._
 import org.kohsuke.args4j.{ Option => Args4jOption, Argument }
 import org.apache.spark.rdd.RDD
 import org.apache.spark.{ Logging, SparkContext }

--- a/adam-cli/src/main/scala/org/bdgenomics/adam/cli/CountKmers.scala
+++ b/adam-cli/src/main/scala/org/bdgenomics/adam/cli/CountKmers.scala
@@ -22,7 +22,7 @@ import org.apache.hadoop.mapreduce.Job
 import org.apache.spark.{ SparkContext, Logging }
 import org.apache.spark.rdd.RDD
 import org.bdgenomics.adam.rdd.ADAMContext._
-import org.bdgenomics.adam.rdd.read.ADAMAlignmentRecordContext._
+import org.bdgenomics.adam.rdd.read.AlignmentRecordContext._
 import org.bdgenomics.adam.util.ParquetLogger
 import org.bdgenomics.formats.avro.AlignmentRecord
 import org.kohsuke.args4j.{ Argument, Option => Args4jOption }

--- a/adam-cli/src/main/scala/org/bdgenomics/adam/cli/Fasta2ADAM.scala
+++ b/adam-cli/src/main/scala/org/bdgenomics/adam/cli/Fasta2ADAM.scala
@@ -21,8 +21,8 @@ import org.apache.hadoop.mapreduce.Job
 import org.apache.spark.{ Logging, SparkContext }
 import org.bdgenomics.adam.rdd.ADAMContext._
 import org.bdgenomics.adam.rdd.ADAMContext
-import org.bdgenomics.adam.rdd.contig.ADAMNucleotideContigFragmentContext._
-import org.bdgenomics.adam.rdd.contig.ADAMNucleotideContigFragmentContext
+import org.bdgenomics.adam.rdd.contig.NucleotideContigFragmentContext._
+import org.bdgenomics.adam.rdd.contig.NucleotideContigFragmentContext
 import org.bdgenomics.formats.avro.AlignmentRecord
 import org.kohsuke.args4j.{ Argument, Option => Args4jOption }
 
@@ -53,7 +53,7 @@ class Fasta2ADAM(protected val args: Fasta2ADAMArgs) extends ADAMSparkCommand[Fa
 
   def run(sc: SparkContext, job: Job) {
     log.info("Loading FASTA data from disk.")
-    val adamFasta = new ADAMNucleotideContigFragmentContext(sc).adamSequenceLoad(args.fastaFile, args.fragmentLength)
+    val adamFasta = new NucleotideContigFragmentContext(sc).adamSequenceLoad(args.fastaFile, args.fragmentLength)
     if (args.verbose) {
       println("FASTA contains:")
       println(adamFasta.adamGetSequenceDictionary())

--- a/adam-cli/src/main/scala/org/bdgenomics/adam/cli/Features2ADAM.scala
+++ b/adam-cli/src/main/scala/org/bdgenomics/adam/cli/Features2ADAM.scala
@@ -22,7 +22,7 @@ import org.apache.spark.SparkContext
 import org.apache.spark.rdd.RDD
 import org.bdgenomics.adam.models.BaseFeature
 import org.bdgenomics.adam.rdd.ADAMContext._
-import org.bdgenomics.adam.rdd.features.ADAMFeaturesContext._
+import org.bdgenomics.adam.rdd.features.FeaturesContext._
 import org.bdgenomics.formats.avro.Feature
 import org.kohsuke.args4j.Argument
 

--- a/adam-cli/src/main/scala/org/bdgenomics/adam/cli/FlagStat.scala
+++ b/adam-cli/src/main/scala/org/bdgenomics/adam/cli/FlagStat.scala
@@ -22,7 +22,7 @@ import org.apache.spark.SparkContext
 import org.apache.spark.rdd.RDD
 import org.bdgenomics.adam.projections.{ Projection, AlignmentRecordField }
 import org.bdgenomics.adam.rdd.ADAMContext._
-import org.bdgenomics.adam.rdd.read.ADAMAlignmentRecordContext._
+import org.bdgenomics.adam.rdd.read.AlignmentRecordContext._
 import org.bdgenomics.formats.avro.AlignmentRecord
 import org.kohsuke.args4j.Argument
 

--- a/adam-cli/src/main/scala/org/bdgenomics/adam/cli/GenotypeConcordance.scala
+++ b/adam-cli/src/main/scala/org/bdgenomics/adam/cli/GenotypeConcordance.scala
@@ -25,7 +25,7 @@ import org.kohsuke.args4j.{ Argument, Option => Args4jOption }
 import org.bdgenomics.adam.predicates.GenotypeRecordPASSPredicate
 import org.bdgenomics.adam.projections.GenotypeField
 import org.bdgenomics.adam.rdd.ADAMContext._
-import org.bdgenomics.adam.rdd.variation.ADAMVariationContext._
+import org.bdgenomics.adam.rdd.variation.VariationContext._
 import org.bdgenomics.adam.rdd.variation.ConcordanceTable
 import org.bdgenomics.formats.avro.Genotype
 

--- a/adam-cli/src/main/scala/org/bdgenomics/adam/cli/PrintGenes.scala
+++ b/adam-cli/src/main/scala/org/bdgenomics/adam/cli/PrintGenes.scala
@@ -20,7 +20,7 @@ package org.bdgenomics.adam.cli
 import org.apache.hadoop.mapreduce.Job
 import org.apache.spark.rdd.RDD
 import org.bdgenomics.adam.models._
-import org.bdgenomics.adam.rdd.features.ADAMFeaturesContext._
+import org.bdgenomics.adam.rdd.features.FeaturesContext._
 import org.bdgenomics.adam.models.GeneContext._
 import org.bdgenomics.adam.rdd.features.GeneFeatureRDD._
 import org.bdgenomics.formats.avro.Feature

--- a/adam-cli/src/main/scala/org/bdgenomics/adam/cli/PrintTags.scala
+++ b/adam-cli/src/main/scala/org/bdgenomics/adam/cli/PrintTags.scala
@@ -23,7 +23,7 @@ import org.apache.spark.rdd.RDD
 import org.bdgenomics.adam.projections.AlignmentRecordField._
 import org.bdgenomics.adam.projections.Projection
 import org.bdgenomics.adam.rdd.ADAMContext._
-import org.bdgenomics.adam.rdd.read.ADAMAlignmentRecordContext._
+import org.bdgenomics.adam.rdd.read.AlignmentRecordContext._
 import org.bdgenomics.formats.avro.AlignmentRecord
 import org.kohsuke.args4j.{ Argument, Option }
 

--- a/adam-cli/src/main/scala/org/bdgenomics/adam/cli/Reads2Ref.scala
+++ b/adam-cli/src/main/scala/org/bdgenomics/adam/cli/Reads2Ref.scala
@@ -22,8 +22,8 @@ import org.apache.spark.SparkContext
 import org.apache.spark.rdd.RDD
 import org.bdgenomics.adam.predicates.UniqueMappedReadPredicate
 import org.bdgenomics.adam.rdd.ADAMContext._
-import org.bdgenomics.adam.rdd.pileup.ADAMPileupContext._
-import org.bdgenomics.adam.rdd.read.ADAMAlignmentRecordContext._
+import org.bdgenomics.adam.rdd.pileup.PileupContext._
+import org.bdgenomics.adam.rdd.read.AlignmentRecordContext._
 import org.bdgenomics.formats.avro.{ AlignmentRecord, Pileup }
 import org.kohsuke.args4j.{ Option => option, Argument }
 

--- a/adam-cli/src/main/scala/org/bdgenomics/adam/cli/Transform.scala
+++ b/adam-cli/src/main/scala/org/bdgenomics/adam/cli/Transform.scala
@@ -22,8 +22,8 @@ import org.apache.spark.{ SparkContext, Logging }
 import org.apache.spark.rdd.RDD
 import org.bdgenomics.adam.models.SnpTable
 import org.bdgenomics.adam.rdd.ADAMContext._
-import org.bdgenomics.adam.rdd.read.ADAMAlignmentRecordContext._
-import org.bdgenomics.adam.rdd.variation.ADAMVariationContext._
+import org.bdgenomics.adam.rdd.read.AlignmentRecordContext._
+import org.bdgenomics.adam.rdd.variation.VariationContext._
 import org.bdgenomics.adam.rich.RichVariant
 import org.bdgenomics.formats.avro.AlignmentRecord
 import org.kohsuke.args4j.{ Argument, Option => Args4jOption }

--- a/adam-cli/src/main/scala/org/bdgenomics/adam/cli/Vcf2ADAM.scala
+++ b/adam-cli/src/main/scala/org/bdgenomics/adam/cli/Vcf2ADAM.scala
@@ -19,7 +19,7 @@ package org.bdgenomics.adam.cli
 
 import org.bdgenomics.adam.models.{ SequenceDictionary, VariantContext }
 import org.bdgenomics.adam.rdd.ADAMContext._
-import org.bdgenomics.adam.rdd.variation.ADAMVariationContext._
+import org.bdgenomics.adam.rdd.variation.VariationContext._
 import org.apache.hadoop.mapreduce.Job
 import org.apache.spark.{ Logging, SparkContext }
 import org.apache.spark.rdd.RDD

--- a/adam-cli/src/main/scala/org/bdgenomics/adam/cli/VcfAnnotation2ADAM.scala
+++ b/adam-cli/src/main/scala/org/bdgenomics/adam/cli/VcfAnnotation2ADAM.scala
@@ -36,7 +36,7 @@ package org.bdgenomics.adam.cli
 import org.apache.hadoop.mapreduce.Job
 import org.apache.spark.{ Logging, SparkContext }
 import org.kohsuke.args4j.{ Argument, Option => Args4jOption }
-import org.bdgenomics.adam.rdd.variation.ADAMVariationContext._
+import org.bdgenomics.adam.rdd.variation.VariationContext._
 import org.bdgenomics.adam.rdd.ADAMContext._
 import org.bdgenomics.formats.avro._
 import org.apache.spark.rdd.RDD

--- a/adam-cli/src/main/scala/org/bdgenomics/adam/cli/VizReads.scala
+++ b/adam-cli/src/main/scala/org/bdgenomics/adam/cli/VizReads.scala
@@ -24,7 +24,7 @@ import org.bdgenomics.adam.models.{ OrderedTrackedLayout, ReferenceRegion }
 import org.bdgenomics.adam.projections.AlignmentRecordField._
 import org.bdgenomics.adam.projections.Projection
 import org.bdgenomics.adam.rdd.ADAMContext._
-import org.bdgenomics.adam.rdd.read.ADAMAlignmentRecordContext._
+import org.bdgenomics.adam.rdd.read.AlignmentRecordContext._
 import org.bdgenomics.adam.rich.ReferenceMappingContext.AlignmentRecordReferenceMapping
 import org.bdgenomics.formats.avro.AlignmentRecord
 import org.fusesource.scalate.TemplateEngine

--- a/adam-core/src/main/scala/org/bdgenomics/adam/algorithms/consensus/ConsensusGeneratorFromKnowns.scala
+++ b/adam-core/src/main/scala/org/bdgenomics/adam/algorithms/consensus/ConsensusGeneratorFromKnowns.scala
@@ -22,7 +22,7 @@ import org.apache.spark.rdd.RDD
 import org.bdgenomics.adam.models._
 import org.bdgenomics.adam.rdd.ADAMContext._
 import org.bdgenomics.adam.rdd.read.realignment.IndelRealignmentTarget
-import org.bdgenomics.adam.rdd.variation.ADAMVariationContext._
+import org.bdgenomics.adam.rdd.variation.VariationContext._
 import org.bdgenomics.adam.rich.RichAlignmentRecord
 
 class ConsensusGeneratorFromKnowns(file: String, sc: SparkContext) extends ConsensusGenerator {

--- a/adam-core/src/main/scala/org/bdgenomics/adam/models/IndelTable.scala
+++ b/adam-core/src/main/scala/org/bdgenomics/adam/models/IndelTable.scala
@@ -20,7 +20,7 @@ package org.bdgenomics.adam.models
 import org.apache.spark.{ Logging, SparkContext }
 import org.apache.spark.SparkContext._
 import org.apache.spark.rdd.RDD
-import org.bdgenomics.adam.rdd.variation.ADAMVariationContext._
+import org.bdgenomics.adam.rdd.variation.VariationContext._
 import org.bdgenomics.formats.avro.Variant
 
 class IndelTable(private val table: Map[String, Iterable[Consensus]]) extends Serializable with Logging {

--- a/adam-core/src/main/scala/org/bdgenomics/adam/models/VariantContext.scala
+++ b/adam-core/src/main/scala/org/bdgenomics/adam/models/VariantContext.scala
@@ -23,7 +23,7 @@ import org.bdgenomics.adam.rich.RichVariant._
 
 /**
  * Note: VariantContext inherits its name from the Picard VariantContext, and is not related to the SparkContext object.
- * If you're looking for the latter, see [[org.bdgenomics.adam.rdd.variation.ADAMVariationContext]]
+ * If you're looking for the latter, see [[org.bdgenomics.adam.rdd.variation.VariationContext]]
  */
 
 object VariantContext {

--- a/adam-core/src/main/scala/org/bdgenomics/adam/rdd/ADAMContext.scala
+++ b/adam-core/src/main/scala/org/bdgenomics/adam/rdd/ADAMContext.scala
@@ -33,7 +33,7 @@ import org.bdgenomics.adam.instrumentation.ADAMMetricsListener
 import org.bdgenomics.adam.models._
 import org.bdgenomics.adam.predicates.ADAMPredicate
 import org.bdgenomics.adam.projections.{ AlignmentRecordField, NucleotideContigFragmentField, Projection }
-import org.bdgenomics.adam.rdd.read.ADAMAlignmentRecordContext
+import org.bdgenomics.adam.rdd.read.AlignmentRecordContext
 import org.bdgenomics.adam.rich.RichAlignmentRecord
 import org.bdgenomics.adam.util.HadoopUtil
 import org.bdgenomics.formats.avro.{ AlignmentRecord, NucleotideContigFragment, Pileup }
@@ -195,7 +195,7 @@ class ADAMContext(val sc: SparkContext) extends Serializable with Logging {
       if (projection.isDefined) {
         log.warn("Projection is ignored when loading a BAM file")
       }
-      val reads = ADAMAlignmentRecordContext.adamBamLoad(sc, filePath).asInstanceOf[RDD[T]]
+      val reads = AlignmentRecordContext.adamBamLoad(sc, filePath).asInstanceOf[RDD[T]]
       if (predicate.isDefined) {
         val predicateClass = predicate.get
         val filter = predicateClass.newInstance()
@@ -208,7 +208,7 @@ class ADAMContext(val sc: SparkContext) extends Serializable with Logging {
       if (projection.isDefined) {
         log.warn("Projection is ignored when loading an interleaved FASTQ file")
       }
-      val reads = ADAMAlignmentRecordContext.adamInterleavedFastqLoad(sc, filePath).asInstanceOf[RDD[T]]
+      val reads = AlignmentRecordContext.adamInterleavedFastqLoad(sc, filePath).asInstanceOf[RDD[T]]
       if (predicate.isDefined) {
         val predicateClass = predicate.get
         val filter = predicateClass.newInstance()
@@ -221,7 +221,7 @@ class ADAMContext(val sc: SparkContext) extends Serializable with Logging {
       if (projection.isDefined) {
         log.warn("Projection is ignored when loading a FASTQ file")
       }
-      val reads = ADAMAlignmentRecordContext.adamUnpairedFastqLoad(sc, filePath).asInstanceOf[RDD[T]]
+      val reads = AlignmentRecordContext.adamUnpairedFastqLoad(sc, filePath).asInstanceOf[RDD[T]]
       if (predicate.isDefined) {
         val predicateClass = predicate.get
         val filter = predicateClass.newInstance()

--- a/adam-core/src/main/scala/org/bdgenomics/adam/rdd/contig/NucleotideContigFragmentContext.scala
+++ b/adam-core/src/main/scala/org/bdgenomics/adam/rdd/contig/NucleotideContigFragmentContext.scala
@@ -25,15 +25,15 @@ import org.bdgenomics.adam.converters.FastaConverter
 import org.bdgenomics.adam.rdd.ADAMContext._
 import org.bdgenomics.formats.avro.NucleotideContigFragment
 
-object ADAMNucleotideContigFragmentContext {
+object NucleotideContigFragmentContext {
   // Add ADAM Spark context methods
-  implicit def sparkContextToADAMContext(sc: SparkContext): ADAMNucleotideContigFragmentContext = new ADAMNucleotideContigFragmentContext(sc)
+  implicit def sparkContextToADAMContext(sc: SparkContext): NucleotideContigFragmentContext = new NucleotideContigFragmentContext(sc)
 
   // Add methods specific to the ADAMNucleotideContig RDDs
-  implicit def rddToContigFragmentRDD(rdd: RDD[NucleotideContigFragment]) = new ADAMNucleotideContigFragmentRDDFunctions(rdd)
+  implicit def rddToContigFragmentRDD(rdd: RDD[NucleotideContigFragment]) = new NucleotideContigFragmentRDDFunctions(rdd)
 }
 
-class ADAMNucleotideContigFragmentContext(val sc: SparkContext) extends Serializable with Logging {
+class NucleotideContigFragmentContext(val sc: SparkContext) extends Serializable with Logging {
 
   def adamSequenceLoad(filePath: String, fragmentLength: Long): RDD[NucleotideContigFragment] = {
     if (filePath.endsWith(".fasta") || filePath.endsWith(".fa")) {

--- a/adam-core/src/main/scala/org/bdgenomics/adam/rdd/contig/NucleotideContigFragmentRDDFunctions.scala
+++ b/adam-core/src/main/scala/org/bdgenomics/adam/rdd/contig/NucleotideContigFragmentRDDFunctions.scala
@@ -37,7 +37,7 @@ import parquet.hadoop.util.ContextUtil
 import scala.math.max
 import scala.Some
 
-class ADAMNucleotideContigFragmentRDDFunctions(rdd: RDD[NucleotideContigFragment]) extends ADAMSequenceDictionaryRDDAggregator[NucleotideContigFragment](rdd) {
+class NucleotideContigFragmentRDDFunctions(rdd: RDD[NucleotideContigFragment]) extends ADAMSequenceDictionaryRDDAggregator[NucleotideContigFragment](rdd) {
 
   /**
    * Rewrites the contig IDs of a FASTA reference set to match the contig IDs present in a

--- a/adam-core/src/main/scala/org/bdgenomics/adam/rdd/features/FeaturesContext.scala
+++ b/adam-core/src/main/scala/org/bdgenomics/adam/rdd/features/FeaturesContext.scala
@@ -15,17 +15,27 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.bdgenomics.adam.rdd.pileup
+package org.bdgenomics.adam.rdd.features
 
+import org.apache.spark.{ SparkContext, Logging }
 import org.apache.spark.rdd.RDD
-import org.bdgenomics.adam.models._
-import org.bdgenomics.formats.avro.Pileup
+import org.bdgenomics.formats.avro.Feature
 
-object ADAMPileupContext {
+object FeaturesContext {
+  implicit def sparkContextToADAMFeaturesContext(sc: SparkContext): FeaturesContext = new FeaturesContext(sc)
+}
 
-  // Add methods specific to the Pileup RDDs
-  implicit def rddToADAMPileupRDD(rdd: RDD[Pileup]) = new ADAMPileupRDDFunctions(rdd)
+class FeaturesContext(sc: SparkContext) extends Serializable with Logging {
 
-  // Add methods specific to the Rod RDDs
-  implicit def rddToRodRDD(rdd: RDD[Rod]) = new ADAMRodRDDFunctions(rdd)
+  def adamGTFFeatureLoad(filePath: String): RDD[Feature] = {
+    sc.textFile(filePath).flatMap(new GTFParser().parse)
+  }
+
+  def adamBEDFeatureLoad(filePath: String): RDD[Feature] = {
+    sc.textFile(filePath).flatMap(new BEDParser().parse)
+  }
+
+  def adamNarrowPeakFeatureLoad(filePath: String): RDD[Feature] = {
+    sc.textFile(filePath).flatMap(new NarrowPeakParser().parse)
+  }
 }

--- a/adam-core/src/main/scala/org/bdgenomics/adam/rdd/pileup/PileupContext.scala
+++ b/adam-core/src/main/scala/org/bdgenomics/adam/rdd/pileup/PileupContext.scala
@@ -15,27 +15,17 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.bdgenomics.adam.rdd.features
+package org.bdgenomics.adam.rdd.pileup
 
-import org.apache.spark.{ SparkContext, Logging }
 import org.apache.spark.rdd.RDD
-import org.bdgenomics.formats.avro.Feature
+import org.bdgenomics.adam.models._
+import org.bdgenomics.formats.avro.Pileup
 
-object ADAMFeaturesContext {
-  implicit def sparkContextToADAMFeaturesContext(sc: SparkContext): ADAMFeaturesContext = new ADAMFeaturesContext(sc)
-}
+object PileupContext {
 
-class ADAMFeaturesContext(sc: SparkContext) extends Serializable with Logging {
+  // Add methods specific to the Pileup RDDs
+  implicit def rddToPileupRDD(rdd: RDD[Pileup]) = new PileupRDDFunctions(rdd)
 
-  def adamGTFFeatureLoad(filePath: String): RDD[Feature] = {
-    sc.textFile(filePath).flatMap(new GTFParser().parse)
-  }
-
-  def adamBEDFeatureLoad(filePath: String): RDD[Feature] = {
-    sc.textFile(filePath).flatMap(new BEDParser().parse)
-  }
-
-  def adamNarrowPeakFeatureLoad(filePath: String): RDD[Feature] = {
-    sc.textFile(filePath).flatMap(new NarrowPeakParser().parse)
-  }
+  // Add methods specific to the Rod RDDs
+  implicit def rddToRodRDD(rdd: RDD[Rod]) = new RodRDDFunctions(rdd)
 }

--- a/adam-core/src/main/scala/org/bdgenomics/adam/rdd/pileup/PileupRDDFunctions.scala
+++ b/adam-core/src/main/scala/org/bdgenomics/adam/rdd/pileup/PileupRDDFunctions.scala
@@ -22,7 +22,7 @@ import org.apache.spark.rdd.RDD
 import org.bdgenomics.adam.models._
 import org.bdgenomics.formats.avro._
 
-class ADAMPileupRDDFunctions(rdd: RDD[Pileup]) extends Serializable with Logging {
+class PileupRDDFunctions(rdd: RDD[Pileup]) extends Serializable with Logging {
 
   /**
    * Converts ungrouped pileup bases into reference grouped bases.
@@ -37,14 +37,14 @@ class ADAMPileupRDDFunctions(rdd: RDD[Pileup]) extends Serializable with Logging
   }
 }
 
-class ADAMRodRDDFunctions(rdd: RDD[Rod]) extends Serializable with Logging {
+class RodRDDFunctions(rdd: RDD[Rod]) extends Serializable with Logging {
   /**
    * Given an RDD of rods, splits the rods up by the specific sample they correspond to.
    * Returns a flat RDD.
    *
    * @return Rods split up by samples and _not_ grouped together.
    */
-  def adamSplitRodsBySamples(): RDD[Rod] = {
+  def splitRodsBySamples(): RDD[Rod] = {
     rdd.flatMap(_.splitBySamples())
   }
 
@@ -54,7 +54,7 @@ class ADAMRodRDDFunctions(rdd: RDD[Rod]) extends Serializable with Logging {
    *
    * @return Rods split up by samples and grouped together by position.
    */
-  def adamDivideRodsBySamples(): RDD[(ReferencePosition, List[Rod])] = {
+  def divideRodsBySamples(): RDD[(ReferencePosition, List[Rod])] = {
     rdd.keyBy(_.position).map(r => (r._1, r._2.splitBySamples()))
   }
 
@@ -68,7 +68,7 @@ class ADAMRodRDDFunctions(rdd: RDD[Rod]) extends Serializable with Logging {
    *
    * @return Average coverage across mapped loci.
    */
-  def adamRodCoverage(): Double = {
+  def rodCoverage(): Double = {
     val totalBases: Long = rdd.map(_.pileups.length.toLong).reduce(_ + _)
 
     // coverage is the total count of bases, over the total number of loci

--- a/adam-core/src/main/scala/org/bdgenomics/adam/rdd/read/AlignmentRecordContext.scala
+++ b/adam-core/src/main/scala/org/bdgenomics/adam/rdd/read/AlignmentRecordContext.scala
@@ -42,12 +42,12 @@ import org.seqdoop.hadoop_bam.{
 import org.seqdoop.hadoop_bam.util.SAMHeaderReader
 import parquet.hadoop.util.ContextUtil
 
-object ADAMAlignmentRecordContext extends Serializable with Logging {
+object AlignmentRecordContext extends Serializable with Logging {
   // Add ADAM Spark context methods
-  implicit def adamContextToADAMContext(ac: ADAMContext): ADAMAlignmentRecordContext = new ADAMAlignmentRecordContext(ac.sc)
+  implicit def adamContextToADAMContext(ac: ADAMContext): AlignmentRecordContext = new AlignmentRecordContext(ac.sc)
 
   // Add methods specific to Read RDDs
-  implicit def rddToADAMRecordRDD(rdd: RDD[AlignmentRecord]) = new ADAMAlignmentRecordRDDFunctions(rdd)
+  implicit def rddToADAMRecordRDD(rdd: RDD[AlignmentRecord]) = new AlignmentRecordRDDFunctions(rdd)
 
   private[rdd] def adamBamLoad(sc: SparkContext,
                                filePath: String): RDD[AlignmentRecord] = {
@@ -90,14 +90,14 @@ object ADAMAlignmentRecordContext extends Serializable with Logging {
   }
 }
 
-class ADAMAlignmentRecordContext(val sc: SparkContext) extends Serializable with Logging {
+class AlignmentRecordContext(val sc: SparkContext) extends Serializable with Logging {
 
   def adamFastqLoad(firstPairPath: String,
                     secondPairPath: String,
                     fixPairs: Boolean = false): RDD[AlignmentRecord] = {
     // load rdds
-    val firstPairRdd = ADAMAlignmentRecordContext.adamUnpairedFastqLoad(sc, firstPairPath)
-    val secondPairRdd = ADAMAlignmentRecordContext.adamUnpairedFastqLoad(sc, secondPairPath)
+    val firstPairRdd = AlignmentRecordContext.adamUnpairedFastqLoad(sc, firstPairPath)
+    val secondPairRdd = AlignmentRecordContext.adamUnpairedFastqLoad(sc, secondPairPath)
 
     // cache rdds
     firstPairRdd.cache()

--- a/adam-core/src/main/scala/org/bdgenomics/adam/rdd/read/AlignmentRecordRDDFunctions.scala
+++ b/adam-core/src/main/scala/org/bdgenomics/adam/rdd/read/AlignmentRecordRDDFunctions.scala
@@ -31,7 +31,7 @@ import org.bdgenomics.adam.converters.AlignmentRecordConverter
 import org.bdgenomics.adam.models._
 import org.bdgenomics.adam.rdd.ADAMContext._
 import org.bdgenomics.adam.rdd.ADAMSequenceDictionaryRDDAggregator
-import org.bdgenomics.adam.rdd.read.ADAMAlignmentRecordContext._
+import org.bdgenomics.adam.rdd.read.AlignmentRecordContext._
 import org.bdgenomics.adam.rdd.read.correction.{ ErrorCorrection, TrimReads }
 import org.bdgenomics.adam.rdd.read.realignment.RealignIndels
 import org.bdgenomics.adam.rdd.read.recalibration.BaseQualityRecalibration
@@ -39,7 +39,7 @@ import org.bdgenomics.adam.rich.RichAlignmentRecord
 import org.bdgenomics.adam.util.MapTools
 import org.bdgenomics.formats.avro._
 
-class ADAMAlignmentRecordRDDFunctions(rdd: RDD[AlignmentRecord]) extends ADAMSequenceDictionaryRDDAggregator[AlignmentRecord](rdd) {
+class AlignmentRecordRDDFunctions(rdd: RDD[AlignmentRecord]) extends ADAMSequenceDictionaryRDDAggregator[AlignmentRecord](rdd) {
 
   /**
    * Calculates the subset of the RDD whose AlignmentRecords overlap the corresponding

--- a/adam-core/src/main/scala/org/bdgenomics/adam/rdd/read/MarkDuplicates.scala
+++ b/adam-core/src/main/scala/org/bdgenomics/adam/rdd/read/MarkDuplicates.scala
@@ -20,7 +20,7 @@ package org.bdgenomics.adam.rdd.read
 import org.apache.spark.rdd.RDD
 import org.bdgenomics.adam.models.{ ReferencePositionPair, ReferencePositionWithOrientation, SingleReadBucket }
 import org.bdgenomics.adam.rdd.ADAMContext._
-import org.bdgenomics.adam.rdd.read.ADAMAlignmentRecordContext._
+import org.bdgenomics.adam.rdd.read.AlignmentRecordContext._
 import org.bdgenomics.formats.avro.AlignmentRecord
 
 private[rdd] object MarkDuplicates extends Serializable {

--- a/adam-core/src/main/scala/org/bdgenomics/adam/rdd/read/comparisons/ComparisonTraversalEngine.scala
+++ b/adam-core/src/main/scala/org/bdgenomics/adam/rdd/read/comparisons/ComparisonTraversalEngine.scala
@@ -27,16 +27,16 @@ import org.bdgenomics.adam.metrics.filters.GeneratorFilter
 import org.bdgenomics.adam.models.ReadBucket
 import org.bdgenomics.adam.projections.{ FieldValue, Projection }
 import org.bdgenomics.adam.rdd.ADAMContext._
-import org.bdgenomics.adam.rdd.read.ADAMAlignmentRecordContext._
-import org.bdgenomics.adam.rdd.read.ADAMAlignmentRecordContext
+import org.bdgenomics.adam.rdd.read.AlignmentRecordContext._
+import org.bdgenomics.adam.rdd.read.AlignmentRecordContext
 import org.bdgenomics.formats.avro.AlignmentRecord
 import scala.reflect.ClassTag
 
 class ComparisonTraversalEngine(schema: Seq[FieldValue], input1: RDD[AlignmentRecord], input2: RDD[AlignmentRecord])(implicit sc: SparkContext) {
   def this(schema: Seq[FieldValue], input1Paths: Seq[Path], input2Paths: Seq[Path])(implicit sc: SparkContext) =
     this(schema,
-      new ADAMAlignmentRecordContext(sc).loadADAMFromPaths(input1Paths),
-      new ADAMAlignmentRecordContext(sc).loadADAMFromPaths(input2Paths))(sc)
+      new AlignmentRecordContext(sc).loadADAMFromPaths(input1Paths),
+      new AlignmentRecordContext(sc).loadADAMFromPaths(input2Paths))(sc)
 
   lazy val projection = Projection(schema: _*)
 

--- a/adam-core/src/main/scala/org/bdgenomics/adam/rdd/variation/VariationContext.scala
+++ b/adam-core/src/main/scala/org/bdgenomics/adam/rdd/variation/VariationContext.scala
@@ -24,18 +24,18 @@ import org.apache.spark.SparkContext._
 import org.apache.spark.rdd.RDD
 import org.bdgenomics.adam.converters.VariantContextConverter
 import org.bdgenomics.adam.models.{ VariantContext, SequenceDictionary }
-import org.bdgenomics.adam.rdd.variation.ADAMVariationContext._
+import org.bdgenomics.adam.rdd.variation.VariationContext._
 import org.bdgenomics.adam.util.HadoopUtil
 import org.bdgenomics.formats.avro.{ DatabaseVariantAnnotation, Genotype }
 import parquet.hadoop.util.ContextUtil
 
-object ADAMVariationContext {
-  implicit def sparkContextToADAMVariationContext(sc: SparkContext): ADAMVariationContext = new ADAMVariationContext(sc)
+object VariationContext {
+  implicit def sparkContextToVariationContext(sc: SparkContext): VariationContext = new VariationContext(sc)
   implicit def rddToVariantContextRDD(rdd: RDD[VariantContext]) = new VariantContextRDDFunctions(rdd)
   implicit def rddToADAMGenotypeRDD(rdd: RDD[Genotype]) = new GenotypeRDDFunctions(rdd)
 }
 
-class ADAMVariationContext(@transient val sc: SparkContext) extends Serializable with Logging {
+class VariationContext(@transient val sc: SparkContext) extends Serializable with Logging {
   /**
    * This method will create a new RDD of VariantContext objects
    * @param filePath: input VCF file to read
@@ -75,7 +75,7 @@ class ADAMVariationContext(@transient val sc: SparkContext) extends Serializable
     log.info("Writing %s file to %s".format(vcfFormat, filePath))
 
     // Initialize global header object required by Hadoop VCF Writer
-    val header = variants.adamGetCallsetSamples()
+    val header = variants.getCallsetSamples()
     val bcastHeader = sc.broadcast(header)
     val mp = variants.mapPartitionsWithIndex((idx, iter) => {
       log.warn("Setting header for partition " + idx)

--- a/adam-core/src/main/scala/org/bdgenomics/adam/rdd/variation/VariationRDDFunctions.scala
+++ b/adam-core/src/main/scala/org/bdgenomics/adam/rdd/variation/VariationRDDFunctions.scala
@@ -53,7 +53,7 @@ class VariantContextRDDFunctions(rdd: RDD[VariantContext]) extends ADAMSequenceD
 
   }
 
-  def adamGetCallsetSamples(): List[String] = {
+  def getCallsetSamples(): List[String] = {
     rdd.flatMap(c => c.genotypes.map(_.getSampleId).toSeq.distinct)
       .distinct
       .map(_.toString)

--- a/adam-core/src/main/scala/org/bdgenomics/adam/util/VcfHeaderUtils.scala
+++ b/adam-core/src/main/scala/org/bdgenomics/adam/util/VcfHeaderUtils.scala
@@ -19,7 +19,7 @@ package org.bdgenomics.adam.util
 
 import org.bdgenomics.adam.models.{ VariantContext, SequenceDictionary }
 import org.bdgenomics.adam.rdd.ADAMContext._
-import org.bdgenomics.adam.rdd.variation.ADAMVariationContext._
+import org.bdgenomics.adam.rdd.variation.VariationContext._
 import org.apache.spark.rdd.RDD
 import htsjdk.variant.vcf.{
   VCFHeader,
@@ -60,7 +60,7 @@ object VcfHeaderUtils {
    */
   def makeHeader(rdd: RDD[VariantContext]): VCFHeader = {
     val sequenceDict = rdd.adamGetSequenceDictionary()
-    val samples = rdd.adamGetCallsetSamples()
+    val samples = rdd.getCallsetSamples()
 
     makeHeader(sequenceDict, samples)
   }

--- a/adam-core/src/test/scala/org/bdgenomics/adam/converters/FastaConverterSuite.scala
+++ b/adam-core/src/test/scala/org/bdgenomics/adam/converters/FastaConverterSuite.scala
@@ -18,7 +18,7 @@
 package org.bdgenomics.adam.converters
 
 import org.bdgenomics.adam.rdd.ADAMContext._
-import org.bdgenomics.adam.rdd.contig.ADAMNucleotideContigFragmentContext
+import org.bdgenomics.adam.rdd.contig.NucleotideContigFragmentContext
 import org.bdgenomics.adam.util.SparkFunSuite
 import java.io.File
 
@@ -211,7 +211,7 @@ class FastaConverterSuite extends SparkFunSuite {
 
   sparkTest("convert reference fasta file") {
     //Loading "human_g1k_v37_chr1_59kb.fasta"
-    val referenceSequences = new ADAMNucleotideContigFragmentContext(sc).adamSequenceLoad(chr1File, 10).collect()
+    val referenceSequences = new NucleotideContigFragmentContext(sc).adamSequenceLoad(chr1File, 10).collect()
     assert(referenceSequences.forall(_.getContig.getContigName.toString == "1"))
     assert(referenceSequences.slice(0, referenceSequences.length - 2).forall(_.getFragmentSequence.length == 10))
 

--- a/adam-core/src/test/scala/org/bdgenomics/adam/models/GeneSuite.scala
+++ b/adam-core/src/test/scala/org/bdgenomics/adam/models/GeneSuite.scala
@@ -26,7 +26,7 @@ import GeneContext._
 import org.apache.spark.rdd.RDD
 import org.bdgenomics.adam.rdd.features.GeneFeatureRDD._
 import org.bdgenomics.adam.util.SparkFunSuite
-import org.bdgenomics.adam.rdd.features.ADAMFeaturesContext._
+import org.bdgenomics.adam.rdd.features.FeaturesContext._
 import org.bdgenomics.formats.avro.Feature
 
 import scala.io.Source

--- a/adam-core/src/test/scala/org/bdgenomics/adam/rdd/contig/ADAMNucleotideContigFragmentRDDFunctionsSuite.scala
+++ b/adam-core/src/test/scala/org/bdgenomics/adam/rdd/contig/ADAMNucleotideContigFragmentRDDFunctionsSuite.scala
@@ -20,7 +20,7 @@ package org.bdgenomics.adam.rdd.contig
 import org.apache.spark.rdd.RDD
 import org.bdgenomics.adam.models._
 import org.bdgenomics.adam.rdd.ADAMContext._
-import org.bdgenomics.adam.rdd.contig.ADAMNucleotideContigFragmentContext._
+import org.bdgenomics.adam.rdd.contig.NucleotideContigFragmentContext._
 import org.bdgenomics.adam.util.SparkFunSuite
 import org.bdgenomics.formats.avro._
 

--- a/adam-core/src/test/scala/org/bdgenomics/adam/rdd/features/FeatureParsingSuite.scala
+++ b/adam-core/src/test/scala/org/bdgenomics/adam/rdd/features/FeatureParsingSuite.scala
@@ -19,7 +19,7 @@ package org.bdgenomics.adam.rdd.features
 
 import org.bdgenomics.adam.util.SparkFunSuite
 import org.apache.spark.rdd.RDD
-import org.bdgenomics.adam.rdd.features.ADAMFeaturesContext._
+import org.bdgenomics.adam.rdd.features.FeaturesContext._
 import org.bdgenomics.formats.avro.Feature
 
 class FeatureParsingSuite extends SparkFunSuite {

--- a/adam-core/src/test/scala/org/bdgenomics/adam/rdd/pileup/ADAMPileupRDDFunctionsSuite.scala
+++ b/adam-core/src/test/scala/org/bdgenomics/adam/rdd/pileup/ADAMPileupRDDFunctionsSuite.scala
@@ -18,7 +18,7 @@
 package org.bdgenomics.adam.rdd.pileup
 
 import org.apache.spark.rdd.RDD
-import org.bdgenomics.adam.rdd.pileup.ADAMPileupContext._
+import org.bdgenomics.adam.rdd.pileup.PileupContext._
 import org.bdgenomics.adam.util.SparkFunSuite
 import org.bdgenomics.formats.avro._
 
@@ -139,7 +139,7 @@ class ADAMPileupRDDFunctionsSuite extends SparkFunSuite {
     assert(rods.filter(_.position.pos == 1L).flatMap(_.pileups).filter(_.getReadBase == Base.C).count === 1)
     assert(rods.filter(_.isSingleSample).count === 0)
 
-    val split = rods.adamSplitRodsBySamples()
+    val split = rods.splitRodsBySamples()
 
     assert(split.count === 2)
     assert(split.filter(_.position.pos == 1L).count === 2)
@@ -175,7 +175,7 @@ class ADAMPileupRDDFunctionsSuite extends SparkFunSuite {
     assert(rods.filter(_.position.pos == 1L).flatMap(_.pileups).filter(_.getReadBase == Base.C).count === 1)
     assert(rods.filter(_.isSingleSample).count === 1)
 
-    val split = rods.adamSplitRodsBySamples()
+    val split = rods.splitRodsBySamples()
 
     assert(split.count === 1)
     assert(split.filter(_.isSingleSample).count === 1)
@@ -200,7 +200,7 @@ class ADAMPileupRDDFunctionsSuite extends SparkFunSuite {
     val pileups: RDD[Pileup] = sc.parallelize(List(p0, p1))
 
     val coverage = pileups.adamPileupsToRods(1)
-      .adamRodCoverage()
+      .rodCoverage()
 
     // floating point, so apply tolerance
     assert(coverage > 0.99 && coverage < 1.01)
@@ -225,7 +225,7 @@ class ADAMPileupRDDFunctionsSuite extends SparkFunSuite {
     val pileups: RDD[Pileup] = sc.parallelize(List(p0, p1))
 
     val coverage = pileups.adamPileupsToRods(1)
-      .adamRodCoverage()
+      .rodCoverage()
 
     // floating point, so apply tolerance
     assert(coverage > 1.99 && coverage < 2.01)

--- a/adam-core/src/test/scala/org/bdgenomics/adam/rdd/read/ADAMAlignmentRecordContextSuite.scala
+++ b/adam-core/src/test/scala/org/bdgenomics/adam/rdd/read/ADAMAlignmentRecordContextSuite.scala
@@ -20,7 +20,7 @@ package org.bdgenomics.adam.rdd.read
 import java.io.File
 import org.apache.hadoop.fs.Path
 import org.bdgenomics.adam.rdd.ADAMContext._
-import org.bdgenomics.adam.rdd.read.ADAMAlignmentRecordContext._
+import org.bdgenomics.adam.rdd.read.AlignmentRecordContext._
 import org.bdgenomics.adam.util.SparkFunSuite
 import org.bdgenomics.formats.avro.{ AlignmentRecord, Contig }
 
@@ -53,7 +53,7 @@ class ADAMAlignmentRecordContextSuite extends SparkFunSuite {
 
     saved.adamSave(loc)
     try {
-      val loaded = new ADAMAlignmentRecordContext(sc).loadADAMFromPaths(Seq(path))
+      val loaded = new AlignmentRecordContext(sc).loadADAMFromPaths(Seq(path))
 
       assert(loaded.count() === saved.count())
     } catch {
@@ -69,7 +69,7 @@ class ADAMAlignmentRecordContextSuite extends SparkFunSuite {
 
     sparkTest("import records from interleaved FASTQ: %d".format(testNumber)) {
 
-      val reads = ADAMAlignmentRecordContext.adamInterleavedFastqLoad(sc, path)
+      val reads = AlignmentRecordContext.adamInterleavedFastqLoad(sc, path)
       if (testNumber == 1) {
         assert(reads.count === 6)
         assert(reads.filter(_.getReadPaired).count === 6)
@@ -93,7 +93,7 @@ class ADAMAlignmentRecordContextSuite extends SparkFunSuite {
 
     sparkTest("import records from single ended FASTQ: %d".format(testNumber)) {
 
-      val reads = ADAMAlignmentRecordContext.adamUnpairedFastqLoad(sc, path)
+      val reads = AlignmentRecordContext.adamUnpairedFastqLoad(sc, path)
       if (testNumber == 1) {
         assert(reads.count === 6)
         assert(reads.filter(_.getReadPaired).count === 0)
@@ -113,7 +113,7 @@ class ADAMAlignmentRecordContextSuite extends SparkFunSuite {
   sparkTest("read properly paired fastq") {
     val path1 = ClassLoader.getSystemClassLoader.getResource("proper_pairs_1.fq").getFile
     val path2 = ClassLoader.getSystemClassLoader.getResource("proper_pairs_2.fq").getFile
-    val reads = new ADAMAlignmentRecordContext(sc).adamFastqLoad(path1, path2)
+    val reads = new AlignmentRecordContext(sc).adamFastqLoad(path1, path2)
 
     assert(reads.count === 6)
     assert(reads.filter(_.getReadPaired).count === 6)
@@ -125,7 +125,7 @@ class ADAMAlignmentRecordContextSuite extends SparkFunSuite {
   sparkTest("read properly paired fastq and force pair fixing") {
     val path1 = ClassLoader.getSystemClassLoader.getResource("proper_pairs_1.fq").getFile
     val path2 = ClassLoader.getSystemClassLoader.getResource("proper_pairs_2.fq").getFile
-    val reads = new ADAMAlignmentRecordContext(sc).adamFastqLoad(path1, path2, true)
+    val reads = new AlignmentRecordContext(sc).adamFastqLoad(path1, path2, true)
 
     assert(reads.count === 6)
     assert(reads.filter(_.getReadPaired).count === 6)
@@ -137,7 +137,7 @@ class ADAMAlignmentRecordContextSuite extends SparkFunSuite {
   sparkTest("read improperly paired fastq by noting size mismatch") {
     val path1 = ClassLoader.getSystemClassLoader.getResource("improper_pairs_1.fq").getFile
     val path2 = ClassLoader.getSystemClassLoader.getResource("improper_pairs_2.fq").getFile
-    val reads = new ADAMAlignmentRecordContext(sc).adamFastqLoad(path1, path2)
+    val reads = new AlignmentRecordContext(sc).adamFastqLoad(path1, path2)
 
     assert(reads.count === 4)
     assert(reads.filter(_.getReadPaired).count === 4)

--- a/adam-core/src/test/scala/org/bdgenomics/adam/rdd/read/ADAMAlignmentRecordRDDFunctionsSuite.scala
+++ b/adam-core/src/test/scala/org/bdgenomics/adam/rdd/read/ADAMAlignmentRecordRDDFunctionsSuite.scala
@@ -21,7 +21,7 @@ import java.nio.file.Files
 import org.apache.spark.rdd.RDD
 import org.bdgenomics.adam.models._
 import org.bdgenomics.adam.rdd.ADAMContext._
-import org.bdgenomics.adam.rdd.read.ADAMAlignmentRecordContext._
+import org.bdgenomics.adam.rdd.read.AlignmentRecordContext._
 import org.bdgenomics.adam.util.SparkFunSuite
 import org.bdgenomics.formats.avro._
 import scala.util.Random
@@ -254,7 +254,7 @@ class ADAMAlignmentRecordRDDFunctionsSuite extends SparkFunSuite {
     val tempFile = Files.createTempDirectory("reads12")
     rdd12A.adamSAMSave(tempFile.toAbsolutePath.toString + "/reads12.sam", asSam = true)
 
-    val rdd12B: RDD[AlignmentRecord] = ADAMAlignmentRecordContext.adamBamLoad(sc, tempFile.toAbsolutePath.toString + "/reads12.sam/part-r-00000")
+    val rdd12B: RDD[AlignmentRecord] = AlignmentRecordContext.adamBamLoad(sc, tempFile.toAbsolutePath.toString + "/reads12.sam/part-r-00000")
 
     assert(rdd12B.count() === rdd12A.count())
 

--- a/adam-core/src/test/scala/org/bdgenomics/adam/rdd/read/MarkDuplicatesSuite.scala
+++ b/adam-core/src/test/scala/org/bdgenomics/adam/rdd/read/MarkDuplicatesSuite.scala
@@ -19,7 +19,7 @@ package org.bdgenomics.adam.rdd.read
 
 import java.util.UUID
 import org.bdgenomics.adam.rdd.ADAMContext._
-import org.bdgenomics.adam.rdd.read.ADAMAlignmentRecordContext._
+import org.bdgenomics.adam.rdd.read.AlignmentRecordContext._
 import org.bdgenomics.adam.util.SparkFunSuite
 import org.bdgenomics.formats.avro.{ AlignmentRecord, Contig }
 

--- a/adam-core/src/test/scala/org/bdgenomics/adam/rdd/read/realignment/RealignIndelsSuite.scala
+++ b/adam-core/src/test/scala/org/bdgenomics/adam/rdd/read/realignment/RealignIndelsSuite.scala
@@ -20,7 +20,7 @@ package org.bdgenomics.adam.rdd.read.realignment
 import org.apache.spark.rdd.RDD
 import org.bdgenomics.adam.models.{ Consensus, ReferencePosition }
 import org.bdgenomics.adam.rdd.ADAMContext._
-import org.bdgenomics.adam.rdd.read.ADAMAlignmentRecordContext._
+import org.bdgenomics.adam.rdd.read.AlignmentRecordContext._
 import org.bdgenomics.adam.rich.RichAlignmentRecord
 import org.bdgenomics.adam.util.SparkFunSuite
 import org.bdgenomics.formats.avro.AlignmentRecord

--- a/adam-core/src/test/scala/org/bdgenomics/adam/rdd/read/recalibration/BaseQualityRecalibrationSuite.scala
+++ b/adam-core/src/test/scala/org/bdgenomics/adam/rdd/read/recalibration/BaseQualityRecalibrationSuite.scala
@@ -21,7 +21,7 @@ import java.io.File
 import org.apache.spark.rdd.RDD
 import org.bdgenomics.adam.models.SnpTable
 import org.bdgenomics.adam.rdd.ADAMContext._
-import org.bdgenomics.adam.rdd.variation.ADAMVariationContext._
+import org.bdgenomics.adam.rdd.variation.VariationContext._
 import org.bdgenomics.adam.rich.DecadentRead._
 import org.bdgenomics.adam.rich.RichVariant
 import org.bdgenomics.adam.util.SparkFunSuite

--- a/adam-core/src/test/scala/org/bdgenomics/adam/rdd/variation/ADAMVariationContextSuite.scala
+++ b/adam-core/src/test/scala/org/bdgenomics/adam/rdd/variation/ADAMVariationContextSuite.scala
@@ -21,7 +21,7 @@ import com.google.common.io.Files
 import java.io.File
 import org.apache.spark.rdd.RDD
 import org.bdgenomics.adam.models.VariantContext
-import org.bdgenomics.adam.rdd.variation.ADAMVariationContext._
+import org.bdgenomics.adam.rdd.variation.VariationContext._
 import org.bdgenomics.adam.util.SparkFunSuite
 import org.bdgenomics.formats.avro.{ GenotypeAllele, Genotype, Variant, Contig }
 import scala.collection.JavaConversions._

--- a/adam-core/src/test/scala/org/bdgenomics/adam/rdd/variation/ADAMVariationRDDFunctionsSuite.scala
+++ b/adam-core/src/test/scala/org/bdgenomics/adam/rdd/variation/ADAMVariationRDDFunctionsSuite.scala
@@ -21,7 +21,7 @@ import org.bdgenomics.adam.util.SparkFunSuite
 import org.bdgenomics.formats.avro._
 import org.apache.spark.rdd.RDD
 import org.bdgenomics.adam.models.VariantContext
-import org.bdgenomics.adam.rdd.variation.ADAMVariationContext._
+import org.bdgenomics.adam.rdd.variation.VariationContext._
 
 class ADAMVariationRDDFunctionsSuite extends SparkFunSuite {
 
@@ -48,7 +48,7 @@ class ADAMVariationRDDFunctionsSuite extends SparkFunSuite {
       .build()
 
     val vc = VariantContext.buildFromGenotypes(List(genotype0, genotype1))
-    val samples = sc.parallelize(List(vc)).adamGetCallsetSamples()
+    val samples = sc.parallelize(List(vc)).getCallsetSamples()
 
     assert(samples.count(_ == "you") === 1)
     assert(samples.count(_ == "me") === 1)

--- a/adam-core/src/test/scala/org/bdgenomics/adam/rdd/variation/GenotypeRDDFunctionsSuite.scala
+++ b/adam-core/src/test/scala/org/bdgenomics/adam/rdd/variation/GenotypeRDDFunctionsSuite.scala
@@ -19,7 +19,7 @@ package org.bdgenomics.adam.rdd.variation
 
 import org.bdgenomics.adam.util.SparkFunSuite
 import org.bdgenomics.formats.avro._
-import org.bdgenomics.adam.rdd.variation.ADAMVariationContext._
+import org.bdgenomics.adam.rdd.variation.VariationContext._
 import scala.collection.JavaConversions._
 import org.apache.spark.SparkContext._
 import org.apache.spark.rdd.RDD


### PR DESCRIPTION
This initial commit includes just the change for the ADAMFeaturesContext
class/object.

I'll add more commits (and accept PRs to this PR!) which remove the prefix from other classes.

Fixes #416.
