### PR TITLE
[ADAM-480] Switch assembly to single goal.

### DIFF
--- a/adam-cli/pom.xml
+++ b/adam-cli/pom.xml
@@ -45,7 +45,7 @@
           <execution>
             <phase>package</phase>
             <goals>
-              <goal>assembly</goal>
+              <goal>single</goal>
             </goals>
           </execution>
         </executions>


### PR DESCRIPTION
Fixes #480. Moves the assembly plugin to the `single` goal, which eliminates the fork-and-rerun process.
