### PR TITLE
Fix foreach block for vcf ingest

### DIFF
--- a/adam-cli/src/main/scala/org/bdgenomics/adam/cli/Vcf2FlatGenotype.scala
+++ b/adam-cli/src/main/scala/org/bdgenomics/adam/cli/Vcf2FlatGenotype.scala
@@ -116,14 +116,15 @@ class Vcf2FlatGenotype(args: Vcf2FlatGenotypeArgs) extends ADAMCommand {
           }
           i += lineCount
         }
-
-        vcfReader.close()
-        writers.foreach(_.close())
-
-        System.err.flush()
-        System.out.flush()
-        println("\nFinished! Converted %d lines total.".format(i))
     }
+
+    vcfReader.close()
+    writers.foreach(_.close())
+
+    System.err.flush()
+    System.out.flush()
+    println("\nFinished! Converted %d lines total.".format(i))
+
   }
 }
 


### PR DESCRIPTION
foreach block for writing out vcf records seemed to accidentally include cleanup code as well.   Simply moved it up to ensure cleanup code called once at the end of processing all the lines.  
