### PR TITLE
Upgrade from Parquet 1.4.3 to 1.6.0rc4

### DIFF
--- a/adam-core/src/main/scala/org/bdgenomics/adam/parquet_reimpl/ParquetPartition.scala
+++ b/adam-core/src/main/scala/org/bdgenomics/adam/parquet_reimpl/ParquetPartition.scala
@@ -114,7 +114,13 @@ object ParquetPartition {
 
     val columnIOFactory: ColumnIOFactory = new ColumnIOFactory
     val columnIO = columnIOFactory.getColumnIO(requestedSchema.convertToParquet(), actualSchema.convertToParquet())
-    val reader = columnIO.getRecordReader[T](pageReadStore, recordMaterializer, filter)
+
+    // TODO: Use Scala Option instead of null
+    val reader = if (filter == null.asInstanceOf[UnboundRecordFilter]) {
+      columnIO.getRecordReader[T](pageReadStore, recordMaterializer)
+    } else {
+      columnIO.getRecordReader[T](pageReadStore, recordMaterializer, filter)
+    }
 
     new Iterator[T] {
       var recordsRead = 0

--- a/pom.xml
+++ b/pom.xml
@@ -22,7 +22,7 @@
     <scala.artifact.suffix>2.10</scala.artifact.suffix>
     <avro.version>1.7.6</avro.version>
     <spark.version>1.1.0</spark.version>
-    <parquet.version>1.4.3</parquet.version>
+    <parquet.version>1.6.0rc4</parquet.version>
     <!-- Edit the following line to configure the Hadoop (HDFS) version. -->
     <hadoop.version>2.2.0</hadoop.version>
     <scoverage.version>0.99.2</scoverage.version>


### PR DESCRIPTION
This upgrade adds dictionary support which dramatically reduces the
memory footprint.

For example, a simple program to load and count mouse mitochondrial DNA..

  val reads = ac.loadAlignments("/workspace/data/mouse_chrM.adam").cache()
  println(reads.count())

In 1.6.0rc4, this rdd was able to be cached in memory, e.g.

14/11/24 10:37:16 INFO BlockManagerInfo: Added rdd_1_0 in memory on zenfractal:60004 (size: 193.0 MB, free: 72.5 MB)

With 1.4.3, it was not, e.g.

14/11/24 10:33:07 WARN CacheManager: Not enough space to cache partition rdd_1_0 in memory! Free memory is 278185689 bytes.
