### PR TITLE
[ADAM-489] Moved Spark and Hadoop to provided dependency.

### DIFF
--- a/adam-apis/pom.xml
+++ b/adam-apis/pom.xml
@@ -90,6 +90,14 @@
 
   <dependencies>
     <dependency>
+      <groupId>org.apache.hadoop</groupId>
+      <artifactId>hadoop-client</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.spark</groupId>
+      <artifactId>spark-core_${scala.artifact.suffix}</artifactId>
+    </dependency>
+    <dependency>
       <groupId>org.bdgenomics.bdg-formats</groupId>
       <artifactId>bdg-formats</artifactId>
     </dependency>

--- a/adam-cli/pom.xml
+++ b/adam-cli/pom.xml
@@ -116,6 +116,14 @@
 
   <dependencies>
     <dependency>
+      <groupId>org.apache.hadoop</groupId>
+      <artifactId>hadoop-client</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.spark</groupId>
+      <artifactId>spark-core_${scala.artifact.suffix}</artifactId>
+    </dependency>
+    <dependency>
       <groupId>org.scoverage</groupId>
       <artifactId>scalac-scoverage-plugin_${scala.artifact.suffix}</artifactId>
     </dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -350,6 +350,7 @@
         <groupId>org.apache.hadoop</groupId>
         <artifactId>hadoop-client</artifactId>
         <version>${hadoop.version}</version>
+        <scope>provided</scope>
         <exclusions>
           <exclusion>
             <groupId>asm</groupId>
@@ -377,6 +378,7 @@
         <groupId>org.apache.spark</groupId>
         <artifactId>spark-core_${scala.artifact.suffix}</artifactId>
         <version>${spark.version}</version>
+        <scope>provided</scope>
         <exclusions>
           <exclusion>
             <groupId>org.apache.hadoop</groupId>


### PR DESCRIPTION
Resolves #489. Makes the Spark/Hadoop dependencies `provided`.
