### PR TITLE
Refactor some file writing and reading logic

### DIFF
--- a/adam-apis/src/main/scala/org/bdgenomics/adam/apis/java/JavaAlignmentRecordRDD.scala
+++ b/adam-apis/src/main/scala/org/bdgenomics/adam/apis/java/JavaAlignmentRecordRDD.scala
@@ -39,11 +39,13 @@ class JavaAlignmentRecordRDD(val jrdd: JavaRDD[AlignmentRecord]) extends Seriali
                pageSize: java.lang.Integer,
                compressCodec: CompressionCodecName,
                disableDictionaryEncoding: java.lang.Boolean) {
-    jrdd.rdd.adamSave(filePath,
+    jrdd.rdd.adamParquetSave(
+      filePath,
       blockSize,
       pageSize,
       compressCodec,
-      disableDictionaryEncoding)
+      disableDictionaryEncoding
+    )
   }
 
   /**
@@ -52,7 +54,7 @@ class JavaAlignmentRecordRDD(val jrdd: JavaRDD[AlignmentRecord]) extends Seriali
    * @param filePath Path to save the file at.
    */
   def adamSave(filePath: java.lang.String) {
-    jrdd.rdd.adamSave(filePath)
+    jrdd.rdd.adamParquetSave(filePath)
   }
 
   /**
@@ -67,7 +69,7 @@ class JavaAlignmentRecordRDD(val jrdd: JavaRDD[AlignmentRecord]) extends Seriali
   }
 
   /**
-   * Saves this RDD to disk as a SAM/BAM file.
+   * Saves this RDD to disk as a SAM file.
    *
    * @param filePath Path to save the file at.
    */

--- a/adam-cli/src/main/scala/org/bdgenomics/adam/cli/ADAMMain.scala
+++ b/adam-cli/src/main/scala/org/bdgenomics/adam/cli/ADAMMain.scala
@@ -29,36 +29,49 @@ object ADAMMain extends Logging {
 
   private val commandGroups =
     List(
-      CommandGroup("ADAM ACTIONS", List(
-        CompareADAM,
-        FindReads,
-        CalculateDepth,
-        CountKmers,
-        Transform,
-        /* TODO (nealsid): Reimplement in terms of new schema
+      CommandGroup(
+        "ADAM ACTIONS",
+        List(
+          CompareADAM,
+          FindReads,
+          CalculateDepth,
+          CountKmers,
+          Transform,
+          /* TODO (nealsid): Reimplement in terms of new schema
 	  ComputeVariants
 	*/
-        PluginExecutor)),
-      CommandGroup("CONVERSION OPERATIONS", List(
-        Bam2ADAM,
-        Vcf2FlatGenotype,
-        Vcf2ADAM,
-        VcfAnnotation2ADAM,
-        ADAM2Vcf,
-        Fasta2ADAM,
-        Reads2Ref,
-        MpileupCommand,
-        Features2ADAM)),
-      CommandGroup("PRINT", List(
-        PrintADAM,
-        PrintGenes,
-        FlagStat,
-        VizReads,
-        PrintTags,
-        ListDict,
-        SummarizeGenotypes,
-        AlleleCount,
-        BuildInformation)))
+          PluginExecutor
+        )
+      ),
+      CommandGroup(
+        "CONVERSION OPERATIONS",
+        List(
+          Bam2ADAM,
+          Vcf2FlatGenotype,
+          Vcf2ADAM,
+          VcfAnnotation2ADAM,
+          ADAM2Vcf,
+          Fasta2ADAM,
+          Reads2Ref,
+          MpileupCommand,
+          Features2ADAM
+        )
+      ),
+      CommandGroup(
+        "PRINT",
+        List(
+          PrintADAM,
+          PrintGenes,
+          FlagStat,
+          VizReads,
+          PrintTags,
+          ListDict,
+          SummarizeGenotypes,
+          AlleleCount,
+          BuildInformation
+        )
+      )
+    )
 
   private def printCommands() {
     println("\n")

--- a/adam-cli/src/main/scala/org/bdgenomics/adam/cli/Bam2ADAM.scala
+++ b/adam-cli/src/main/scala/org/bdgenomics/adam/cli/Bam2ADAM.scala
@@ -61,7 +61,12 @@ class Bam2ADAM(args: Bam2ADAMArgs) extends ADAMCommand {
 
           val parquetWriter = new AvroParquetWriter[AlignmentRecord](
             new Path(args.outputPath + "/part%d".format(threadNum)),
-            AlignmentRecord.SCHEMA$, args.compressionCodec, args.blockSize, args.pageSize, !args.disableDictionary)
+            AlignmentRecord.SCHEMA$,
+            args.compressionCodec,
+            args.blockSize,
+            args.pageSize,
+            !args.disableDictionaryEncoding
+          )
 
           val samRecordConverter = new SAMRecordConverter
 

--- a/adam-cli/src/main/scala/org/bdgenomics/adam/cli/Fasta2ADAM.scala
+++ b/adam-cli/src/main/scala/org/bdgenomics/adam/cli/Fasta2ADAM.scala
@@ -20,10 +20,8 @@ package org.bdgenomics.adam.cli
 import org.apache.hadoop.mapreduce.Job
 import org.apache.spark.{ Logging, SparkContext }
 import org.bdgenomics.adam.rdd.ADAMContext._
-import org.bdgenomics.adam.rdd.ADAMContext
 import org.bdgenomics.adam.rdd.contig.NucleotideContigFragmentContext._
 import org.bdgenomics.adam.rdd.contig.NucleotideContigFragmentContext
-import org.bdgenomics.formats.avro.AlignmentRecord
 import org.kohsuke.args4j.{ Argument, Option => Args4jOption }
 
 object Fasta2ADAM extends ADAMCommandCompanion {
@@ -35,7 +33,7 @@ object Fasta2ADAM extends ADAMCommandCompanion {
   }
 }
 
-class Fasta2ADAMArgs extends Args4jBase with ParquetArgs {
+class Fasta2ADAMArgs extends Args4jBase with ParquetSaveArgs {
   @Argument(required = true, metaVar = "FASTA", usage = "The FASTA file to convert", index = 0)
   var fastaFile: String = null
   @Argument(required = true, metaVar = "ADAM", usage = "Location to write ADAM data", index = 1)
@@ -60,8 +58,7 @@ class Fasta2ADAM(protected val args: Fasta2ADAMArgs) extends ADAMSparkCommand[Fa
     }
 
     log.info("Writing records to disk.")
-    adamFasta.adamSave(args.outputPath, blockSize = args.blockSize, pageSize = args.pageSize,
-      compressCodec = args.compressionCodec, disableDictionaryEncoding = args.disableDictionary)
+    adamFasta.adamParquetSave(args)
   }
 }
 

--- a/adam-cli/src/main/scala/org/bdgenomics/adam/cli/Features2ADAM.scala
+++ b/adam-cli/src/main/scala/org/bdgenomics/adam/cli/Features2ADAM.scala
@@ -35,7 +35,7 @@ object Features2ADAM extends ADAMCommandCompanion {
   }
 }
 
