### PR TITLE
read “OQ” attr from structured SAMRecord field

### DIFF
--- a/adam-core/src/main/scala/org/bdgenomics/adam/converters/SAMRecordConverter.scala
+++ b/adam-core/src/main/scala/org/bdgenomics/adam/converters/SAMRecordConverter.scala
@@ -17,8 +17,8 @@
  */
 package org.bdgenomics.adam.converters
 
-import htsjdk.samtools.{ CigarElement, SAMReadGroupRecord, SAMRecord }
 import org.bdgenomics.adam.models.{ SequenceRecord, Attribute, RecordGroupDictionary, SequenceDictionary }
+import htsjdk.samtools.{ SAMUtils, CigarElement, SAMReadGroupRecord, SAMRecord }
 import org.bdgenomics.adam.util.AttributeUtils
 import org.bdgenomics.formats.avro.AlignmentRecord
 import scala.collection.JavaConverters._
@@ -53,6 +53,7 @@ class SAMRecordConverter extends Serializable {
       .setBasesTrimmedFromStart(startTrim)
       .setBasesTrimmedFromEnd(endTrim)
       .setQual(samRecord.getBaseQualityString)
+      .setOrigQual(SAMUtils.phredToFastq(samRecord.getOriginalBaseQualities))
 
     // Only set the reference information if the read is aligned, matching the mate reference
     // This prevents looking up a -1 in the sequence dictionary
@@ -148,8 +149,6 @@ class SAMRecordConverter extends Serializable {
         attr =>
           if (attr.tag == "MD") {
             builder.setMismatchingPositions(attr.value.toString)
-          } else if (attr.tag == "OQ") {
-            builder.setOrigQual(attr.value.toString)
           } else {
             tags ::= AttributeUtils.convertSAMTagAndValue(attr)
           }


### PR DESCRIPTION
converting into and out of BAM using ADAM was dropping the “OQ” attr;
HTSJDK puts it in its own field but ADAM was looking for it in the
catch-all attributes field.
