### PR TITLE
[ADAM-532] Fix wigFix intermittent test failure

### DIFF
--- a/adam-cli/src/test/scala/org/bdgenomics/adam/cli/Features2ADAMSuite.scala
+++ b/adam-cli/src/test/scala/org/bdgenomics/adam/cli/Features2ADAMSuite.scala
@@ -93,7 +93,7 @@ class Features2ADAMSuite extends FunSuite {
     val schema = Projection(featureId, contig, start, end, value)
     val lister = new ParquetLister[Feature](Some(schema))
 
-    val converted = lister.materialize(outputPath).toSeq
+    val converted = lister.materialize(outputPath).toSeq.sortBy(f => f.getStart)
 
     assert(converted.size === 10)
     assert(converted(0).getContig.getContigName == "chr5")


### PR DESCRIPTION
When reading the converted output, it's possible that the order of the records is undefined.  I added a sort which should make things more reliable.

Fixes #532.