-class Features2ADAMArgs extends Args4jBase with ParquetArgs {
+class Features2ADAMArgs extends Args4jBase with ParquetSaveArgs {
   @Argument(required = true, metaVar = "FEATURES",
     usage = "The features file to convert (e.g., .bed, .gff)", index = 0)
   var featuresFile: String = _
@@ -59,8 +59,6 @@ class Features2ADAM(val args: Features2ADAMArgs)
       case "bed"        => sc.adamBEDFeatureLoad(args.featuresFile)
       case "narrowPeak" => sc.adamNarrowPeakFeatureLoad(args.featuresFile)
     }
-    features.adamSave(args.outputPath, blockSize = args.blockSize,
-      pageSize = args.pageSize, compressCodec = args.compressionCodec,
-      disableDictionaryEncoding = args.disableDictionary)
+    features.adamParquetSave(args)
   }
 }

--- a/adam-cli/src/main/scala/org/bdgenomics/adam/cli/ParquetArgs.scala
+++ b/adam-cli/src/main/scala/org/bdgenomics/adam/cli/ParquetArgs.scala
@@ -17,10 +17,11 @@
  */
 package org.bdgenomics.adam.cli
 
+import org.bdgenomics.adam.rdd.{ ADAMSaveArgs, ADAMParquetArgs }
 import org.kohsuke.args4j.Option
 import parquet.hadoop.metadata.CompressionCodecName
 
