### PR TITLE
random nits

### DIFF
--- a/adam-core/src/main/scala/org/bdgenomics/adam/rdd/ADAMContext.scala
+++ b/adam-core/src/main/scala/org/bdgenomics/adam/rdd/ADAMContext.scala
@@ -219,7 +219,8 @@ class ADAMContext(val sc: SparkContext) extends Serializable with Logging {
       } else {
         reads
       }
-    } else if ((filePath.endsWith(".fastq") || filePath.endsWith(".fq")) && classOf[AlignmentRecord].isAssignableFrom(manifest[T].runtimeClass)) {
+    } else if ((filePath.endsWith(".fastq") || filePath.endsWith(".fq")) &&
+      classOf[AlignmentRecord].isAssignableFrom(manifest[T].runtimeClass)) {
 
       if (projection.isDefined) {
         log.warn("Projection is ignored when loading a FASTQ file")

--- a/adam-core/src/main/scala/org/bdgenomics/adam/rdd/read/AlignmentRecordContext.scala
+++ b/adam-core/src/main/scala/org/bdgenomics/adam/rdd/read/AlignmentRecordContext.scala
@@ -92,6 +92,13 @@ object AlignmentRecordContext extends Serializable with Logging {
 
 class AlignmentRecordContext(val sc: SparkContext) extends Serializable with Logging {
 
+  /**
+   * Load AlignmentRecords from two paired-end FASTQ files.
+   *
+   * @param firstPairPath Path to read first-mates from
+   * @param secondPairPath Path to read second-mates from
+   * @param fixPairs Iff true, joins the first- and second-reads around their read name (minus the /1 or /2 suffix)
+   */
   def adamFastqLoad(firstPairPath: String,
                     secondPairPath: String,
                     fixPairs: Boolean = false): RDD[AlignmentRecord] = {
@@ -119,7 +126,7 @@ class AlignmentRecordContext(val sc: SparkContext) extends Serializable with Log
         .build())
     } else {
       // all paired end reads should have the same name, except for the last two
-      // characters, which will be _1/_2
+      // characters, which will be {/1, /2}
       firstPairRdd.keyBy(_.getReadName.toString.dropRight(2)).join(secondPairRdd.keyBy(_.getReadName.toString.dropRight(2)))
         .flatMap(kv => Seq(AlignmentRecord.newBuilder(kv._2._1)
           .setReadPaired(true)

--- a/adam-core/src/main/scala/org/bdgenomics/adam/rdd/read/AlignmentRecordRDDFunctions.scala
+++ b/adam-core/src/main/scala/org/bdgenomics/adam/rdd/read/AlignmentRecordRDDFunctions.scala
@@ -87,8 +87,22 @@ class AlignmentRecordRDDFunctions(rdd: RDD[AlignmentRecord])
     // write file to disk
     val conf = rdd.context.hadoopConfiguration
     asSam match {
-      case true  => withKey.saveAsNewAPIHadoopFile(filePath, classOf[LongWritable], classOf[SAMRecordWritable], classOf[ADAMSAMOutputFormat[LongWritable]], conf)
-      case false => withKey.saveAsNewAPIHadoopFile(filePath, classOf[LongWritable], classOf[SAMRecordWritable], classOf[ADAMBAMOutputFormat[LongWritable]], conf)
+      case true =>
+        withKey.saveAsNewAPIHadoopFile(
+          filePath,
+          classOf[LongWritable],
+          classOf[SAMRecordWritable],
+          classOf[ADAMSAMOutputFormat[LongWritable]],
+          conf
+        )
+      case false =>
+        withKey.saveAsNewAPIHadoopFile(
+          filePath,
+          classOf[LongWritable],
+          classOf[SAMRecordWritable],
+          classOf[ADAMBAMOutputFormat[LongWritable]],
+          conf
+        )
     }
   }
 

--- a/pom.xml
+++ b/pom.xml
@@ -283,6 +283,7 @@
               <alignParameters>true</alignParameters>
               <alignSingleLineCaseStatements>true</alignSingleLineCaseStatements>
               <doubleIndentClassDeclaration>true</doubleIndentClassDeclaration>
+              <preserveDanglingCloseParenthesis>true</preserveDanglingCloseParenthesis>
             </configuration>
           </execution>
         </executions>


### PR DESCRIPTION
- disable scalariform's auto-rewriting of dangling parends. lmk if you guys feel strongly that this should never be done (vs. were just inheriting a scalariform default), I like the option to use a dangling close-parend in some cases.
- wrap some long lines and update some comments
