### PR TITLE
Few transform tweaks

### DIFF
--- a/adam-cli/src/main/scala/org/bdgenomics/adam/cli/Transform.scala
+++ b/adam-cli/src/main/scala/org/bdgenomics/adam/cli/Transform.scala
@@ -49,6 +49,8 @@ class TransformArgs extends Args4jBase with ParquetArgs {
   var markDuplicates: Boolean = false
   @Args4jOption(required = false, name = "-recalibrate_base_qualities", usage = "Recalibrate the base quality scores (ILLUMINA only)")
   var recalibrateBaseQualities: Boolean = false
+  @Args4jOption(required = false, name = "-dump_observations", usage = "Local path to dump BQSR observations to. Outputs CSV format.")
+  var observationsPath: String = null
   @Args4jOption(required = false, name = "-known_snps", usage = "Sites-only VCF giving location of known SNPs")
   var knownSnpsFile: String = null
   @Args4jOption(required = false, name = "-realign_indels", usage = "Locally realign indels present in reads.")
@@ -130,7 +132,7 @@ class Transform(protected val args: TransformArgs) extends ADAMSparkCommand[Tran
       log.info("Recalibrating base qualities")
       val variants: RDD[RichVariant] = sc.adamVCFLoad(args.knownSnpsFile).map(_.variant)
       val knownSnps = SnpTable(variants)
-      adamRecords = adamRecords.adamBQSR(sc.broadcast(knownSnps))
+      adamRecords = adamRecords.adamBQSR(sc.broadcast(knownSnps), Option(args.observationsPath))
     }
 
     if (args.qualityBasedTrim && !args.trimBeforeBQSR) {

--- a/adam-core/src/main/scala/org/bdgenomics/adam/rdd/read/AlignmentRecordRDDFunctions.scala
+++ b/adam-core/src/main/scala/org/bdgenomics/adam/rdd/read/AlignmentRecordRDDFunctions.scala
@@ -215,8 +215,18 @@ class AlignmentRecordRDDFunctions(rdd: RDD[AlignmentRecord])
     MarkDuplicates(rdd)
   }
 
-  def adamBQSR(knownSnps: Broadcast[SnpTable]): RDD[AlignmentRecord] = {
-    BaseQualityRecalibration(rdd, knownSnps)
+  /**
+   * Runs base quality score recalibration on a set of reads. Uses a table of
+   * known SNPs to mask true variation during the recalibration process.
+   *
+   * @param knownSnps A table of known SNPs to mask valid variants.
+   * @param observationDumpFile An optional local path to dump recalibration
+   *                            observations to.
+   * @return Returns an RDD of recalibrated reads.
+   */
+  def adamBQSR(knownSnps: Broadcast[SnpTable],
+               observationDumpFile: Option[String] = None): RDD[AlignmentRecord] = {
+    BaseQualityRecalibration(rdd, knownSnps, observationDumpFile)
   }
 
   /**


### PR DESCRIPTION
Fixes #432 and #433. Puts BQSR after indel realignment and makes it possible to dump BQSR observations to a file.
