### PR TITLE
[ADAM-529] Attaching scaladoc to released distribution.

### DIFF
--- a/distribution/src/main/assembly/assembly.xml
+++ b/distribution/src/main/assembly/assembly.xml
@@ -21,6 +21,30 @@
             <outputDirectory>.</outputDirectory>
         </fileSet>
         <fileSet>
+            <directory>../adam-core/target/site/scaladocs</directory>
+            <outputDirectory>scaladocs</outputDirectory>
+        </fileSet>
+        <fileSet>
+            <directory>../adam-core/target/apidocs</directory>
+            <outputDirectory>javadocs</outputDirectory>
+        </fileSet>
+        <fileSet>
+            <directory>../adam-apis/target/site/scaladocs</directory>
+            <outputDirectory>scaladocs</outputDirectory>
+        </fileSet>
+        <fileSet>
+            <directory>../adam-apis/target/apidocs</directory>
+            <outputDirectory>javadocs</outputDirectory>
+        </fileSet>
+        <fileSet>
+            <directory>../adam-cli/target/site/scaladocs</directory>
+            <outputDirectory>scaladocs</outputDirectory>
+        </fileSet>
+        <fileSet>
+            <directory>../adam-cli/target/apidocs</directory>
+            <outputDirectory>javadocs</outputDirectory>
+        </fileSet>
+        <fileSet>
             <directory>../adam-cli/target/appassembler/bin</directory>
             <outputDirectory>bin</outputDirectory>
             <excludes>

--- a/pom.xml
+++ b/pom.xml
@@ -475,6 +475,70 @@
         <!-- distribution should be last -->
         <module>distribution</module>
       </modules>
+      <build>
+        <plugins>
+          <plugin>
+            <groupId>org.apache.maven.plugins</groupId>
+            <artifactId>maven-source-plugin</artifactId>
+            <version>2.2.1</version>
+            <executions>
+              <execution>
+                <id>attach-sources</id>
+                <phase>package</phase>
+                <goals>
+                  <goal>jar-no-fork</goal>
+                </goals>
+              </execution>
+            </executions>
+          </plugin>
+          <plugin>
+            <groupId>org.apache.maven.plugins</groupId>
+            <artifactId>maven-javadoc-plugin</artifactId>
+            <version>2.9.1</version>
+            <executions>
+              <execution>
+                <id>attach-javadocs</id>
+                <phase>package</phase>
+                <goals>
+                  <goal>jar</goal>
+                </goals>
+              </execution>
+            </executions>
+          </plugin>
+          <plugin>
+            <groupId>net.alchim31.maven</groupId>
+            <artifactId>scala-maven-plugin</artifactId>
+            <executions>
+              <execution>
+                <id>scala-compile-first</id>
+                <phase>process-resources</phase>
+                <goals>
+                  <goal>compile</goal>
+                </goals>
+                <configuration>
+                  <args>
+                    <arg>-g:vars</arg>
+                  </args>
+                </configuration>
+              </execution>
+              <execution>
+                <id>scala-test-compile-first</id>
+                <phase>process-test-resources</phase>
+                <goals>
+                  <goal>testCompile</goal>
+                </goals>
+              </execution>
+              <execution>
+                <id>attach-scaladocs</id>
+                <phase>package</phase>
+                <goals>
+                  <goal>doc-jar</goal>
+                </goals>
+              </execution>
+            </executions>
+          </plugin>
+        </plugins>
+      </build>
     </profile>
     <!-- Only build coverage in when we want to run coverage -->
     <profile>
@@ -553,32 +617,6 @@
       <id>sonatype-oss-release</id>
       <build>
         <plugins>
-          <plugin>
-            <groupId>org.apache.maven.plugins</groupId>
-            <artifactId>maven-source-plugin</artifactId>
-            <version>2.2.1</version>
-            <executions>
-              <execution>
-                <id>attach-sources</id>
-                <goals>
-                  <goal>jar-no-fork</goal>
-                </goals>
-              </execution>
-            </executions>
-          </plugin>
-          <plugin>
-            <groupId>org.apache.maven.plugins</groupId>
-            <artifactId>maven-javadoc-plugin</artifactId>
-            <version>2.9.1</version>
-            <executions>
-              <execution>
-                <id>attach-javadocs</id>
-                <goals>
-                  <goal>jar</goal>
-                </goals>
-              </execution>
-            </executions>
-          </plugin>
           <plugin>
             <groupId>org.apache.maven.plugins</groupId>
             <artifactId>maven-gpg-plugin</artifactId>


### PR DESCRIPTION
Resolves #529. Adds both Scaladoc and Javadoc to the released binary distribution.
