### PR TITLE
[ADAM-518] Move distribution stage into a profile.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -32,8 +32,6 @@
     <module>adam-core</module>
     <module>adam-apis</module>
     <module>adam-cli</module>
-    <!-- distribution should be last -->
-    <module>distribution</module>
   </modules>
   
   <licenses>
@@ -468,6 +466,16 @@
   </dependencyManagement>
 
   <profiles>
+    <profile>
+      <id>distribution</id>
+      <modules>
+        <module>adam-core</module>
+        <module>adam-apis</module>
+        <module>adam-cli</module>
+        <!-- distribution should be last -->
+        <module>distribution</module>
+      </modules>
+    </profile>
     <!-- Only build coverage in when we want to run coverage -->
     <profile>
       <id>coverage</id>

--- a/scripts/jenkins-test
+++ b/scripts/jenkins-test
@@ -10,7 +10,7 @@ HADOOP_VERSION="$(grep "<hadoop.version>" "$PROJECT_ROOT/pom.xml"  | head -2 | t
 echo "Testing ADAM version ${VERSION} on Hadoop ${HADOOP_VERSION}"
 
 export MAVEN_OPTS="-Xmx1536m -XX:MaxPermSize=1g"
-mvn test -Dnetworkconnected -Dhadoop.version="${HADOOP_VERSION}"
+mvn test -P distribution -Dnetworkconnected -Dhadoop.version="${HADOOP_VERSION}"
 
 ADAM_TMP_DIR="$(mktemp -d -t "adamTestXXXXXXX")"
 # Just to be paranoid.. use a directory internal to the ADAM_TMP_DIR

--- a/scripts/release/release.sh
+++ b/scripts/release/release.sh
@@ -1,3 +1,3 @@
 #!/bin/sh
 
-mvn -Dresume=false release:clean release:prepare release:perform
+mvn -P distribution -Dresume=false release:clean release:prepare release:perform

--- a/scripts/release/rollback.sh
+++ b/scripts/release/rollback.sh
@@ -1,3 +1,3 @@
 #!/bin/sh
 
-mvn release:rollback
+mvn -P distribution release:rollback


### PR DESCRIPTION
Resolves #518. Moves distribution stage into a profile. The profile is run during CI tests and during releases.
