### PR TITLE
Add ability to save paired-FASTQ files

### DIFF
--- a/adam-cli/src/main/scala/org/bdgenomics/adam/cli/ADAMMain.scala
+++ b/adam-cli/src/main/scala/org/bdgenomics/adam/cli/ADAMMain.scala
@@ -37,6 +37,7 @@ object ADAMMain extends Logging {
           CalculateDepth,
           CountKmers,
           Transform,
+          Adam2Fastq,
           /* TODO (nealsid): Reimplement in terms of new schema
 	  ComputeVariants
 	*/

--- a/adam-cli/src/main/scala/org/bdgenomics/adam/cli/Adam2Fastq.scala
+++ b/adam-cli/src/main/scala/org/bdgenomics/adam/cli/Adam2Fastq.scala
@@ -1,0 +1,84 @@
+/**
+ * Licensed to Big Data Genomics (BDG) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The BDG licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.bdgenomics.adam.cli
+
+import htsjdk.samtools.ValidationStringency
+import org.apache.hadoop.mapreduce.Job
+import org.apache.spark.SparkContext
+import org.apache.spark.rdd.RDD
+import org.apache.spark.storage.StorageLevel
+import org.bdgenomics.adam.projections.{ AlignmentRecordField, Projection }
+import org.bdgenomics.adam.rdd.ADAMContext._
+import org.bdgenomics.formats.avro.AlignmentRecord
+import org.kohsuke.args4j.{ Option => Args4JOption, Argument }
+import org.bdgenomics.adam.rdd.read.AlignmentRecordContext._
+
+class Adam2FastqArgs extends ParquetLoadSaveArgs {
+  @Argument(required = false, metaVar = "OUTPUT", usage = "When writing FASTQ data, all second-in-pair reads will go here, if this argument is provided", index = 2)
+  var outputPath2: String = null
+  @Args4JOption(required = false, name = "-samtools_validation", usage = "SAM tools validation level; when STRICT, checks that all reads are paired.")
+  var validationStringency = ValidationStringency.LENIENT
+  @Args4JOption(required = false, name = "-repartition", usage = "Set the number of partitions to map data to")
+  var repartition: Int = -1
+  @Args4JOption(required = false, name = "-persist-level", usage = "Persist() intermediate RDDs")
+  var persistLevel: String = null
+  @Args4JOption(required = false, name = "-no-projection", usage = "Disable projection on records. No great reason to do this, but useful for testing / comparison.")
+  var disableProjection: Boolean = false
+}
+
+object Adam2Fastq extends ADAMCommandCompanion {
+  override val commandName = "adam2fastq"
+  override val commandDescription = "Convert BAM to FASTQ files"
+
+  override def apply(cmdLine: Array[String]): Adam2Fastq =
+    new Adam2Fastq(Args4j[Adam2FastqArgs](cmdLine))
+}
+
+class Adam2Fastq(val args: Adam2FastqArgs) extends ADAMSparkCommand[Adam2FastqArgs] {
+  override val companion = Adam2Fastq
+
+  override def run(sc: SparkContext, job: Job): Unit = {
+
+    val projectionOpt =
+      if (!args.disableProjection)
+        Some(
+          Projection(
+            AlignmentRecordField.readName,
+            AlignmentRecordField.sequence,
+            AlignmentRecordField.origQual
+          )
+        )
+      else
+        None
+
+    var reads: RDD[AlignmentRecord] = sc.adamLoad(args.inputPath, projection = projectionOpt)
+
+    if (args.repartition != -1) {
+      log.info("Repartitioning reads to to '%d' partitions".format(args.repartition))
+      reads = reads.repartition(args.repartition)
+    }
+
+    reads.adamSaveAsPairedFastq(
+      args.outputPath,
+      args.outputPath2,
+      validationStringency = args.validationStringency,
+      persistLevel = Option(args.persistLevel).map(StorageLevel.fromString(_))
+    )
+  }
+
+}

--- a/adam-cli/src/main/scala/org/bdgenomics/adam/cli/ParquetArgs.scala
+++ b/adam-cli/src/main/scala/org/bdgenomics/adam/cli/ParquetArgs.scala
@@ -18,7 +18,7 @@
 package org.bdgenomics.adam.cli
 
 import org.bdgenomics.adam.rdd.{ ADAMSaveArgs, ADAMParquetArgs }
-import org.kohsuke.args4j.Option
+import org.kohsuke.args4j.{ Argument, Option }
 import parquet.hadoop.metadata.CompressionCodecName
 
 trait ParquetArgs extends Args4jBase with ADAMParquetArgs {
@@ -35,3 +35,15 @@ trait ParquetArgs extends Args4jBase with ADAMParquetArgs {
 }
 
 trait ParquetSaveArgs extends ParquetArgs with ADAMSaveArgs
+
+trait LoadFileArgs {
+  @Argument(required = true, metaVar = "INPUT", usage = "The ADAM, BAM or SAM file to load as input", index = 0)
+  var inputPath: String = null
+}
+
+trait SaveFileArgs {
+  @Argument(required = true, metaVar = "OUTPUT", usage = "The ADAM, BAM or SAM file to save as output", index = 1)
+  var outputPath: String = null
+}
+
+trait ParquetLoadSaveArgs extends ParquetSaveArgs with LoadFileArgs with SaveFileArgs

--- a/adam-core/src/main/scala/org/bdgenomics/adam/converters/AlignmentRecordConverter.scala
+++ b/adam-core/src/main/scala/org/bdgenomics/adam/converters/AlignmentRecordConverter.scala
@@ -36,11 +36,22 @@ class AlignmentRecordConverter extends Serializable {
    * @param adamRecord Read to convert to FASTQ.
    * @return Returns this read in string form.
    */
-  def convertToFastq(adamRecord: AlignmentRecord): String = {
-    "@" + adamRecord.getReadName + "\n" +
-      adamRecord.getSequence + "\n" +
-      "+\n" +
-      adamRecord.getQual
+  def convertToFastq(adamRecord: AlignmentRecord, maybeAddSuffix: Boolean = false): String = {
+    val readNameSuffix =
+      if (maybeAddSuffix &&
+        !AlignmentRecordConverter.readNameHasPairedSuffix(adamRecord) &&
+        adamRecord.getFirstOfPair != null) {
+        "/" + (
+          if (adamRecord.getFirstOfPair)
+            "1"
+          else
+            "2"
+        )
+      } else {
+        ""
+      }
+
+    "@%s%s\n%s\n+\n%s".format(adamRecord.getReadName, readNameSuffix, adamRecord.getSequence, adamRecord.getQual)
   }
 
   /**
@@ -167,4 +178,15 @@ class AlignmentRecordConverter extends Serializable {
 
     samHeader
   }
+}
+
+object AlignmentRecordConverter {
+
+  def readNameHasPairedSuffix(adamRecord: AlignmentRecord): Boolean = {
+    adamRecord.getReadName.length() > 2 &&
+      adamRecord.getReadName.charAt(adamRecord.getReadName.length() - 2) == '/' &&
+      (adamRecord.getReadName.charAt(adamRecord.getReadName.length() - 1) == '1' ||
+        adamRecord.getReadName.charAt(adamRecord.getReadName.length() - 1) == '2')
+  }
+
 }


### PR DESCRIPTION
There is existing functionality for loading a pair of FASTQ files, but not for saving such files. I am in need of a tool to convert some BAM files to paired-FASTQs, so I added this capability.

I'm not an expert on the convention of having read names all end with `/1` in one file and `/2` in the other; for my purposes I want to always write them out that way and have the option of doing some strict sanity checking (all reads have a mate on the way in and out), so I added a few optional levels of verification to the loading and saving steps.
