### PR TITLE
Fixed typo on MAVEN_OPTS quotation mark

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ You will need to have [Maven](http://maven.apache.org/) installed in order to bu
 ```
 $ git clone https://github.com/bigdatagenomics/adam.git
 $ cd adam
-$ export "MAVEN_OPTS=-Xmx512m -XX:MaxPermSize=128m"
+$ export MAVEN_OPTS="-Xmx512m -XX:MaxPermSize=128m"
 $ mvn clean package -DskipTests
 ...
 [INFO] ------------------------------------------------------------------------


### PR DESCRIPTION
- In build instructions, left quotation mark was placed on the left of the variable name: export "MAVEN_OPTS
- Changed to export MAVEN_OPTS="
