### PR TITLE
Moved the Timers object from bdg-utils back to ADAM

### DIFF
--- a/adam-cli/src/main/scala/org/bdgenomics/adam/cli/Transform.scala
+++ b/adam-cli/src/main/scala/org/bdgenomics/adam/cli/Transform.scala
@@ -21,7 +21,7 @@ import org.apache.hadoop.mapreduce.Job
 import org.apache.spark.{ SparkContext, Logging }
 import org.apache.spark.rdd.RDD
 import org.bdgenomics.adam.algorithms.consensus._
-import org.bdgenomics.utils.instrumentation.Timers._
+import org.bdgenomics.adam.instrumentation.Timers._
 import org.bdgenomics.adam.models.SnpTable
 import org.bdgenomics.adam.rdd.ADAMContext._
 import org.bdgenomics.adam.rdd.ADAMSaveAnyArgs

--- a/adam-core/src/main/scala/org/bdgenomics/adam/converters/AlignmentRecordConverter.scala
+++ b/adam-core/src/main/scala/org/bdgenomics/adam/converters/AlignmentRecordConverter.scala
@@ -22,7 +22,7 @@ import org.bdgenomics.adam.models.{ RecordGroupDictionary, SAMFileHeaderWritable
 import org.bdgenomics.adam.rdd.ADAMContext._
 import org.bdgenomics.adam.rich.RichAlignmentRecord
 import org.bdgenomics.formats.avro.AlignmentRecord
-import org.bdgenomics.utils.instrumentation.Timers._
+import org.bdgenomics.adam.instrumentation.Timers._
 
 class AlignmentRecordConverter extends Serializable {
 

--- a/adam-core/src/main/scala/org/bdgenomics/adam/instrumentation/Timers.scala
+++ b/adam-core/src/main/scala/org/bdgenomics/adam/instrumentation/Timers.scala
@@ -1,0 +1,76 @@
+/**
+ * Licensed to Big Data Genomics (BDG) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The BDG licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.bdgenomics.adam.instrumentation
+
+import org.bdgenomics.utils.instrumentation.Metrics
+
+/**
+ * Contains [[Timers]] that are used to instrument ADAM.
+ */
+object Timers extends Metrics {
+
+  // File Loading
+  val LoadAlignmentRecords = timer("Load Alignment Records")
+  val BAMLoad = timer("BAM File Load")
+  val ParquetLoad = timer("Parquet File Load")
+
+  // Trim Reads
+  val TrimReadsInDriver = timer("Trim Reads")
+  val TrimRead = timer("Trim Reads")
+  val TrimCigar = timer("Trim Cigar")
+  val TrimMDTag = timer("Trim MD Tag")
+
+  // Trim Low Quality Read Groups
+  val TrimLowQualityInDriver = timer("Trim Low Quality Read Groups")
+
+  // Mark Duplicates
+  val MarkDuplicatesInDriver = timer("Mark Duplicates")
+  val CreateReferencePositionPair = timer("Create Reference Position Pair")
+  val PerformDuplicateMarking = timer("Perform Duplicate Marking")
+  val ScoreAndMarkReads = timer("Score and Mark Reads")
+  val MarkReads = timer("Mark Reads")
+
+  // Recalibrate Base Qualities
+  val BQSRInDriver = timer("Base Quality Recalibration")
+  val CreateKnownSnpsTable = timer("Create Known SNPs Table")
+  val RecalibrateRead = timer("Recalibrate Read")
+
+  // Realign Indels
+  val RealignIndelsInDriver = timer("Realign Indels")
+  val FindTargets = timer("Find Targets")
+  val CreateIndelRealignmentTargets = timer("Create Indel Realignment Targets for Read")
+  val SortTargets = timer("Sort Targets")
+  val JoinTargets = timer("Join Targets")
+  val MapTargets = timer("Map Targets")
+  val RealignTargetGroup = timer("Realign Target Group")
+  val GetReferenceFromReads = timer("Get Reference From Reads")
+  val SweepReadOverReferenceForQuality = timer("Sweep Read Over Reference For Quality")
+
+  // Sort Reads
+  val SortReads = timer("Sort Reads")
+
+  // File Saving
+  val SAMSave = timer("SAM Save")
+  val ConvertToSAM = timer("Convert To SAM")
+  val ConvertToSAMRecord = timer("Convert To SAM Record")
+  val SaveAsADAM = timer("Save File In ADAM Format")
+  val WriteADAMRecord = timer("Write ADAM Record")
+  val WriteBAMRecord = timer("Write BAM Record")
+  val WriteSAMRecord = timer("Write SAM Record")
+
+}

--- a/adam-core/src/main/scala/org/bdgenomics/adam/models/ReferencePositionPair.scala
+++ b/adam-core/src/main/scala/org/bdgenomics/adam/models/ReferencePositionPair.scala
@@ -21,7 +21,7 @@ import com.esotericsoftware.kryo.{ Kryo, Serializer }
 import com.esotericsoftware.kryo.io.{ Input, Output }
 import org.apache.spark.Logging
 import Ordering.Option
-import org.bdgenomics.utils.instrumentation.Timers.CreateReferencePositionPair
+import org.bdgenomics.adam.instrumentation.Timers.CreateReferencePositionPair
 
 object ReferencePositionPair extends Logging {
   def apply(singleReadBucket: SingleReadBucket): ReferencePositionPair = CreateReferencePositionPair.time {

--- a/adam-core/src/main/scala/org/bdgenomics/adam/rdd/ADAMContext.scala
+++ b/adam-core/src/main/scala/org/bdgenomics/adam/rdd/ADAMContext.scala
@@ -30,7 +30,7 @@ import org.apache.hadoop.io.LongWritable
 import org.apache.spark.rdd.MetricsContext._
 import org.apache.spark.{ Logging, SparkConf, SparkContext }
 import org.bdgenomics.adam.converters.SAMRecordConverter
-import org.bdgenomics.utils.instrumentation.Timers._
+import org.bdgenomics.adam.instrumentation.Timers._
 import org.bdgenomics.adam.models._
 import org.bdgenomics.adam.predicates.ADAMPredicate
 import org.bdgenomics.adam.projections.{ AlignmentRecordField, NucleotideContigFragmentField, Projection }

--- a/adam-core/src/main/scala/org/bdgenomics/adam/rdd/ADAMRDDFunctions.scala
+++ b/adam-core/src/main/scala/org/bdgenomics/adam/rdd/ADAMRDDFunctions.scala
@@ -22,7 +22,7 @@ import org.apache.avro.specific.SpecificRecord
 import org.apache.spark.Logging
 import org.apache.spark.rdd.{ InstrumentedOutputFormat, RDD }
 import org.apache.spark.rdd.MetricsContext._
-import org.bdgenomics.utils.instrumentation.Timers._
+import org.bdgenomics.adam.instrumentation.Timers._
 import org.bdgenomics.adam.models._
 import org.bdgenomics.adam.util.{
   HadoopUtil,

--- a/adam-core/src/main/scala/org/bdgenomics/adam/rdd/read/ADAMBAMOutputFormat.scala
+++ b/adam-core/src/main/scala/org/bdgenomics/adam/rdd/read/ADAMBAMOutputFormat.scala
@@ -21,7 +21,7 @@ import org.seqdoop.hadoop_bam.{ SAMRecordWritable, KeyIgnoringBAMOutputFormat }
 import htsjdk.samtools.SAMFileHeader
 import org.apache.spark.rdd.InstrumentedOutputFormat
 import org.apache.hadoop.mapreduce.OutputFormat
-import org.bdgenomics.utils.instrumentation.Timers
+import org.bdgenomics.adam.instrumentation.Timers
 
 object ADAMBAMOutputFormat extends Serializable {
 

--- a/adam-core/src/main/scala/org/bdgenomics/adam/rdd/read/ADAMSAMOutputFormat.scala
+++ b/adam-core/src/main/scala/org/bdgenomics/adam/rdd/read/ADAMSAMOutputFormat.scala
@@ -20,7 +20,7 @@ package org.bdgenomics.adam.rdd.read
 import org.seqdoop.hadoop_bam.{ SAMRecordWritable, KeyIgnoringAnySAMOutputFormat, SAMFormat }
 import htsjdk.samtools.SAMFileHeader
 import org.apache.spark.rdd.InstrumentedOutputFormat
-import org.bdgenomics.utils.instrumentation.Timers
+import org.bdgenomics.adam.instrumentation.Timers
 import org.apache.hadoop.mapreduce.OutputFormat
 
 object ADAMSAMOutputFormat extends Serializable {

--- a/adam-core/src/main/scala/org/bdgenomics/adam/rdd/read/AlignmentRecordRDDFunctions.scala
+++ b/adam-core/src/main/scala/org/bdgenomics/adam/rdd/read/AlignmentRecordRDDFunctions.scala
@@ -31,7 +31,7 @@ import org.bdgenomics.adam.algorithms.consensus.{
   ConsensusGeneratorFromReads
 }
 import org.bdgenomics.adam.converters.AlignmentRecordConverter
-import org.bdgenomics.utils.instrumentation.Timers._
+import org.bdgenomics.adam.instrumentation.Timers._
 import org.bdgenomics.adam.models._
 import org.bdgenomics.adam.rdd.ADAMContext._
 import org.bdgenomics.adam.rdd.{ ADAMSaveArgs, ADAMSaveAnyArgs, ADAMSequenceDictionaryRDDAggregator }

--- a/adam-core/src/main/scala/org/bdgenomics/adam/rdd/read/MarkDuplicates.scala
+++ b/adam-core/src/main/scala/org/bdgenomics/adam/rdd/read/MarkDuplicates.scala
@@ -18,7 +18,7 @@
 package org.bdgenomics.adam.rdd.read
 
 import org.apache.spark.rdd.RDD
-import org.bdgenomics.utils.instrumentation.Timers._
+import org.bdgenomics.adam.instrumentation.Timers._
 import org.bdgenomics.adam.models.{ ReferencePositionPair, ReferencePositionWithOrientation, SingleReadBucket }
 import org.bdgenomics.adam.rdd.ADAMContext._
 import org.bdgenomics.adam.rdd.read.AlignmentRecordContext._

--- a/adam-core/src/main/scala/org/bdgenomics/adam/rdd/read/correction/TrimReads.scala
+++ b/adam-core/src/main/scala/org/bdgenomics/adam/rdd/read/correction/TrimReads.scala
@@ -23,7 +23,7 @@ import org.apache.spark.rdd.RDD
 import org.bdgenomics.formats.avro.AlignmentRecord
 import org.bdgenomics.adam.rdd.ADAMContext._
 import org.bdgenomics.adam.util.PhredUtils
-import org.bdgenomics.utils.instrumentation.Timers._
+import org.bdgenomics.adam.instrumentation.Timers._
 import scala.annotation.tailrec
 import scala.math.{ log => mathLog, exp }
 

--- a/adam-core/src/main/scala/org/bdgenomics/adam/rdd/read/realignment/IndelRealignmentTarget.scala
+++ b/adam-core/src/main/scala/org/bdgenomics/adam/rdd/read/realignment/IndelRealignmentTarget.scala
@@ -25,7 +25,7 @@ import org.bdgenomics.adam.models.ReferenceRegion
 import org.bdgenomics.adam.rdd.ADAMContext._
 import org.bdgenomics.adam.rich.RichAlignmentRecord
 import org.bdgenomics.formats.avro.AlignmentRecord
-import org.bdgenomics.utils.instrumentation.Timers._
+import org.bdgenomics.adam.instrumentation.Timers._
 import scala.collection.immutable.TreeSet
 
 object ZippedTargetOrdering extends Ordering[(IndelRealignmentTarget, Int)] {

--- a/adam-core/src/main/scala/org/bdgenomics/adam/rdd/read/realignment/RealignIndels.scala
+++ b/adam-core/src/main/scala/org/bdgenomics/adam/rdd/read/realignment/RealignIndels.scala
@@ -27,7 +27,7 @@ import org.bdgenomics.adam.rich.RichAlignmentRecord
 import org.bdgenomics.adam.rich.RichAlignmentRecord._
 import org.bdgenomics.adam.util.ImplicitJavaConversions._
 import org.bdgenomics.adam.util.MdTag
-import org.bdgenomics.utils.instrumentation.Timers._
+import org.bdgenomics.adam.instrumentation.Timers._
 import org.bdgenomics.formats.avro.AlignmentRecord
 import scala.annotation.tailrec
 import scala.collection.immutable.{ NumericRange, TreeSet }

--- a/adam-core/src/main/scala/org/bdgenomics/adam/rdd/read/realignment/RealignmentTargetFinder.scala
+++ b/adam-core/src/main/scala/org/bdgenomics/adam/rdd/read/realignment/RealignmentTargetFinder.scala
@@ -21,7 +21,7 @@ import org.apache.spark.Logging
 import org.apache.spark.rdd.RDD
 import org.bdgenomics.adam.rdd.ADAMContext._
 import org.bdgenomics.adam.rich.RichAlignmentRecord
-import org.bdgenomics.utils.instrumentation.Timers._
+import org.bdgenomics.adam.instrumentation.Timers._
 import scala.annotation.tailrec
 import scala.collection.immutable.TreeSet
 import com.sun.xml.internal.bind.v2.TODO

--- a/adam-core/src/main/scala/org/bdgenomics/adam/rdd/read/recalibration/Recalibrator.scala
+++ b/adam-core/src/main/scala/org/bdgenomics/adam/rdd/read/recalibration/Recalibrator.scala
@@ -21,7 +21,7 @@ import org.bdgenomics.adam.rich.RichAlignmentRecord._
 import org.bdgenomics.adam.rich.DecadentRead
 import org.bdgenomics.adam.util.QualityScore
 import org.bdgenomics.formats.avro.AlignmentRecord
-import org.bdgenomics.utils.instrumentation.Timers._
+import org.bdgenomics.adam.instrumentation.Timers._
 import scala.math.{ exp, log }
 
 class Recalibrator(val table: RecalibrationTable, val minAcceptableQuality: QualityScore)


### PR DESCRIPTION
This moves the Timers object back from bdg-utils to ADAM, as it contains ADAM-specific timers. 

I'll raise another PR to remove the Timers object from bdg-utils, but I don't think it's necessary to make a new bdg-utils release or anything.