### PR TITLE
Adding RegionRDDFunctions

### DIFF
--- a/adam-cli/src/main/scala/org/bdgenomics/adam/cli/CalculateDepth.scala
+++ b/adam-cli/src/main/scala/org/bdgenomics/adam/cli/CalculateDepth.scala
@@ -23,15 +23,14 @@ import org.apache.hadoop.mapreduce.Job
 import org.apache.spark.SparkContext
 import org.apache.spark.SparkContext._
 import org.apache.spark.rdd.RDD
-import org.bdgenomics.adam.models.{ ReferenceRegionContext, SequenceDictionary, ReferenceRegion }
+import org.bdgenomics.adam.models.{ SequenceDictionary, ReferenceRegion }
+import org.bdgenomics.adam.models.ReferenceRegionContext._
 import org.bdgenomics.adam.projections.Projection
 import org.bdgenomics.adam.projections.AlignmentRecordField._
 import org.bdgenomics.adam.rdd.ADAMContext._
 import org.bdgenomics.adam.rdd.BroadcastRegionJoin
 import org.bdgenomics.formats.avro.AlignmentRecord
 import scala.io._
-
-import ReferenceRegionContext._
 
 /**
  * CalculateDepth (accessible as the command 'depth' through the CLI) takes two arguments,

--- a/adam-cli/src/main/scala/org/bdgenomics/adam/cli/CalculateDepth.scala
+++ b/adam-cli/src/main/scala/org/bdgenomics/adam/cli/CalculateDepth.scala
@@ -23,13 +23,15 @@ import org.apache.hadoop.mapreduce.Job
 import org.apache.spark.SparkContext
 import org.apache.spark.SparkContext._
 import org.apache.spark.rdd.RDD
-import org.bdgenomics.adam.models.{ SequenceDictionary, ReferenceRegion }
+import org.bdgenomics.adam.models.{ ReferenceRegionContext, SequenceDictionary, ReferenceRegion }
 import org.bdgenomics.adam.projections.Projection
 import org.bdgenomics.adam.projections.AlignmentRecordField._
 import org.bdgenomics.adam.rdd.ADAMContext._
 import org.bdgenomics.adam.rdd.BroadcastRegionJoin
 import org.bdgenomics.formats.avro.AlignmentRecord
 import scala.io._
+
+import ReferenceRegionContext._
 
 /**
  * CalculateDepth (accessible as the command 'depth' through the CLI) takes two arguments,

--- a/adam-core/src/main/scala/org/bdgenomics/adam/converters/FragmentConverter.scala
+++ b/adam-core/src/main/scala/org/bdgenomics/adam/converters/FragmentConverter.scala
@@ -20,6 +20,7 @@ package org.bdgenomics.adam.converters
 import org.apache.spark.SparkContext._
 import org.apache.spark.rdd.RDD
 import org.bdgenomics.adam.models.ReferenceRegion
+import org.bdgenomics.adam.models.ReferenceRegionContext._
 import org.bdgenomics.formats.avro._
 import scala.annotation.tailrec
 

--- a/adam-core/src/main/scala/org/bdgenomics/adam/models/Gene.scala
+++ b/adam-core/src/main/scala/org/bdgenomics/adam/models/Gene.scala
@@ -22,6 +22,7 @@ import org.apache.spark.rdd.RDD
 import org.bdgenomics.adam.rdd.ADAMContext._
 import org.bdgenomics.adam.util.SequenceUtils
 import org.bdgenomics.formats.avro.{ Strand, Feature }
+import ReferenceRegionContext._
 
 /**
  * A 'gene model' is a small, hierarchical collection of objects: Genes, Transcripts, and Exons.

--- a/adam-core/src/main/scala/org/bdgenomics/adam/rdd/Coverage.scala
+++ b/adam-core/src/main/scala/org/bdgenomics/adam/rdd/Coverage.scala
@@ -53,7 +53,7 @@ class Coverage(val window: Long) extends Serializable {
    * @return an RDD containing the ReferenceRegions corresponding to the coverage regions
    *         of the input set 'coveringRegions'
    */
