### PR TITLE
Added tests for multi Parquet rdds in S3.

### DIFF
--- a/adam-core/pom.xml
+++ b/adam-core/pom.xml
@@ -236,7 +236,6 @@
             <groupId>org.scalatest</groupId>
             <artifactId>scalatest-maven-plugin</artifactId>
             <configuration>
-              <tagsToExclude>org.bdgenomics.adam.util.S3Test</tagsToExclude>
               <tagsToInclude>org.bdgenomics.adam.util.NetworkConnected</tagsToInclude>
             </configuration>
           </plugin>

--- a/adam-core/src/test/scala/org/bdgenomics/adam/io/ByteAccessSuite.scala
+++ b/adam-core/src/test/scala/org/bdgenomics/adam/io/ByteAccessSuite.scala
@@ -29,9 +29,6 @@ class ByteAccessSuite extends FunSuite {
   lazy val credentials = new CredentialsProperties(Some(new File(System.getProperty("user.home") + "/spark.conf")))
     .awsCredentials(Some("s3"))
 
-  lazy val bucketName = System.getenv("BUCKET_NAME")
-  lazy val parquetLocation = System.getenv("PARQUET_LOCATION")
-
   test("ByteArrayByteAccess returns arbitrary subsets of bytes correctly") {
     val bytes = Array[Byte](0, 1, 2, 3, 4, 5, 6, 7, 8, 9)
     val access = new ByteArrayByteAccess(bytes)
@@ -116,8 +113,8 @@ class ByteAccessSuite extends FunSuite {
 
   test("Testing S3 byte access", NetworkConnected, S3Test) {
     val byteAccess = new S3ByteAccess(new AmazonS3Client(credentials),
-      bucketName,
-      parquetLocation)
+      "bdgenomics-test",
+      "reads-0-2-0")
     assert(byteAccess.readFully(0, 1)(0) === 80)
   }
 }

--- a/adam-core/src/test/scala/org/bdgenomics/adam/parquet_reimpl/AvroParquetRDDSuite.scala
+++ b/adam-core/src/test/scala/org/bdgenomics/adam/parquet_reimpl/AvroParquetRDDSuite.scala
@@ -20,18 +20,18 @@ package org.bdgenomics.adam.parquet_reimpl
 import java.io.{ ByteArrayInputStream, ByteArrayOutputStream, File }
 import java.lang.Iterable
 import java.net.URI
-
 import org.bdgenomics.adam.io._
 import org.bdgenomics.adam.models.ReferenceRegion
 import org.bdgenomics.adam.parquet_reimpl.filters.{ FilterTuple, SerializableUnboundRecordFilter }
 import org.bdgenomics.adam.parquet_reimpl.index.ReferenceFoldingContext._
 import org.bdgenomics.adam.parquet_reimpl.index._
-import org.bdgenomics.adam.projections.Projection
+import org.bdgenomics.adam.projections.{ AlignmentRecordField, Projection }
 import org.bdgenomics.adam.util._
 import org.bdgenomics.formats.avro.{ AlignmentRecord, FlatGenotype }
 import parquet.column.ColumnReader
 import parquet.filter.{ RecordFilter, UnboundRecordFilter }
-
+import parquet.filter.ColumnPredicates.equalTo
+import parquet.filter.ColumnRecordFilter.column
 import scala.collection.JavaConversions._
 import scala.io.Source
 
@@ -48,10 +48,43 @@ class RDDFunSuite extends SparkFunSuite {
 
 class AvroMultiParquetRDDSuite extends RDDFunSuite {
 
+  lazy val credentials = new CredentialsProperties(Some(new File(System.getProperty("user.home") + "/spark.conf")))
+    .awsCredentials(Some("s3"))
+
   sparkTest("test load parquet_test directory loads all reads from two files") {
     val locator = new ClasspathFileLocator("parquet_test")
     val multiLoader = new AvroMultiParquetRDD[AlignmentRecord](sc, locator, null, None)
     assert(multiLoader.count() === 400)
+  }
+
+  sparkTest("Retrieve records from a multi-partition Parquet directory through S3", silenceSpark = true, NetworkConnected, S3Test) {
+
+    val locator = new S3FileLocator(credentials, "bdgenomics-test", "NA12878.adam")
+    val rdd = new AvroMultiParquetRDD[AlignmentRecord](
+      sc,
+      locator,
+      null,
+      None)
+
+    assert(rdd.count() === 565)
+  }
+
+  sparkTest("Retrieve records from a multi-partition Parquet directory through S3 and apply both a projection and a predicate", silenceSpark = true, NetworkConnected, S3Test) {
+
+    class DuplicatesOnlyPredicate extends UnboundRecordFilter {
+      def bind(readers: Iterable[ColumnReader]): RecordFilter = {
+        column(AlignmentRecordField.duplicateRead.toString(), equalTo(true)).bind(readers)
+      }
+    }
+
+    val locator = new S3FileLocator(credentials, "bdgenomics-test", "NA12878.adam")
+    val rdd = new AvroMultiParquetRDD[AlignmentRecord](
+      sc,
+      locator,
+      new DuplicatesOnlyPredicate,
+      Some(Projection(AlignmentRecordField.duplicateRead)))
+
+    assert(rdd.count() === 107)
   }
 }
 
@@ -199,9 +232,6 @@ class AvroParquetRDDSuite extends SparkFunSuite {
   lazy val credentials = new CredentialsProperties(Some(new File(System.getProperty("user.home") + "/spark.conf")))
     .awsCredentials(Some("s3"))
 
-  lazy val bucketName = System.getenv("BUCKET_NAME")
-  lazy val parquetLocation = System.getenv("PARQUET_LOCATION")
-
   sparkTest("Retrieve records from a Parquet file through classpath") {
     val locator = new ClasspathFileLocator("reads-0-2-0")
     val rdd = new AvroParquetRDD[AlignmentRecord](
@@ -236,7 +266,7 @@ class AvroParquetRDDSuite extends SparkFunSuite {
 
   sparkTest("Retrieve records from a Parquet file through S3", silenceSpark = true, NetworkConnected, S3Test) {
 
-    val locator = new S3FileLocator(credentials, bucketName, parquetLocation)
+    val locator = new S3FileLocator(credentials, "bdgenomics-test", "reads-0-2-0")
     val rdd = new AvroParquetRDD[AlignmentRecord](
       sc,
       null,
@@ -299,7 +329,7 @@ class AvroParquetRDDSuite extends SparkFunSuite {
 
     val schema = Projection(readName, start, contig)
 
-    val locator = new S3FileLocator(credentials, bucketName, parquetLocation)
+    val locator = new S3FileLocator(credentials, "bdgenomics-test", "reads-0-2-0")
     val rdd = new AvroParquetRDD[AlignmentRecord](
       sc,
       null,
@@ -367,7 +397,7 @@ class AvroParquetRDDSuite extends SparkFunSuite {
     val schema = Projection(readName, start, sequence)
     val filter = new ReadNameFilter("simread:1:189606653:true")
 
-    val locator = new S3FileLocator(credentials, bucketName, parquetLocation)
+    val locator = new S3FileLocator(credentials, "bdgenomics-test", "reads-0-2-0")
     val rdd = new AvroParquetRDD[AlignmentRecord](
       sc,
       filter,

--- a/adam-core/src/test/scala/org/bdgenomics/adam/parquet_reimpl/ParquetCommonSuite.scala
+++ b/adam-core/src/test/scala/org/bdgenomics/adam/parquet_reimpl/ParquetCommonSuite.scala
@@ -30,9 +30,6 @@ class ParquetCommonSuite extends FunSuite {
   lazy val credentials = new CredentialsProperties(Some(new File(System.getProperty("user.home") + "/spark.conf")))
     .awsCredentials(Some("s3"))
 
-  lazy val bucketName = System.getenv("bucket-name")
-  lazy val parquetLocation = System.getenv("parquet-location")
-
   val filename = Thread.currentThread().getContextClassLoader.getResource("small_adam.fgenotype").getFile
   val s3Filename = ""
 
@@ -51,8 +48,8 @@ class ParquetCommonSuite extends FunSuite {
 
   test("Reading a footer from S3", NetworkConnected, S3Test) {
     val byteAccess = new S3ByteAccess(new AmazonS3Client(credentials),
-      bucketName,
-      parquetLocation)
+      "bdgenomics-test",
+      "reads-0-2-0")
     val footer = ParquetCommon.readFooter(byteAccess)
     assert(footer.rowGroups.length === 1)
   }


### PR DESCRIPTION
@tdanford @carlyeks A little something something for you both to look at. I cleaned up the S3 tests a bit. You'll need to set `AWS_SECRET_ACCESS_KEY` and `AWS_ACCESS_KEY_ID` to run. The multi-parquet S3 tests fail due to:

```
- Retrieve records from a multi-partition Parquet directory through S3 *** FAILED ***
  java.lang.IllegalArgumentException: requirement failed: File does not appear to be a Parquet file
  at scala.Predef$.require(Predef.scala:233)
  at org.bdgenomics.adam.rdd.ParquetCommon$.readFileMetadata(ParquetCommon.scala:70)
  at org.bdgenomics.adam.parquet_reimpl.AvroMultiParquetRDD$$anonfun$3.apply(AvroParquetRDD.scala:128)
  at org.bdgenomics.adam.parquet_reimpl.AvroMultiParquetRDD$$anonfun$3.apply(AvroParquetRDD.scala:126)
  at scala.collection.TraversableLike$$anonfun$flatMap$1.apply(TraversableLike.scala:251)
  at scala.collection.TraversableLike$$anonfun$flatMap$1.apply(TraversableLike.scala:251)
  at scala.collection.immutable.List.foreach(List.scala:318)
  at scala.collection.generic.TraversableForwarder$class.foreach(TraversableForwarder.scala:32)
  at scala.collection.mutable.ListBuffer.foreach(ListBuffer.scala:45)
  at scala.collection.TraversableLike$class.flatMap(TraversableLike.scala:251)
  ...
- Retrieve records from a multi-partition Parquet directory through S3 and apply both a projection and a predicate *** FAILED ***
  java.lang.IllegalArgumentException: requirement failed: File does not appear to be a Parquet file
  at scala.Predef$.require(Predef.scala:233)
  at org.bdgenomics.adam.rdd.ParquetCommon$.readFileMetadata(ParquetCommon.scala:70)
  at org.bdgenomics.adam.parquet_reimpl.AvroMultiParquetRDD$$anonfun$3.apply(AvroParquetRDD.scala:128)
  at org.bdgenomics.adam.parquet_reimpl.AvroMultiParquetRDD$$anonfun$3.apply(AvroParquetRDD.scala:126)
  at scala.collection.TraversableLike$$anonfun$flatMap$1.apply(TraversableLike.scala:251)
  at scala.collection.TraversableLike$$anonfun$flatMap$1.apply(TraversableLike.scala:251)
  at scala.collection.immutable.List.foreach(List.scala:318)
  at scala.collection.generic.TraversableForwarder$class.foreach(TraversableForwarder.scala:32)
  at scala.collection.mutable.ListBuffer.foreach(ListBuffer.scala:45)
  at scala.collection.TraversableLike$class.flatMap(TraversableLike.scala:251)
  ...
```

So, something's not _quite_ right in the implementation.