-trait ParquetArgs extends Args4jBase {
+trait ParquetArgs extends Args4jBase with ADAMParquetArgs {
   @Option(required = false, name = "-parquet_block_size", usage = "Parquet block size (default = 128mb)")
   var blockSize = 128 * 1024 * 1024
   @Option(required = false, name = "-parquet_page_size", usage = "Parquet page size (default = 1mb)")
@@ -28,8 +29,9 @@ trait ParquetArgs extends Args4jBase {
   @Option(required = false, name = "-parquet_compression_codec", usage = "Parquet compression codec")
   var compressionCodec = CompressionCodecName.GZIP
   @Option(name = "-parquet_disable_dictionary", usage = "Disable dictionary encoding")
-  var disableDictionary = false
+  override var disableDictionaryEncoding = false
   @Option(required = false, name = "-parquet_logging_level", usage = "Parquet logging level (default = severe)")
   var logLevel = "SEVERE"
 }
 
+trait ParquetSaveArgs extends ParquetArgs with ADAMSaveArgs

--- a/adam-cli/src/main/scala/org/bdgenomics/adam/cli/Reads2Ref.scala
+++ b/adam-cli/src/main/scala/org/bdgenomics/adam/cli/Reads2Ref.scala
@@ -40,12 +40,12 @@ object Reads2RefArgs {
   val MIN_MAPQ_DEFAULT: Long = 30L
 }
 
-class Reads2RefArgs extends Args4jBase with ParquetArgs {
+class Reads2RefArgs extends Args4jBase with ParquetSaveArgs {
   @Argument(metaVar = "ADAMREADS", required = true, usage = "ADAM read-oriented data", index = 0)
   var readInput: String = _
 
   @Argument(metaVar = "DIR", required = true, usage = "Location to create reference-oriented ADAM data", index = 1)
-  var pileupOutput: String = _
+  var outputPath: String = _
 
   @option(name = "-mapq", usage = "Minimal mapq value allowed for a read (default = 30)")
   var minMapq: Long = Reads2RefArgs.MIN_MAPQ_DEFAULT
@@ -68,7 +68,6 @@ class Reads2Ref(protected val args: Reads2RefArgs) extends ADAMSparkCommand[Read
 
     val coverage = pileupCount / readCount
 
-    pileups.adamSave(args.pileupOutput, blockSize = args.blockSize, pageSize = args.pageSize,
-      compressCodec = args.compressionCodec, disableDictionaryEncoding = args.disableDictionary)
+    pileups.adamParquetSave(args)
   }
 }

--- a/adam-cli/src/main/scala/org/bdgenomics/adam/cli/Transform.scala
+++ b/adam-cli/src/main/scala/org/bdgenomics/adam/cli/Transform.scala
@@ -23,6 +23,7 @@ import org.apache.spark.rdd.RDD
 import org.bdgenomics.adam.algorithms.consensus._
 import org.bdgenomics.adam.models.SnpTable
 import org.bdgenomics.adam.rdd.ADAMContext._
+import org.bdgenomics.adam.rdd.ADAMSaveAnyArgs
 import org.bdgenomics.adam.rdd.read.AlignmentRecordContext._
 import org.bdgenomics.adam.rdd.variation.VariationContext._
 import org.bdgenomics.adam.rich.RichVariant
@@ -38,7 +39,7 @@ object Transform extends ADAMCommandCompanion {
   }
 }
 
-class TransformArgs extends Args4jBase with ParquetArgs {
+class TransformArgs extends Args4jBase with ADAMSaveAnyArgs with ParquetArgs {
   @Argument(required = true, metaVar = "INPUT", usage = "The ADAM, BAM or SAM file to apply the transforms to", index = 0)
   var inputPath: String = null
   @Argument(required = true, metaVar = "OUTPUT", usage = "Location to write the transformed data in ADAM/Parquet format", index = 1)
@@ -151,20 +152,6 @@ class Transform(protected val args: TransformArgs) extends ADAMSparkCommand[Tran
       adamRecords = adamRecords.adamSortReadsByReferencePosition()
     }
 
-    if (args.outputPath.endsWith(".sam")) {
-      log.info("Saving data in SAM format")
-      adamRecords.adamSAMSave(args.outputPath)
-    } else if (args.outputPath.endsWith(".bam")) {
-      log.info("Saving data in BAM format")
-      adamRecords.adamSAMSave(args.outputPath, asSam = false)
-    } else if (args.outputPath.endsWith(".fq") || args.outputPath.endsWith(".fastq") ||
-      args.outputPath.endsWith(".ifq")) {
-      log.info("Saving data in FASTQ format.")
-      adamRecords.adamSaveAsFastq(args.outputPath, args.sortFastqOutput)
-    } else {
-      log.info("Saving data in ADAM format")
-      adamRecords.adamSave(args.outputPath, blockSize = args.blockSize, pageSize = args.pageSize,
-        compressCodec = args.compressionCodec, disableDictionaryEncoding = args.disableDictionary)
-    }
+    adamRecords.adamSave(args)
   }
 }

--- a/adam-cli/src/main/scala/org/bdgenomics/adam/cli/Vcf2ADAM.scala
+++ b/adam-cli/src/main/scala/org/bdgenomics/adam/cli/Vcf2ADAM.scala
@@ -35,7 +35,7 @@ object Vcf2ADAM extends ADAMCommandCompanion {
   }
 }
 
-class Vcf2ADAMArgs extends Args4jBase with ParquetArgs {
+class Vcf2ADAMArgs extends Args4jBase with ParquetSaveArgs {
   @Args4jOption(required = false, name = "-dict", usage = "Reference dictionary")
   var dictionaryFile: File = _
 
@@ -67,11 +67,6 @@ class Vcf2ADAM(val args: Vcf2ADAMArgs) extends ADAMSparkCommand[Vcf2ADAMArgs] wi
       adamVariants.flatMap(p => p.genotypes)
     }
 
-    gts.adamSave(
-      args.outputPath,
-      blockSize = args.blockSize,
-      pageSize = args.pageSize,
-      compressCodec = args.compressionCodec,
-      disableDictionaryEncoding = args.disableDictionary)
+    gts.adamParquetSave(args)
   }
 }

