### PR TITLE
[ADAM-563] Add warning message when saving Parquet files with incorrect extension

### DIFF
--- a/adam-core/src/main/scala/org/bdgenomics/adam/rdd/ADAMRDDFunctions.scala
+++ b/adam-core/src/main/scala/org/bdgenomics/adam/rdd/ADAMRDDFunctions.scala
@@ -69,6 +69,10 @@ class ADAMRDDFunctions[T <% SpecificRecord: Manifest](rdd: RDD[T]) extends Seria
                       disableDictionaryEncoding: Boolean = false): Unit = SaveAsADAM.time {
     log.info("Saving data in ADAM format")
 
+    if (!filePath.endsWith(".adam")) {
+      log.error("Filename does not end with *.adam extension. File will be saved, but must be renamed to be opened.")
+    }
+
     val job = HadoopUtil.newJob(rdd.context)
     ParquetLogger.hadoopLoggerLevel(Level.SEVERE)
     ParquetOutputFormat.setCompression(job, compressCodec)


### PR DESCRIPTION
Resolves #563. Prints warning if file does not have "*.adam" extension.