### PR TITLE
CLI & mappability filter for region join, custom exceptions

### DIFF
--- a/adam-cli/src/main/scala/org/bdgenomics/adam/cli/ADAMMain.scala
+++ b/adam-cli/src/main/scala/org/bdgenomics/adam/cli/ADAMMain.scala
@@ -35,13 +35,13 @@ object ADAMMain extends Logging {
         CountReads,
         CalculateDepth,
         CountKmers,
-	Adam2Fastq,
+        Adam2Fastq,
         Transform,
         /* TODO (nealsid): Reimplement in terms of new schema
 	  ComputeVariants
 	*/
-          PluginExecutor
-        )
+        PluginExecutor
+      )
       ),
       CommandGroup(
         "CONVERSION OPERATIONS",

--- a/adam-cli/src/main/scala/org/bdgenomics/adam/cli/ADAMMain.scala
+++ b/adam-cli/src/main/scala/org/bdgenomics/adam/cli/ADAMMain.scala
@@ -29,16 +29,15 @@ object ADAMMain extends Logging {
 
   private val commandGroups =
     List(
-      CommandGroup(
-        "ADAM ACTIONS",
-        List(
-          CompareADAM,
-          FindReads,
-          CalculateDepth,
-          CountKmers,
-          Transform,
-          Adam2Fastq,
-          /* TODO (nealsid): Reimplement in terms of new schema
+      CommandGroup("ADAM ACTIONS", List(
+        CompareADAM,
+        FindReads,
+        CountReads,
+        CalculateDepth,
+        CountKmers,
+	Adam2Fastq,
+        Transform,
+        /* TODO (nealsid): Reimplement in terms of new schema
 	  ComputeVariants
 	*/
           PluginExecutor

--- a/adam-cli/src/main/scala/org/bdgenomics/adam/cli/CountReads.scala
+++ b/adam-cli/src/main/scala/org/bdgenomics/adam/cli/CountReads.scala
@@ -1,0 +1,110 @@
+/**
+ * Licensed to Big Data Genomics (BDG) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The BDG licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.bdgenomics.adam.cli
+
+import java.io.IOException
+import java.util.regex.Pattern
+
+import org.apache.hadoop.mapreduce.Job
+import org.apache.spark.SparkContext
+import org.apache.spark.rdd.RDD
+import org.bdgenomics.adam.models.SequenceRecord
+import org.bdgenomics.adam.projections.{ Projection, AlignmentRecordField }
+import org.bdgenomics.adam.rdd.ADAMContext._
+import org.bdgenomics.adam.rdd.features.FeaturesContext._
+import org.bdgenomics.adam.rdd.features.ReadCounter
+import org.bdgenomics.formats.avro.{ Feature, AlignmentRecord }
+import org.kohsuke.args4j.Argument
+
+object CountReads extends ADAMCommandCompanion {
+  val commandName: String = "countreads"
+  val commandDescription: String = "Reads a feature file and counts the number of overlapping reads-per-feature from an accompanying BAM/Parquet file"
+
+  def apply(cmdLine: Array[String]): ADAMCommand = {
+    new CountReads(Args4j[CountReadsArgs](cmdLine))
+  }
+}
+
+class CountReadsArgs extends Args4jBase with ParquetArgs {
+  @Argument(required = true, metaVar = "FEATURES", usage = "The Feature file to count by", index = 0)
+  val featurePath: String = null
+
+  @Argument(required = true, metaVar = "READS", usage = "The reads file to count", index = 1)
+  val readPath: String = null
+}
+
+class CountReads(protected val args: CountReadsArgs) extends ADAMSparkCommand[CountReadsArgs] {
+  val companion: ADAMCommandCompanion = CountReads
+
+  def run(sc: SparkContext, job: Job): Unit = {
+
+    val projection = Projection(
+      AlignmentRecordField.readMapped,
+      AlignmentRecordField.mateMapped,
+      AlignmentRecordField.readPaired,
+      AlignmentRecordField.contig,
+      AlignmentRecordField.mateContig,
+      AlignmentRecordField.primaryAlignment,
+      AlignmentRecordField.duplicateRead,
+      AlignmentRecordField.readMapped,
+      AlignmentRecordField.mateMapped,
+      AlignmentRecordField.firstOfPair,
+      AlignmentRecordField.secondOfPair,
+      AlignmentRecordField.properPair,
+      AlignmentRecordField.mapq,
+      AlignmentRecordField.start,
+      AlignmentRecordField.end,
+      AlignmentRecordField.cigar,
+      AlignmentRecordField.failedVendorQualityChecks)
+
+    try {
+      // TODO(twd) should relax the assumption that these are in GTF format...
+      val features: RDD[Feature] = sc.adamGTFFeatureLoad(args.featurePath)
+
+      val reads: RDD[AlignmentRecord] = sc.adamLoad(args.readPath, projection = Some(projection))
+
+      val dict = sc.adamDictionaryLoad[AlignmentRecord](args.readPath)
+
+      val counted: RDD[(Feature, Int)] = ReadCounter.countReadsByFeature(sc, dict, features, reads)
+
+      counted.map {
+        case ((f: Feature, count: Int)) =>
+          "% 10d\t%s:%d-%d\t%s".format(count,
+            f.getContig.getContigName,
+            f.getStart.toInt, f.getEnd.toInt,
+            Option(f.getFeatureId).getOrElse(""))
+
+      }.collect().foreach(println)
+
+    } catch {
+
+      case io: IOException =>
+
+        val re = Pattern.compile("RuntimeException: (.*) is not a Parquet file")
+        val matcher = re.matcher(io.getMessage)
+
+        if (matcher.find()) {
+          Console.err.println("ERROR: File \"%s\" doesn't appear to be a Parquet file.".format(matcher.group(1)))
+
+        } else {
+          throw io
+        }
+
+    }
+  }
+}

--- a/adam-cli/src/main/scala/org/bdgenomics/adam/cli/CountReads.scala
+++ b/adam-cli/src/main/scala/org/bdgenomics/adam/cli/CountReads.scala
@@ -23,10 +23,8 @@ import java.util.regex.Pattern
 import org.apache.hadoop.mapreduce.Job
 import org.apache.spark.SparkContext
 import org.apache.spark.rdd.RDD
-import org.bdgenomics.adam.models.SequenceRecord
 import org.bdgenomics.adam.projections.{ Projection, AlignmentRecordField }
 import org.bdgenomics.adam.rdd.ADAMContext._
-import org.bdgenomics.adam.rdd.features.FeaturesContext._
 import org.bdgenomics.adam.rdd.features.ReadCounter
 import org.bdgenomics.formats.avro.{ Feature, AlignmentRecord }
 import org.kohsuke.args4j.Argument
@@ -74,7 +72,7 @@ class CountReads(protected val args: CountReadsArgs) extends ADAMSparkCommand[Co
 
     try {
       // TODO(twd) should relax the assumption that these are in GTF format...
-      val features: RDD[Feature] = sc.adamGTFFeatureLoad(args.featurePath)
+      val features: RDD[Feature] = sc.loadFeatures(args.featurePath)
 
       val reads: RDD[AlignmentRecord] = sc.adamLoad(args.readPath, projection = Some(projection))
 

--- a/adam-core/src/main/scala/org/bdgenomics/adam/exceptions/UnmappedException.scala
+++ b/adam-core/src/main/scala/org/bdgenomics/adam/exceptions/UnmappedException.scala
@@ -1,0 +1,28 @@
+/**
+ * Licensed to Big Data Genomics (BDG) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The BDG licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.bdgenomics.adam.exceptions
+
+/**
+ * An exception which indicates that a record was unmapped -- it is thrown during
+ * processing steps which require all records to be mapped to genomic coordinates.
+ *
+ * @param msg A custom message
+ */
+class UnmappedException(msg: String) extends Exception(msg) {
+  def this(x: Any) = this("\"%s\" didn't have reference coordinates".format(x))
+}

--- a/adam-core/src/main/scala/org/bdgenomics/adam/models/ReferenceMapping.scala
+++ b/adam-core/src/main/scala/org/bdgenomics/adam/models/ReferenceMapping.scala
@@ -20,4 +20,5 @@ package org.bdgenomics.adam.models
 trait ReferenceMapping[T] {
   def getReferenceName(value: T): String
   def getReferenceRegion(value: T): ReferenceRegion
+  def hasReferenceRegion(value: T): Boolean
 }

--- a/adam-core/src/main/scala/org/bdgenomics/adam/rdd/features/ReadCounter.scala
+++ b/adam-core/src/main/scala/org/bdgenomics/adam/rdd/features/ReadCounter.scala
@@ -21,7 +21,7 @@ import org.apache.spark.SparkContext
 import org.apache.spark.rdd.RDD
 import org.bdgenomics.adam.models.SequenceDictionary
 import org.bdgenomics.adam.rdd.ADAMContext._
-import org.bdgenomics.adam.rdd.RegionJoin
+import org.bdgenomics.adam.rdd.BroadcastRegionJoin
 import org.bdgenomics.adam.rich.ReferenceMappingContext._
 import org.bdgenomics.formats.avro.{ AlignmentRecord, Feature }
 
@@ -42,7 +42,7 @@ object ReadCounter {
                           reads: RDD[AlignmentRecord]): RDD[(Feature, Int)] = {
 
     val joined: RDD[(Feature, AlignmentRecord)] =
-      RegionJoin.partitionAndJoin(sc, dict, features, reads)
+      BroadcastRegionJoin.partitionAndJoin(sc, features, reads)
 
     val counted: RDD[(Feature, Int)] = joined.groupBy(_._1).map {
       case ((key: Feature, values: Iterable[(Feature, AlignmentRecord)])) => key -> values.size

--- a/adam-core/src/main/scala/org/bdgenomics/adam/rdd/features/ReadCounter.scala
+++ b/adam-core/src/main/scala/org/bdgenomics/adam/rdd/features/ReadCounter.scala
@@ -1,0 +1,57 @@
+/**
+ * Licensed to Big Data Genomics (BDG) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The BDG licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.bdgenomics.adam.rdd.features
+
+import org.apache.spark.SparkContext
+import org.apache.spark.rdd.RDD
+import org.bdgenomics.adam.models.SequenceDictionary
+import org.bdgenomics.adam.rdd.ADAMContext._
+import org.bdgenomics.adam.rdd.RegionJoin
+import org.bdgenomics.adam.rich.ReferenceMappingContext._
+import org.bdgenomics.formats.avro.{ AlignmentRecord, Feature }
+
+object ReadCounter {
+
+  /**
+   * Calculates the number of reads which overlap each Feature, in a given RDD.
+   *
+   * @param features The RDD of Features
+   * @param reads The RDD of reads (AlignmentRecord values)
+   * @return an RDD which contains each Feature, and an associated integer indicating
+   *         the number of reads (from the 'reads' RDD) which overlapped any portion of the
+   *         Feature.
+   */
+  def countReadsByFeature(sc: SparkContext,
+                          dict: SequenceDictionary,
+                          features: RDD[Feature],
+                          reads: RDD[AlignmentRecord]): RDD[(Feature, Int)] = {
+
+    val joined: RDD[(Feature, AlignmentRecord)] =
+      RegionJoin.partitionAndJoin(sc, dict, features, reads)
+
+    val counted: RDD[(Feature, Int)] = joined.groupBy(_._1).map {
+      case ((key: Feature, values: Iterable[(Feature, AlignmentRecord)])) => key -> values.size
+    }.cache()
+
+    //val uncounted: RDD[Feature] = features.subtract(counted.map(_._1))
+    //counted.union(uncounted.map(f => (f, 0)))
+
+    counted
+  }
+
+}

--- a/adam-core/src/main/scala/org/bdgenomics/adam/rich/ReferenceMappingContext.scala
+++ b/adam-core/src/main/scala/org/bdgenomics/adam/rich/ReferenceMappingContext.scala
@@ -25,24 +25,30 @@ import org.bdgenomics.formats.avro.{ AlignmentRecord, Feature, Genotype }
  */
 object ReferenceMappingContext {
 
-  implicit object GenotypeReferenceMapping extends ReferenceMapping[Genotype] with Serializable {
-    override def getReferenceName(value: Genotype): String = value.getVariant.getContig.getContigName.toString
-    override def getReferenceRegion(value: Genotype): ReferenceRegion =
-      ReferenceRegion(value.getVariant.getContig.getContigName.toString, value.getVariant.getStart, value.getVariant.getEnd)
+  implicit object FlatGenotypeReferenceMapping extends ReferenceMapping[FlatGenotype] with Serializable {
+    override def getReferenceName(value: FlatGenotype): String = value.getReferenceName.toString
+    override def getReferenceRegion(value: FlatGenotype): ReferenceRegion =
+      ReferenceRegion(value.getReferenceName.toString, value.getPosition, value.getPosition)
+    override def hasReferenceRegion(value: FlatGenotype): Boolean =
+      value.getReferenceName != null && value.getPosition != null
   }
 
   implicit object AlignmentRecordReferenceMapping extends ReferenceMapping[AlignmentRecord] with Serializable {
     override def getReferenceName(value: AlignmentRecord): String = value.getContig.getContigName.toString
     override def getReferenceRegion(value: AlignmentRecord): ReferenceRegion = ReferenceRegion(value).orNull
+    override def hasReferenceRegion(value: AlignmentRecord): Boolean = value.getReadMapped
   }
 
   implicit object ReferenceRegionReferenceMapping extends ReferenceMapping[ReferenceRegion] with Serializable {
     override def getReferenceName(value: ReferenceRegion): String = value.referenceName.toString
     override def getReferenceRegion(value: ReferenceRegion): ReferenceRegion = value
+    override def hasReferenceRegion(value: ReferenceRegion): Boolean = true
   }
 
   implicit object FeatureReferenceMapping extends ReferenceMapping[Feature] with Serializable {
     override def getReferenceName(value: Feature): String = value.getContig.getContigName.toString
     override def getReferenceRegion(value: Feature): ReferenceRegion = ReferenceRegion(value)
+    override def hasReferenceRegion(value: Feature): Boolean =
+      value.getContig.getContigName != null && value.getStart != null && value.getEnd != null
   }
 }

--- a/adam-core/src/main/scala/org/bdgenomics/adam/rich/ReferenceMappingContext.scala
+++ b/adam-core/src/main/scala/org/bdgenomics/adam/rich/ReferenceMappingContext.scala
@@ -18,12 +18,29 @@
 package org.bdgenomics.adam.rich
 
 import org.bdgenomics.adam.models.{ ReferenceRegion, ReferenceMapping }
-import org.bdgenomics.formats.avro.{ FlatGenotype, AlignmentRecord, Feature }
+import org.bdgenomics.formats.avro._
 
 /**
  * A common location in which to drop some ReferenceMapping implementations.
  */
 object ReferenceMappingContext {
+
+  implicit object VariantReferenceMapping extends ReferenceMapping[Variant] with Serializable {
+    override def getReferenceName(value: Variant): String = value.getContig.getContigName.toString
+    override def getReferenceRegion(value: Variant): ReferenceRegion =
+      ReferenceRegion(value.getContig.getContigName, value.getStart, value.getEnd)
+    override def hasReferenceRegion(value: Variant): Boolean =
+      value.getContig.getContigName != null && value.getStart != null
+  }
+
+  implicit object GenotypeReferenceMapping extends ReferenceMapping[Genotype] with Serializable {
+    override def getReferenceName(value: Genotype): String =
+      VariantReferenceMapping.getReferenceName(value.getVariant)
+    override def getReferenceRegion(value: Genotype): ReferenceRegion =
+      VariantReferenceMapping.getReferenceRegion(value.getVariant)
+    override def hasReferenceRegion(value: Genotype): Boolean =
+      VariantReferenceMapping.hasReferenceRegion(value.getVariant)
+  }
 
   implicit object FlatGenotypeReferenceMapping extends ReferenceMapping[FlatGenotype] with Serializable {
     override def getReferenceName(value: FlatGenotype): String = value.getReferenceName.toString

--- a/adam-core/src/main/scala/org/bdgenomics/adam/rich/ReferenceMappingContext.scala
+++ b/adam-core/src/main/scala/org/bdgenomics/adam/rich/ReferenceMappingContext.scala
@@ -18,7 +18,7 @@
 package org.bdgenomics.adam.rich
 
 import org.bdgenomics.adam.models.{ ReferenceRegion, ReferenceMapping }
-import org.bdgenomics.formats.avro.{ AlignmentRecord, Feature, Genotype }
+import org.bdgenomics.formats.avro.{ FlatGenotype, AlignmentRecord, Feature }
 
 /**
  * A common location in which to drop some ReferenceMapping implementations.


### PR DESCRIPTION
Fixes #420, #297 

Several changes: 
* adding a filter for 'mappability' to the ``partitionAndJoin`` method, fixing (I hope) Christos's problem
* creating a CLI tool for accessing/testing RegionJoin (and for re-creating the bug) 
* adding a custom exception, for throwing errors related to unmapped reads or records (see #420) 
* added a ``hasReferenceRegion`` to ``ReferenceMapping`` -- to explicitly check for whether a value _can_ be converted to a ReferenceRegion