### PR TITLE
Attempted to clean up issues in pom.xml.

### DIFF
--- a/adam-core/pom.xml
+++ b/adam-core/pom.xml
@@ -236,7 +236,7 @@
             <groupId>org.scalatest</groupId>
             <artifactId>scalatest-maven-plugin</artifactId>
             <configuration>
-              <tagsToExclude>org.bdgenomics.adam.util.S3Test</tagsToExclude>
+              <tagsToInclude>org.bdgenomics.adam.util.S3Test</tagsToInclude>
               <tagsToInclude>org.bdgenomics.adam.util.NetworkConnected</tagsToInclude>
             </configuration>
           </plugin>

--- a/pom.xml
+++ b/pom.xml
@@ -404,6 +404,12 @@
         <groupId>org.seqdoop</groupId>
         <artifactId>hadoop-bam</artifactId>
         <version>7.0.0</version>
+        <exclusions>
+          <exclusion>
+            <groupId>commons-httpclient</groupId>
+            <artifactId>commons-httpclient</artifactId>
+          </exclusion>
+        </exclusions>
       </dependency>
       <dependency>
         <groupId>org.seqdoop</groupId>
@@ -435,12 +441,11 @@
         <groupId>com.amazonaws</groupId>
         <artifactId>aws-java-sdk</artifactId>
         <version>1.7.5</version>
-        <scope>provided</scope>
       </dependency>
       <dependency>
         <groupId>org.apache.httpcomponents</groupId>
         <artifactId>httpclient</artifactId>
-        <version>4.3.2</version>
+        <version>4.2.6</version>
       </dependency>
       <dependency>
         <groupId>com.netflix.servo</groupId>


### PR DESCRIPTION
This reveals #524. I was playing around with the AvroParquetRDD and ran into a few issues; specifically, the Apache Commons HTTP library that we were depending on _in ADAM_ is in conflict with the version that the AWS SDK needs. Removing this conflict causes the compile to fail. I also found that we weren't running the `S3Test` tagged unit tests at all, which is fun.

Also, as an aside, why was the AWS SDK library marked as `provided`? Am I missing something (i.e., is there a way to side step the dependency conflict above), or...?

CC @tdanford @carlyeks 