### PR TITLE
[ADAM-436] Optionally output original qualities to fastq

### DIFF
--- a/adam-cli/src/main/scala/org/bdgenomics/adam/cli/Adam2Fastq.scala
+++ b/adam-cli/src/main/scala/org/bdgenomics/adam/cli/Adam2Fastq.scala
@@ -31,7 +31,7 @@ import org.bdgenomics.adam.rdd.read.AlignmentRecordContext._
 class Adam2FastqArgs extends ParquetLoadSaveArgs {
   @Argument(required = false, metaVar = "OUTPUT", usage = "When writing FASTQ data, all second-in-pair reads will go here, if this argument is provided", index = 2)
   var outputPath2: String = null
-  @Args4JOption(required = false, name = "-samtools_validation", usage = "SAM tools validation level; when STRICT, checks that all reads are paired.")
+  @Args4JOption(required = false, name = "-validation", usage = "SAM tools validation level; when STRICT, checks that all reads are paired.")
   var validationStringency = ValidationStringency.LENIENT
   @Args4JOption(required = false, name = "-repartition", usage = "Set the number of partitions to map data to")
   var repartition: Int = -1
@@ -60,7 +60,9 @@ class Adam2Fastq(val args: Adam2FastqArgs) extends ADAMSparkCommand[Adam2FastqAr
           Projection(
             AlignmentRecordField.readName,
             AlignmentRecordField.sequence,
-            AlignmentRecordField.origQual
+            AlignmentRecordField.qual,
+            AlignmentRecordField.firstOfPair,
+            AlignmentRecordField.secondOfPair
           )
         )
       else
@@ -73,9 +75,9 @@ class Adam2Fastq(val args: Adam2FastqArgs) extends ADAMSparkCommand[Adam2FastqAr
       reads = reads.repartition(args.repartition)
     }
 
-    reads.adamSaveAsPairedFastq(
+    reads.adamSaveAsFastq(
       args.outputPath,
-      args.outputPath2,
+      Option(args.outputPath2),
       validationStringency = args.validationStringency,
       persistLevel = Option(args.persistLevel).map(StorageLevel.fromString(_))
     )

--- a/adam-core/src/main/scala/org/bdgenomics/adam/converters/AlignmentRecordConverter.scala
+++ b/adam-core/src/main/scala/org/bdgenomics/adam/converters/AlignmentRecordConverter.scala
@@ -36,7 +36,8 @@ class AlignmentRecordConverter extends Serializable {
    * @param adamRecord Read to convert to FASTQ.
    * @return Returns this read in string form.
    */
-  def convertToFastq(adamRecord: AlignmentRecord, maybeAddSuffix: Boolean = false): String = {
+  def convertToFastq(adamRecord: AlignmentRecord,
+                     maybeAddSuffix: Boolean = false): String = {
     val readNameSuffix =
       if (maybeAddSuffix &&
         !AlignmentRecordConverter.readNameHasPairedSuffix(adamRecord) &&
@@ -51,7 +52,12 @@ class AlignmentRecordConverter extends Serializable {
         ""
       }
 
-    "@%s%s\n%s\n+\n%s".format(adamRecord.getReadName, readNameSuffix, adamRecord.getSequence, adamRecord.getQual)
+    "@%s%s\n%s\n+\n%s".format(
+      adamRecord.getReadName,
+      readNameSuffix,
+      adamRecord.getSequence,
+      adamRecord.getQual
+    )
   }
 
   /**

--- a/adam-core/src/main/scala/org/bdgenomics/adam/rdd/read/AlignmentRecordContext.scala
+++ b/adam-core/src/main/scala/org/bdgenomics/adam/rdd/read/AlignmentRecordContext.scala
@@ -47,8 +47,13 @@ object AlignmentRecordContext extends Serializable with Logging {
     log.info("Reading interleaved FASTQ file format %s to create RDD".format(filePath))
 
     val job = HadoopUtil.newJob(sc)
-    val records = sc.newAPIHadoopFile(filePath, classOf[InterleavedFastqInputFormat], classOf[Void],
-      classOf[Text], ContextUtil.getConfiguration(job))
+    val records = sc.newAPIHadoopFile(
+      filePath,
+      classOf[InterleavedFastqInputFormat],
+      classOf[Void],
+      classOf[Text],
+      ContextUtil.getConfiguration(job)
+    )
     val fastqRecordConverter = new FastqRecordConverter
     records.flatMap(fastqRecordConverter.convertPair)
   }
@@ -58,8 +63,13 @@ object AlignmentRecordContext extends Serializable with Logging {
     log.info("Reading unpaired FASTQ file format %s to create RDD".format(filePath))
 
     val job = HadoopUtil.newJob(sc)
-    val records = sc.newAPIHadoopFile(filePath, classOf[SingleFastqInputFormat], classOf[Void],
-      classOf[Text], ContextUtil.getConfiguration(job))
+    val records = sc.newAPIHadoopFile(
+      filePath,
+      classOf[SingleFastqInputFormat],
+      classOf[Void],
+      classOf[Text],
+      ContextUtil.getConfiguration(job)
+    )
     val fastqRecordConverter = new FastqRecordConverter
     records.map(fastqRecordConverter.convertRead)
   }
@@ -132,17 +142,20 @@ class AlignmentRecordContext(val sc: SparkContext) extends Serializable with Log
         }
 
       joinedRDD
-        .flatMap(kv => Seq(AlignmentRecord.newBuilder(kv._2._1)
-          .setReadPaired(true)
-          .setProperPair(true)
-          .setFirstOfPair(true)
-          .setSecondOfPair(false)
-          .build(), AlignmentRecord.newBuilder(kv._2._2)
-          .setReadPaired(true)
-          .setProperPair(true)
-          .setFirstOfPair(false)
-          .setSecondOfPair(true)
-          .build()))
+        .flatMap(kv => Seq(
+          AlignmentRecord.newBuilder(kv._2._1)
+            .setReadPaired(true)
+            .setProperPair(true)
+            .setFirstOfPair(true)
+            .setSecondOfPair(false)
+            .build(),
+          AlignmentRecord.newBuilder(kv._2._2)
+            .setReadPaired(true)
+            .setProperPair(true)
+            .setFirstOfPair(false)
+            .setSecondOfPair(true)
+            .build()
+        ))
     }
 
     // uncache temp rdds

--- a/adam-core/src/test/scala/org/bdgenomics/adam/rdd/read/ADAMAlignmentRecordRDDFunctionsSuite.scala
+++ b/adam-core/src/test/scala/org/bdgenomics/adam/rdd/read/ADAMAlignmentRecordRDDFunctionsSuite.scala
@@ -314,6 +314,17 @@ class ADAMAlignmentRecordRDDFunctionsSuite extends SparkFunSuite {
 
     assert(rddA.count() == 6)
 
+    rddA.foreach(read => {
+      if (read.getFirstOfPair == read.getSecondOfPair)
+        throw new Exception(
+          "Exactly one of first-,second-of-pair should be true for %s: %s %s".format(
+            read.toString,
+            read.getFirstOfPair,
+            read.getSecondOfPair
+          )
+        )
+    })
+
     val tempFile = Files.createTempDirectory("reads")
     val tempPath1 = tempFile.toAbsolutePath.toString + "/reads1.fq"
     val tempPath2 = tempFile.toAbsolutePath.toString + "/reads2.fq"


### PR DESCRIPTION
Some improvements to fastq-writing flow / `adam2fastq`:
- optionally write out original qualities or "recalibrated" ones
- run `adam2fastq` through the single-or-paired-fastq interface based on the number of file arguments passed
- fix a bug where the projection was leaving out needed fields
- add an optional additional sanity check when writing paired-fastq