-  def findCoverageRegions(coveringRegions: RDD[ReferenceRegion]): RDD[ReferenceRegion] = {
+  def findCoverageRegions[R <: ReferenceRegion](coveringRegions: RDD[R]): RDD[ReferenceRegion] = {
 
     // First, map each input region to a window
     val windowKeyedRegions: RDD[(Region, Region)] = coveringRegions.flatMap(regionToWindows)

--- a/adam-core/src/main/scala/org/bdgenomics/adam/rdd/Coverage.scala
+++ b/adam-core/src/main/scala/org/bdgenomics/adam/rdd/Coverage.scala
@@ -21,8 +21,9 @@ import org.apache.spark.SparkContext
 import org.apache.spark.SparkContext._
 import org.apache.spark.rdd.RDD
 import scala.math._
-import org.bdgenomics.adam.models.{ SequenceDictionary, ReferenceRegion }
+import org.bdgenomics.adam.models.{ ReferenceRegionContext, ReferenceRegionOrdering, SequenceDictionary, ReferenceRegion }
 import PairingRDD._
+import ReferenceRegionContext._
 
 /**
  * A base is 'covered' by a region set if any region in the set contains the base itself.
@@ -97,7 +98,7 @@ class Coverage(val window: Long) extends Serializable {
       case (None, None)         => 0
       case (None, Some(r2))     => -1
       case (Some(r1), None)     => 1
-      case (Some(r1), Some(r2)) => r1.compareTo(r2)
+      case (Some(r1), Some(r2)) => ReferenceRegionOrdering.compare(r1, r2)
     }
 
   case class OrientedPoint(chrom: String, pos: Long, polarity: Boolean) extends Ordered[OrientedPoint] with Serializable {

--- a/adam-core/src/main/scala/org/bdgenomics/adam/rdd/RegionJoin.scala
+++ b/adam-core/src/main/scala/org/bdgenomics/adam/rdd/RegionJoin.scala
@@ -37,7 +37,7 @@ trait RegionJoin {
    * @return An RDD of pairs (x, y), where x is from baseRDD, y is from joinedRDD, and the region
    *         corresponding to x overlaps the region corresponding to y.
    */
-  def partitionAndJoin[T, U](baseRDD: RDD[(ReferenceRegion, T)],
-                             joinedRDD: RDD[(ReferenceRegion, U)])(implicit tManifest: ClassTag[T],
-                                                                   uManifest: ClassTag[U]): RDD[(T, U)]
+  def partitionAndJoin[RT <: ReferenceRegion, T, RU <: ReferenceRegion, U](baseRDD: RDD[(RT, T)],
+                                                                           joinedRDD: RDD[(RU, U)])(implicit tManifest: ClassTag[T],
+                                                                                                    uManifest: ClassTag[U]): RDD[(T, U)]
 }

--- a/adam-core/src/main/scala/org/bdgenomics/adam/rdd/RegionRDDFunctions.scala
+++ b/adam-core/src/main/scala/org/bdgenomics/adam/rdd/RegionRDDFunctions.scala
@@ -1,0 +1,182 @@
+/**
+ * Licensed to Big Data Genomics (BDG) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The BDG licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.bdgenomics.adam.rdd
+
+import org.apache.spark.SparkContext._
+import org.apache.spark.rdd.RDD
+import org.bdgenomics.adam.models.{ SequenceDictionary, ReferenceRegionWithOrientation, ReferenceRegion }
+import org.bdgenomics.adam.models.ReferenceRegionContext._
+import scala.reflect.ClassTag
+import scala.math.max
+
+/**
+ * Functions (joins, filters, groups, counts) that are often invoked on RDD[R] where R is a
+ * type which extends ReferenceRegion (and is often just ReferenceRegion directly).
+ *
+ * @param rdd The argument RDD
+ * @param kt The type of the argument RDD must be explicit
+ * @tparam Region The type of the argument RDD
+ */
+class RegionRDDFunctions[Region <: ReferenceRegion](rdd: RDD[Region])(implicit kt: ClassTag[Region])
+    extends Serializable {
+
+  import RegionRDDFunctions._
+
+  /**
+   * Performs an 'overlap join' on the input RDD, returning pairs whose first element is a member of the
+   * input RDD and whose second element is a member of the argument RDD which overlaps the first element
+   * of the pair.
+   *
+   * @param that The argument RDD
+   * @param kt2 The type of the values in the argument RDD must be explicit.
+   * @tparam R2 The explicit type of the regions in the argument RDD
+   * @return The RDD of pairs (f, s) where f comes from the input RDD and s comes from 'that', the argument
+   *         RDD.
+   */
+  def joinByOverlap[R2 <: ReferenceRegion](that: RDD[R2])(implicit kt2: ClassTag[R2]): RDD[(Region, R2)] =
+    BroadcastRegionJoin.partitionAndJoin[Region, Region, R2, R2](rdd.keyBy(r => r), that.keyBy(r => r))
+
+  /**
+   * Performs a 'range join' on the input RDD, returning pairs whose first element is a member of the
+   * input RDD and whose second element is a member of the argument RDD which is within 'range' bases
+   * of the first element of the pair.
+   *
+   * @param that The argument RDD
+   * @param range A long integer; if two regions are within 'range' of each other (along the same chromosome),
+   *              then they are present in the returned RDD.
+   * @param kt2 The type of the values in the argument RDD must be explicit.
+   * @tparam R2 The explicit type of the regions in the argument RDD
+   * @return The RDD of pairs (f, s) where f comes from the input RDD and s comes from 'that', the argument
+   *         RDD.
+   */
+  def joinWithinRange[R2 <: ReferenceRegion](that: RDD[R2], range: Long)(implicit kt2: ClassTag[R2]): RDD[(Region, R2)] =
+    rdd.keyBy(expander(range))
+      .joinByOverlap(that.keyBy(r => r))
+
+  /**
+   * Performs a 'filter by overlap' on the input RDD, returning only the subset of values in the input
+   * RDD which overlap at least one region in the argument RDD.
+   *
+   * @param that the argument RDD
+   * @param kt2 the type of the values in the argument RDD must be explicit
+   * @tparam R2 the type of the values in the argument RDD
+   * @return The subset of values from the input RDD which overlap at least one element of the
+   *         argument RDD.
+   */
+  def filterByOverlap[R2 <: ReferenceRegion](that: RDD[R2])(implicit kt2: ClassTag[R2]): RDD[Region] =
+    rdd.joinByOverlap(that).map(_._1).distinct()
+
+  /**
+   * Performs a 'filter by range' on the input RDD, returning only the subset of values in the input
+   * RDD which are within a fixed number of basepairs of at least one region in the argument RDD.
+   *
+   * @param that the argument RDD
+   * @param range a long integer; defines the window within which an input region must be of an argument
+   *              region, in order to be reported in the output RDD
+   * @param kt2 the type of the values in the argument RDD must be explicit
+   * @tparam R2 the type of the values in the argument RDD
+   * @return The subset of values from the input RDD which overlap at least one element of the
+   *         argument RDD.
+   */
+  def filterWithinRange[R2 <: ReferenceRegion](that: RDD[R2], range: Long)(implicit kt2: ClassTag[R2]): RDD[Region] =
+    rdd.joinWithinRange(that, range).map(_._1).distinct()
+
+  /**
+   * Performs the equivalent of a joinByOverlap followed by a groupByKey; in effect, this returns
+   * an Iterable of the regions in the argument RDD that overlap a region from the input RDD, _for each_
+   * region of the input RDD.
+   *
+   * @param that the argument RDD
+   * @param kt2 the type of the values in the argument RDD must be explicit
+   * @tparam R2 the type of the values in the argument RDD
+   * @return An RDD of pairs, where the first element is a region from the input RDD and the second
+   *         is an Iterable of regions from the argument RDD which overlap the first element.
+   */
+  def groupByOverlap[R2 <: ReferenceRegion](that: RDD[R2])(implicit kt2: ClassTag[R2]): RDD[(Region, Iterable[R2])] =
+    rdd.joinByOverlap(that).groupByKey()
+
+  /**
+   * Performs the equivalent of a joinByRange followed by a groupByKey; in effect, this returns
+   * an Iterable of the regions in the argument RDD that overlap a region from the input RDD, _for each_
+   * region of the input RDD, where 'overlap' is expanded to include a range around each region
+   * in the argument RDD.
+   *
+   * @param that the argument RDD
+   * @param range a long integer; pairs of regions within this range of each other are considered to
+   *              overlap
+   * @param kt2 the type of the values in the argument RDD must be explicit
+   * @tparam R2 the type of the values in the argument RDD
+   * @return An RDD of pairs, where the first element is a region from the input RDD and the second
+   *         is an Iterable of regions from the argument RDD which overlaps (within the range) the
+   *         first element.
+   */
+  def groupByWithinRange[R2 <: ReferenceRegion](that: RDD[R2], range: Long)(implicit kt2: ClassTag[R2]): RDD[(Region, Iterable[R2])] =
+    rdd.joinWithinRange(that, range).groupByKey()
+
+  /**
+   * Calculates windows of a fixed width that tile the entire genome, and then counts how many
+   * elements of the input RDD overlap each window.
+   *
+   * @param seqDict The dictionary which defines the sequences and lengths of the genome, used for
+   *                defining the set of windows over which counts are to be calculated.
+   * @param windowSize The size of the window (in base-pairs)
+   * @return An RDD of (window, count) pairs
+   */
+  def windowCounts(seqDict: SequenceDictionary, windowSize: Long): RDD[(ReferenceRegion, Int)] =
+    new Coverage(windowSize).getAllWindows(rdd.sparkContext, seqDict)
+      .joinByOverlap(rdd)
+      .groupByKey()
+      .map {
+        case (window: ReferenceRegion, values: Iterable[Region]) =>
+          (window, values.size)
+      }
+
+}
+
+class OrientedRegionRDDFunctions[Region <: ReferenceRegionWithOrientation](rdd: RDD[Region])(implicit kt: ClassTag[Region]) extends Serializable {
+
+  def extend(targetLength: Long): RDD[ReferenceRegionWithOrientation] =
+    rdd.map(r => r.extend(targetLength))
+}
+
+class RegionKeyedRDDFunctions[R <: ReferenceRegion, V](rdd: RDD[(R, V)])(implicit rt: ClassTag[R], vt: ClassTag[V]) extends Serializable {
+
+  import RegionRDDFunctions._
+
+  def joinByOverlap[R2 <: ReferenceRegion, V2](that: RDD[(R2, V2)])(implicit v2t: ClassTag[V2]): RDD[(V, V2)] =
+    BroadcastRegionJoin.partitionAndJoin(rdd, that)
+
+  def filterWithinRange[R2 <: ReferenceRegion, V2](range: Long, that: RDD[(R2, V2)])(implicit v2t: ClassTag[V2]): RDD[(R, V)] =
+    rdd.keyBy(rpair => expander(range)(rpair._1))
+      .joinByOverlap(that)
+      .map(_._1)
+      .distinct()
+}
+
+object RegionRDDFunctions extends Serializable {
+
+  def expander[Region <: ReferenceRegion](range: Long)(r: Region): ReferenceRegion =
+    ReferenceRegion(r.referenceName, max(0, r.start - range), r.end + range)
+
+  implicit def rddToRegionRDDFunctions[R <: ReferenceRegion](rdd: RDD[R])(implicit kt: ClassTag[R]): RegionRDDFunctions[R] =
+    new RegionRDDFunctions[R](rdd)
+  implicit def rddToOrientedRegionRDDFunctions[R <: ReferenceRegionWithOrientation](rdd: RDD[R])(implicit kt: ClassTag[R]): OrientedRegionRDDFunctions[R] =
+    new OrientedRegionRDDFunctions[R](rdd)
+  implicit def rddToRegionKeyedRDDFunctions[R <: ReferenceRegion, V](rdd: RDD[(R, V)])(implicit kt: ClassTag[R], vt: ClassTag[V]): RegionKeyedRDDFunctions[R, V] =
+    new RegionKeyedRDDFunctions[R, V](rdd)
+}

--- a/adam-core/src/main/scala/org/bdgenomics/adam/rdd/RegionRDDFunctions.scala
+++ b/adam-core/src/main/scala/org/bdgenomics/adam/rdd/RegionRDDFunctions.scala
@@ -170,6 +170,17 @@ class RegionKeyedRDDFunctions[R <: ReferenceRegion, V](rdd: RDD[(R, V)])(implici
 
 object RegionRDDFunctions extends Serializable {
 
+  /**
+   * Given a size, produces an 'expander function,' which translates ReferenceRegion values
+   * into ReferenceRegions that are larger (on each end) by the given size. The start of the expanded
+   * region will never be negative -- although the end of the expanded region is unbounded.
+   *
+   * @param range The size of the expansion, on one end (if this is N, the ReferenceRegions produced
+   *              by the expander function will be at most 2N bases larger).
+   * @param r The region argument to the expander function.
+   * @tparam Region The expander function has an argument type parameter, which must be a subtype of ReferenceRegion
+   * @return The expanded region.
+   */
   def expander[Region <: ReferenceRegion](range: Long)(r: Region): ReferenceRegion =
     ReferenceRegion(r.referenceName, max(0, r.start - range), r.end + range)
 

--- a/adam-core/src/main/scala/org/bdgenomics/adam/rdd/contig/FlankReferenceFragments.scala
+++ b/adam-core/src/main/scala/org/bdgenomics/adam/rdd/contig/FlankReferenceFragments.scala
@@ -19,6 +19,7 @@ package org.bdgenomics.adam.rdd.contig
 
 import org.apache.spark.SparkContext._
 import org.apache.spark.rdd.RDD
+import org.bdgenomics.adam.models.ReferenceRegionContext._
 import org.bdgenomics.adam.models.{ ReferenceRegion, SequenceDictionary }
 import org.bdgenomics.adam.rdd.ReferencePartitioner
 import org.bdgenomics.formats.avro.NucleotideContigFragment

--- a/adam-core/src/main/scala/org/bdgenomics/adam/rdd/contig/NucleotideContigFragmentRDDFunctions.scala
+++ b/adam-core/src/main/scala/org/bdgenomics/adam/rdd/contig/NucleotideContigFragmentRDDFunctions.scala
@@ -37,6 +37,7 @@ import parquet.hadoop.metadata.CompressionCodecName
 import parquet.hadoop.util.ContextUtil
 import scala.math.max
 import scala.Some
+import ReferenceRegionContext._
 
 class NucleotideContigFragmentRDDFunctions(rdd: RDD[NucleotideContigFragment]) extends ADAMSequenceDictionaryRDDAggregator[NucleotideContigFragment](rdd) {
 
@@ -78,7 +79,7 @@ class NucleotideContigFragmentRDDFunctions(rdd: RDD[NucleotideContigFragment]) e
       assert(kv1._1.isAdjacent(kv2._1), "Regions being joined must be adjacent. For: " +
         kv1 + ", " + kv2)
 
-      (kv1._1.merge(kv2._1), if (kv1._1.compare(kv2._1) <= 0) {
+      (kv1._1.merge(kv2._1), if (ReferenceRegionOrdering.compare(kv1._1, kv2._1) <= 0) {
         kv1._2 + kv2._2
       } else {
         kv2._2 + kv1._2
@@ -94,7 +95,7 @@ class NucleotideContigFragmentRDDFunctions(rdd: RDD[NucleotideContigFragment]) e
         .map(kv => getString(kv))
         .reduce(reducePairs)
 
-      assert(pair._1.compare(region) == 0,
+      assert(ReferenceRegionOrdering.compare(pair._1, region) == 0,
         "Merging fragments returned a different region than requested.")
 
       pair._2

--- a/adam-core/src/main/scala/org/bdgenomics/adam/rdd/read/realignment/IndelRealignmentTarget.scala
+++ b/adam-core/src/main/scala/org/bdgenomics/adam/rdd/read/realignment/IndelRealignmentTarget.scala
@@ -21,7 +21,7 @@ import com.esotericsoftware.kryo.io.{ Input, Output }
 import com.esotericsoftware.kryo.{ Kryo, Serializer }
 import htsjdk.samtools.CigarOperator
 import org.apache.spark.Logging
-import org.bdgenomics.adam.models.ReferenceRegion
+import org.bdgenomics.adam.models.{ ReferenceRegionOrdering, ReferenceRegion }
 import org.bdgenomics.adam.rdd.ADAMContext._
 import org.bdgenomics.adam.rich.RichAlignmentRecord
 import org.bdgenomics.formats.avro.AlignmentRecord
@@ -51,7 +51,8 @@ object TargetOrdering extends Ordering[IndelRealignmentTarget] {
    * @param b Indel realignment target to compare.
    * @return Comparison done by starting position.
    */
-  def compare(a: IndelRealignmentTarget, b: IndelRealignmentTarget): Int = a.readRange compare b.readRange
+  def compare(a: IndelRealignmentTarget, b: IndelRealignmentTarget): Int =
+    ReferenceRegionOrdering.compare(a.readRange, b.readRange)
 
   /**
    * Check to see if an indel realignment target contains the given read.
@@ -76,7 +77,7 @@ object TargetOrdering extends Ordering[IndelRealignmentTarget] {
   def lt(target: IndelRealignmentTarget, read: RichAlignmentRecord): Boolean = {
     val region = read.readRegion
 
-    region.forall(r => target.readRange.compare(r) < 0)
+    region.forall(r => ReferenceRegionOrdering.compare(target.readRange, r) < 0)
   }
 
   /**

--- a/adam-core/src/test/scala/org/bdgenomics/adam/models/ReferenceRegionSuite.scala
+++ b/adam-core/src/test/scala/org/bdgenomics/adam/models/ReferenceRegionSuite.scala
@@ -22,6 +22,11 @@ import org.bdgenomics.formats.avro.{ AlignmentRecord, Contig }
 
 class ReferenceRegionSuite extends FunSuite {
 
+  test("ReferenceRegion.apply returns a reference region") {
+    val r1 = ReferenceRegion("chr1", 1000, 2000)
+    assert(r1 !== null)
+  }
+
   test("contains(: ReferenceRegion)") {
     assert(region("chr0", 10, 100).contains(region("chr0", 50, 70)))
     assert(region("chr0", 10, 100).contains(region("chr0", 10, 100)))

--- a/adam-core/src/test/scala/org/bdgenomics/adam/rdd/BroadcastRegionJoinSuite.scala
+++ b/adam-core/src/test/scala/org/bdgenomics/adam/rdd/BroadcastRegionJoinSuite.scala
@@ -18,6 +18,7 @@
 package org.bdgenomics.adam.rdd
 
 import org.apache.spark.SparkContext._
+import org.apache.spark.rdd.RDD
 import org.bdgenomics.adam.models.{ ReferenceRegion, SequenceDictionary, SequenceRecord }
 import org.bdgenomics.adam.util.ADAMFunSuite
 import org.bdgenomics.formats.avro.{ AlignmentRecord, Contig }
@@ -126,19 +127,19 @@ class BroadcastRegionJoinSuite extends ADAMFunSuite {
     val record1 = builder.build()
     val record2 = builder.build()
 
-    val rdd1 = sc.parallelize(Seq(record1)).keyBy(ReferenceRegion(_).get)
-    val rdd2 = sc.parallelize(Seq(record2)).keyBy(ReferenceRegion(_).get)
+    val rdd1: RDD[(ReferenceRegion, AlignmentRecord)] = sc.parallelize(Seq(record1)).keyBy(ReferenceRegion(_).get)
+    val rdd2: RDD[(ReferenceRegion, AlignmentRecord)] = sc.parallelize(Seq(record2)).keyBy(ReferenceRegion(_).get)
 
     assert(BroadcastRegionJoinSuite.getReferenceRegion(record1) ===
       BroadcastRegionJoinSuite.getReferenceRegion(record2))
 
-    assert(BroadcastRegionJoin.partitionAndJoin[AlignmentRecord, AlignmentRecord](
+    assert(BroadcastRegionJoin.partitionAndJoin(
       rdd1,
       rdd2).aggregate(true)(
         BroadcastRegionJoinSuite.merge,
         BroadcastRegionJoinSuite.and))
 
-    assert(BroadcastRegionJoin.partitionAndJoin[AlignmentRecord, AlignmentRecord](
+    assert(BroadcastRegionJoin.partitionAndJoin(
       rdd1,
       rdd2)
       .aggregate(0)(
@@ -168,14 +169,14 @@ class BroadcastRegionJoinSuite extends ADAMFunSuite {
     val baseRdd = sc.parallelize(Seq(baseRecord)).keyBy(ReferenceRegion(_).get)
     val recordsRdd = sc.parallelize(Seq(record1, record2)).keyBy(ReferenceRegion(_).get)
 
-    assert(BroadcastRegionJoin.partitionAndJoin[AlignmentRecord, AlignmentRecord](
+    assert(BroadcastRegionJoin.partitionAndJoin(
       baseRdd,
       recordsRdd)
       .aggregate(true)(
         BroadcastRegionJoinSuite.merge,
         BroadcastRegionJoinSuite.and))
 
-    assert(BroadcastRegionJoin.partitionAndJoin[AlignmentRecord, AlignmentRecord](
+    assert(BroadcastRegionJoin.partitionAndJoin(
       baseRdd,
       recordsRdd).count() === 2)
   }
@@ -202,7 +203,7 @@ class BroadcastRegionJoinSuite extends ADAMFunSuite {
       .build()
     val builtRef2 = AlignmentRecord.newBuilder()
       .setContig(contig2)
-      .setStart(1)
+      .setStart(1L)
       .setReadMapped(true)
       .setCigar("1M")
       .setEnd(2L)
@@ -217,14 +218,14 @@ class BroadcastRegionJoinSuite extends ADAMFunSuite {
     val baseRdd = sc.parallelize(Seq(baseRecord1, baseRecord2)).keyBy(ReferenceRegion(_).get)
     val recordsRdd = sc.parallelize(Seq(record1, record2, record3)).keyBy(ReferenceRegion(_).get)
 
-    assert(BroadcastRegionJoin.partitionAndJoin[AlignmentRecord, AlignmentRecord](
+    assert(BroadcastRegionJoin.partitionAndJoin(
       baseRdd,
       recordsRdd)
       .aggregate(true)(
         BroadcastRegionJoinSuite.merge,
         BroadcastRegionJoinSuite.and))
 
-    assert(BroadcastRegionJoin.partitionAndJoin[AlignmentRecord, AlignmentRecord](
+    assert(BroadcastRegionJoin.partitionAndJoin(
       baseRdd,
       recordsRdd).count() === 3)
   }

--- a/adam-core/src/test/scala/org/bdgenomics/adam/rdd/CoverageSuite.scala
+++ b/adam-core/src/test/scala/org/bdgenomics/adam/rdd/CoverageSuite.scala
@@ -105,7 +105,7 @@ class CoverageSuite extends ADAMFunSuite {
   sparkTest("find empty coverage") {
     implicit val sparkContext = sc
     val c = new Coverage(100L)
-    assert(c.findCoverageRegions(Seq()).collect() === Array())
+    assert(c.findCoverageRegions(Seq[ReferenceRegion]()).collect() === Array[ReferenceRegion]())
   }
 
   sparkTest("find coverage of one region") {

--- a/adam-core/src/test/scala/org/bdgenomics/adam/rdd/RegionRDDFunctionsSuite.scala
+++ b/adam-core/src/test/scala/org/bdgenomics/adam/rdd/RegionRDDFunctionsSuite.scala
@@ -26,6 +26,18 @@ import org.bdgenomics.utils.misc.SparkFunSuite
 
 class RegionRDDFunctionsSuite extends SparkFunSuite {
 
+  sparkTest("union of two simple overlapping regions returns a single union region") {
+    val r1: ReferenceRegion = ReferenceRegion("chr1", 1000, 2000)
+    val r2: ReferenceRegion = ReferenceRegion("chr1", 1500, 3000)
+
+    val rdd1 = sc.parallelize(Seq(r1))
+    val rdd2 = sc.parallelize(Seq(r2))
+
+    val unioned = rdd1.spatialUnion(rdd2)
+
+    assert(unioned.collect() === Array(ReferenceRegion("chr1", 1000, 3000)))
+  }
+
   sparkTest("joinByOverlap on an overlapping pair returns one pair") {
     val r1: ReferenceRegion = ReferenceRegion("chr1", 1000, 2000)
     val r2: ReferenceRegion = ReferenceRegion("chr1", 1500, 3000)

--- a/adam-core/src/test/scala/org/bdgenomics/adam/rdd/RegionRDDFunctionsSuite.scala
+++ b/adam-core/src/test/scala/org/bdgenomics/adam/rdd/RegionRDDFunctionsSuite.scala
@@ -1,0 +1,54 @@
+/**
+ * Licensed to Big Data Genomics (BDG) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The BDG licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.bdgenomics.adam.rdd
+
+import org.apache.spark.SparkContext._
+import org.bdgenomics.adam.models.{ ReferenceRegionContext, ReferenceRegion }
+import ADAMContext._
+import ReferenceRegionContext._
+import RegionRDDFunctions._
+import org.bdgenomics.utils.misc.SparkFunSuite
+
+class RegionRDDFunctionsSuite extends SparkFunSuite {
+
+  sparkTest("joinByOverlap on an overlapping pair returns one pair") {
+    val r1: ReferenceRegion = ReferenceRegion("chr1", 1000, 2000)
+    val r2: ReferenceRegion = ReferenceRegion("chr1", 1500, 3000)
+
+    val rdd1 = sc.parallelize(Seq(r1))
+    val rdd2 = sc.parallelize(Seq(r2))
+
+    val joined = rdd1.joinByOverlap(rdd2)
+
+    assert(joined.collect() === Array((r1, r2)))
+  }
+
+  sparkTest("joinByRange on a nearby pair returns one pair") {
+    val r1: ReferenceRegion = ReferenceRegion("chr1", 1000, 2000)
+    val r2: ReferenceRegion = ReferenceRegion("chr1", 3000, 4000)
+
+    val rdd1 = sc.parallelize(Seq(r1))
+    val rdd2 = sc.parallelize(Seq(r2))
+
+    val joined = rdd1.joinWithinRange(rdd2, 1001L)
+    assert(joined.collect() === Array((r1, r2)))
+
+    val joined2 = rdd1.joinWithinRange(rdd2, 500L)
+    assert(joined2.collect().isEmpty)
+  }
+}

--- a/adam-core/src/test/scala/org/bdgenomics/adam/rdd/ShuffleRegionJoinSuite.scala
+++ b/adam-core/src/test/scala/org/bdgenomics/adam/rdd/ShuffleRegionJoinSuite.scala
@@ -55,7 +55,7 @@ class ShuffleRegionJoinSuite extends ADAMFunSuite {
     val baseRdd = sc.parallelize(Seq(baseRecord)).keyBy(ReferenceRegion(_).get)
     val recordsRdd = sc.parallelize(Seq(record1, record2)).keyBy(ReferenceRegion(_).get)
 
-    assert(ShuffleRegionJoin.partitionAndJoin[AlignmentRecord, AlignmentRecord](
+    assert(ShuffleRegionJoin.partitionAndJoin(
       baseRdd,
       recordsRdd,
       seqDict,
@@ -64,7 +64,7 @@ class ShuffleRegionJoinSuite extends ADAMFunSuite {
         ShuffleRegionJoinSuite.merge,
         ShuffleRegionJoinSuite.and))
 
-    assert(ShuffleRegionJoin.partitionAndJoin[AlignmentRecord, AlignmentRecord](
+    assert(ShuffleRegionJoin.partitionAndJoin(
       baseRdd,
       recordsRdd,
       seqDict,
@@ -93,7 +93,7 @@ class ShuffleRegionJoinSuite extends ADAMFunSuite {
       .build()
     val builtRef2 = AlignmentRecord.newBuilder()
       .setContig(contig2)
-      .setStart(1)
+      .setStart(1L)
       .setReadMapped(true)
       .setCigar("1M")
       .setEnd(2L)
@@ -108,7 +108,7 @@ class ShuffleRegionJoinSuite extends ADAMFunSuite {
     val baseRdd = sc.parallelize(Seq(baseRecord1, baseRecord2)).keyBy(ReferenceRegion(_).get)
     val recordsRdd = sc.parallelize(Seq(record1, record2, record3)).keyBy(ReferenceRegion(_).get)
 
-    assert(ShuffleRegionJoin.partitionAndJoin[AlignmentRecord, AlignmentRecord](
+    assert(ShuffleRegionJoin.partitionAndJoin(
       baseRdd,
       recordsRdd,
       seqDict,
@@ -117,7 +117,7 @@ class ShuffleRegionJoinSuite extends ADAMFunSuite {
         ShuffleRegionJoinSuite.merge,
         ShuffleRegionJoinSuite.and))
 
-    assert(ShuffleRegionJoin.partitionAndJoin[AlignmentRecord, AlignmentRecord](
+    assert(ShuffleRegionJoin.partitionAndJoin(
       baseRdd,
       recordsRdd,
       seqDict,

--- a/pom.xml
+++ b/pom.xml
@@ -465,6 +465,20 @@
         <artifactId>aws-java-sdk</artifactId>
         <version>1.7.5</version>
         <scope>provided</scope>
+        <exclusions>
+          <exclusion>
+            <artifactId>jackson-core</artifactId>
+            <groupId>com.fasterxml.jackson.core</groupId>
+          </exclusion>
+          <exclusion>
+            <artifactId>jackson-databind</artifactId>
+            <groupId>com.fasterxml.jackson.core</groupId>
+          </exclusion>
+          <exclusion>
+            <artifactId>jackson-annotations</artifactId>
+            <groupId>com.fasterxml.jackson.core</groupId>
+          </exclusion>
+        </exclusions>
       </dependency>
       <dependency>
         <groupId>org.apache.httpcomponents</groupId>


### PR DESCRIPTION
This PR contains two commits fixing #511 and #512.  

First, it updates ReferenceRegion so that the class doesn't extend Ordered -- rather, we providing _an_ Ordering which can be used in the same contexts (and which we can replace by other orderings, if we want to order the regions in a different way).  

Second, it provides three new RDD wrapper (*Functions) classes, around RDDs of 
1. ReferenceRegions
2. Reference-mappable values
3. Pairs whose first element is a ReferenceRegion

In each case, the wrapper class provides a standard set of operations (join, filter, groupBy, windowCounts) which operate on sets of geometric operations (and are implemented under the hood, here, with RegionJoin.partitionAndJoin).  

These PRs are necessary pre-cursors to the Mutect work that's going on over in the avocado repository.