--- a/adam-cli/src/main/scala/org/bdgenomics/adam/cli/Vcf2FlatGenotype.scala
+++ b/adam-cli/src/main/scala/org/bdgenomics/adam/cli/Vcf2FlatGenotype.scala
@@ -83,7 +83,7 @@ class Vcf2FlatGenotype(args: Vcf2FlatGenotypeArgs) extends ADAMCommand {
       new AvroParquetWriter[FlatGenotype](
         new Path(args.outputPath + "/part_%d".format(index)),
         FlatGenotype.SCHEMA$,
-        args.compressionCodec, args.blockSize, args.pageSize, !args.disableDictionary)
+        args.compressionCodec, args.blockSize, args.pageSize, !args.disableDictionaryEncoding)
 
     // create a new writer for each file to be output
     val writers = indexedSamples.map(_._1).distinct.map(i => createWriter(i))

--- a/adam-cli/src/main/scala/org/bdgenomics/adam/cli/VcfAnnotation2ADAM.scala
+++ b/adam-cli/src/main/scala/org/bdgenomics/adam/cli/VcfAnnotation2ADAM.scala
@@ -54,7 +54,7 @@ object VcfAnnotation2ADAM extends ADAMCommandCompanion {
   }
 }
 
-class VcfAnnotation2ADAMArgs extends Args4jBase with ParquetArgs {
+class VcfAnnotation2ADAMArgs extends Args4jBase with ParquetSaveArgs {
   @Argument(required = true, metaVar = "VCF", usage = "The VCF file with annotations to convert", index = 0)
   var vcfFile: String = _
   @Argument(required = true, metaVar = "ADAM", usage = "Location to write ADAM Variant annotations data", index = 1)
@@ -76,11 +76,9 @@ class VcfAnnotation2ADAM(val args: VcfAnnotation2ADAMArgs) extends ADAMSparkComm
       val keyedAnnotations = existingAnnotations.keyBy(anno => new RichVariant(anno.getVariant))
       val joinedAnnotations = keyedAnnotations.join(annotations.keyBy(anno => new RichVariant(anno.getVariant)))
       val mergedAnnotations = joinedAnnotations.map(kv => VariantAnnotationConverter.mergeAnnotations(kv._2._1, kv._2._2))
-      mergedAnnotations.adamSave(args.outputPath, blockSize = args.blockSize, pageSize = args.pageSize,
-        compressCodec = args.compressionCodec, disableDictionaryEncoding = args.disableDictionary)
+      mergedAnnotations.adamParquetSave(args)
     } else {
-      annotations.adamSave(args.outputPath, blockSize = args.blockSize, pageSize = args.pageSize,
-        compressCodec = args.compressionCodec, disableDictionaryEncoding = args.disableDictionary)
+      annotations.adamParquetSave(args)
     }
 
     log.info("Added %d annotation records".format(annotations.count()))

--- a/adam-core/src/main/scala/org/bdgenomics/adam/models/RecordGroupDictionary.scala
+++ b/adam-core/src/main/scala/org/bdgenomics/adam/models/RecordGroupDictionary.scala
@@ -104,21 +104,22 @@ object RecordGroup {
    * @return Returns a filled Option if record group data is attached to the read, else returns None.
    */
   def apply(read: AlignmentRecord): Option[RecordGroup] = {
-    Option(read.getRecordGroupSample).fold(None.asInstanceOf[Option[RecordGroup]])(rgs => {
-      Option(read.getRecordGroupName).fold(None.asInstanceOf[Option[RecordGroup]])(rgn => {
-        Some(new RecordGroup(rgs.toString,
-          rgn.toString,
-          Option(read.getRecordGroupSequencingCenter).map(_.toString),
-          Option(read.getRecordGroupDescription).map(_.toString),
-          Option(read.getRecordGroupRunDateEpoch).map(_.toLong),
-          Option(read.getRecordGroupFlowOrder).map(_.toString),
-          Option(read.getRecordGroupKeySequence).map(_.toString),
-          Option(read.getRecordGroupLibrary).map(_.toString),
-          Option(read.getRecordGroupPredictedMedianInsertSize).map(_.toInt),
-          Option(read.getRecordGroupPlatform).map(_.toString),
-          Option(read.getRecordGroupPlatformUnit).map(_.toString)))
-      })
-    })
+    for {
+      rgs <- Option(read.getRecordGroupSample)
+      rgn <- Option(read.getRecordGroupName)
+    } yield new RecordGroup(
+      rgs.toString,
+      rgn.toString,
+      Option(read.getRecordGroupSequencingCenter).map(_.toString),
+      Option(read.getRecordGroupDescription).map(_.toString),
+      Option(read.getRecordGroupRunDateEpoch).map(_.toLong),
+      Option(read.getRecordGroupFlowOrder).map(_.toString),
+      Option(read.getRecordGroupKeySequence).map(_.toString),
+      Option(read.getRecordGroupLibrary).map(_.toString),
+      Option(read.getRecordGroupPredictedMedianInsertSize).map(_.toInt),
+      Option(read.getRecordGroupPlatform).map(_.toString),
+      Option(read.getRecordGroupPlatformUnit).map(_.toString)
+    )
   }
 
   /**

--- a/adam-core/src/main/scala/org/bdgenomics/adam/rdd/ADAMRDDFunctions.scala
+++ b/adam-core/src/main/scala/org/bdgenomics/adam/rdd/ADAMRDDFunctions.scala
@@ -32,11 +32,40 @@ import parquet.hadoop.ParquetOutputFormat
 import parquet.hadoop.metadata.CompressionCodecName
 import parquet.hadoop.util.ContextUtil
 
-class ADAMRDDFunctions[T <% SpecificRecord: Manifest](rdd: RDD[T]) extends Serializable {
+trait ADAMParquetArgs {
+  var blockSize: Int
+  var pageSize: Int
+  var compressionCodec: CompressionCodecName
+  var disableDictionaryEncoding: Boolean
+}
 
-  def adamSave(filePath: String, blockSize: Int = 128 * 1024 * 1024,
-               pageSize: Int = 1 * 1024 * 1024, compressCodec: CompressionCodecName = CompressionCodecName.GZIP,
-               disableDictionaryEncoding: Boolean = false) {
+trait ADAMSaveArgs extends ADAMParquetArgs {
+  var outputPath: String
+}
+
+trait ADAMSaveAnyArgs extends ADAMSaveArgs {
+  var sortFastqOutput: Boolean
+}
+
+class ADAMRDDFunctions[T <% SpecificRecord: Manifest](rdd: RDD[T]) extends Serializable with Logging {
+
+  def adamParquetSave(args: ADAMSaveArgs): Unit = {
+    adamParquetSave(
+      args.outputPath,
+      args.blockSize,
+      args.pageSize,
+      args.compressionCodec,
+      args.disableDictionaryEncoding
+    )
+  }
+
+  def adamParquetSave(filePath: String,
+                      blockSize: Int = 128 * 1024 * 1024,
+                      pageSize: Int = 1 * 1024 * 1024,
+                      compressCodec: CompressionCodecName = CompressionCodecName.GZIP,
+                      disableDictionaryEncoding: Boolean = false): Unit = {
+    log.info("Saving data in ADAM format")
+
     val job = HadoopUtil.newJob(rdd.context)
     ParquetLogger.hadoopLoggerLevel(Level.SEVERE)
     ParquetOutputFormat.setCompression(job, compressCodec)

--- a/adam-core/src/test/scala/org/bdgenomics/adam/predicates/GenotypePredicatesSuite.scala
+++ b/adam-core/src/test/scala/org/bdgenomics/adam/predicates/GenotypePredicatesSuite.scala
@@ -61,7 +61,7 @@ class GenotypePredicatesSuite extends SparkFunSuite {
         .build()))
 
     val genotypesParquetFile = new File(Files.createTempDir(), "genotypes")
-    genotypes.adamSave(genotypesParquetFile.getAbsolutePath)
+    genotypes.adamParquetSave(genotypesParquetFile.getAbsolutePath)
 
     val gts1: RDD[Genotype] = sc.adamLoad(
       genotypesParquetFile.getAbsolutePath,
@@ -96,7 +96,7 @@ class GenotypePredicatesSuite extends SparkFunSuite {
         .setVariantCallingAnnotations(failFilterAnnotation).build()))
 
     val genotypesParquetFile = new File(Files.createTempDir(), "genotypes")
-    genotypes.adamSave(genotypesParquetFile.getAbsolutePath)
+    genotypes.adamParquetSave(genotypesParquetFile.getAbsolutePath)
 
     val gts: RDD[Genotype] = sc.adamLoad(genotypesParquetFile.getAbsolutePath)
     assert(gts.count === 2)

--- a/adam-core/src/test/scala/org/bdgenomics/adam/projections/FieldEnumerationSuite.scala
+++ b/adam-core/src/test/scala/org/bdgenomics/adam/projections/FieldEnumerationSuite.scala
@@ -44,7 +44,7 @@ class FieldEnumerationSuite extends SparkFunSuite with BeforeAndAfter {
 
     // Convert the reads12.sam file into a parquet file
     val bamReads: RDD[AlignmentRecord] = sc.adamLoad(readsFilepath)
-    bamReads.adamSave(readsParquetFile.getAbsolutePath)
+    bamReads.adamParquetSave(readsParquetFile.getAbsolutePath)
   }
 
   after {

--- a/adam-core/src/test/scala/org/bdgenomics/adam/rdd/read/ADAMAlignmentRecordContextSuite.scala
+++ b/adam-core/src/test/scala/org/bdgenomics/adam/rdd/read/ADAMAlignmentRecordContextSuite.scala
@@ -51,7 +51,7 @@ class ADAMAlignmentRecordContextSuite extends SparkFunSuite {
     val loc = tempLocation()
     val path = new Path(loc)
 
-    saved.adamSave(loc)
+    saved.adamParquetSave(loc)
     try {
       val loaded = new AlignmentRecordContext(sc).loadADAMFromPaths(Seq(path))
 
@@ -150,7 +150,7 @@ class ADAMAlignmentRecordContextSuite extends SparkFunSuite {
    Little helper function -- because apparently createTempFile creates an actual file, not
    just a name?  Whereas, this returns the name of something that could be mkdir'ed, in the
    same location as createTempFile() uses, so therefore the returned path from this method
-   should be suitable for adamSave().
+   should be suitable for adamParquetSave().
    */
   def tempLocation(suffix: String = "adam"): String = {
     val tempFile = File.createTempFile("ADAMContextSuite", "")

--- a/adam-core/src/test/scala/org/bdgenomics/adam/rdd/read/ADAMAlignmentRecordRDDFunctionsSuite.scala
+++ b/adam-core/src/test/scala/org/bdgenomics/adam/rdd/read/ADAMAlignmentRecordRDDFunctionsSuite.scala
@@ -254,7 +254,7 @@ class ADAMAlignmentRecordRDDFunctionsSuite extends SparkFunSuite {
     val tempFile = Files.createTempDirectory("reads12")
     rdd12A.adamSAMSave(tempFile.toAbsolutePath.toString + "/reads12.sam", asSam = true)
 
-    val rdd12B: RDD[AlignmentRecord] = AlignmentRecordContext.adamBamLoad(sc, tempFile.toAbsolutePath.toString + "/reads12.sam/part-r-00000")
+    val rdd12B: RDD[AlignmentRecord] = sc.adamBamLoad(tempFile.toAbsolutePath.toString + "/reads12.sam/part-r-00000")
 
     assert(rdd12B.count() === rdd12A.count())
 


### PR DESCRIPTION
- Added `adamParquetSave` method that encapsulates the most common file-writing step at the end of ADAM commands, using the existing `ParquetArgs` options as well as an `outputPath` option.
- Added a few methods for writing output inferred from `outputPath` file extensions
- A few random cleanups.

Per usual, commits are in fairly logical chunks, but I'll squash if it looks good.
