### PR TITLE
[ADAM-429] adam-submit now handles args correctly.

### DIFF
--- a/bin/adam-submit
+++ b/bin/adam-submit
@@ -20,7 +20,7 @@
 # Figure out where ADAM is installed
 ADAM_REPO="$(cd `dirname $0`/..; pwd)"
 
-CLASSPATH=$("$ADAM_REPO"/bin/compute-adam-classpath.sh)
+# Get list of required jars for ADAM
 ADAM_JARS=$("$ADAM_REPO"/bin/compute-adam-jars.sh)
 
 # Find the ADAM CLI jar
@@ -39,12 +39,23 @@ if [ "$num_versions" -gt "1" ]; then
 fi
 ADAM_CLI_JAR=$(ls "$ADAM_REPO"/adam-cli/target/appassembler/repo/org/bdgenomics/adam/adam-cli/*/adam-cli-*.jar)
 
+# Find spark-submit script
 if [ -z "$SPARK_HOME" ]; then
   echo "Attempting to use 'spark-submit' on default path; you might need to set SPARK_HOME"
   SPARK_SUBMIT=spark-submit
 else
   SPARK_SUBMIT="$SPARK_HOME"/bin/spark-submit
 fi
+
+# Split args into Spark args and ADAM args
+# NOTE: if Spark uses gatherSparkSubmitOpts in spark-submit, this is unnecessary
+function usage() {
+  echo "adam-submit <spark-args> <adam-args>"
+  exit 0
+}
+source "$SPARK_HOME"/bin/utils.sh
+SUBMIT_USAGE_FUNCTION=usage
+gatherSparkSubmitOpts "$@"
 
 # submit the job to Spark
 "$SPARK_SUBMIT" \
@@ -54,5 +65,6 @@ fi
   --conf spark.kryoserializer.buffer.mb=4 \
   --conf spark.kryo.referenceTracking=true \
   --jars "$ADAM_JARS" \
+  "${SUBMISSION_OPTS[@]}" \
   "$ADAM_CLI_JAR" \
-  "$@"
+  "${APPLICATION_OPTS[@]}"


### PR DESCRIPTION
Makes use of the `gatherSparkSubmitOpts` in Spark's `bin/utils.sh`. Fixes #429
