### PR TITLE
Changed hashCode implementations to improve performance of BQSR

### DIFF
--- a/adam-core/src/main/scala/org/bdgenomics/adam/instrumentation/Timers.scala
+++ b/adam-core/src/main/scala/org/bdgenomics/adam/instrumentation/Timers.scala
@@ -48,7 +48,11 @@ object Timers extends Metrics {
   // Recalibrate Base Qualities
   val BQSRInDriver = timer("Base Quality Recalibration")
   val CreateKnownSnpsTable = timer("Create Known SNPs Table")
+  val ComputeCovariates = timer("Compute Covariates")
+  val ObservationAccumulatorComb = timer("Observation Accumulator: comb")
+  val ObservationAccumulatorSeq = timer("Observation Accumulator: seq")
   val RecalibrateRead = timer("Recalibrate Read")
+  val ComputeQualityScore = timer("Compute Quality Score")
 
   // Realign Indels
   val RealignIndelsInDriver = timer("Realign Indels")

--- a/adam-core/src/main/scala/org/bdgenomics/adam/rdd/read/recalibration/Covariate.scala
+++ b/adam-core/src/main/scala/org/bdgenomics/adam/rdd/read/recalibration/Covariate.scala
@@ -63,18 +63,19 @@ abstract class AbstractCovariate[ValueT] extends Covariate with Serializable {
  * Represents a tuple containing a value for each covariate.
  *
  * The values for mandatory covariates are stored in member fields and optional
- * covariate valuess are in `extras`.
+ * covariate values are in `extras`.
  */
 class CovariateKey(
     val readGroup: String,
     val quality: QualityScore,
     val extras: Seq[Option[Covariate#Value]]) extends Serializable {
 
-  def parts: Seq[Any] = Seq(readGroup, quality) ++ extras
-
   def containsNone: Boolean = extras.exists(_.isEmpty)
 
-  override def toString: String = "[" + parts.mkString(", ") + "]"
+  override def toString: String = {
+    def parts: Seq[Any] = Seq(readGroup, quality) ++ extras
+    "[" + parts.mkString(", ") + "]"
+  }
 
   override def equals(other: Any) = other match {
     case that: CovariateKey =>
@@ -82,7 +83,13 @@ class CovariateKey(
     case _ => false
   }
 
-  override def hashCode = Util.hashCombine(0xD20D1E51, parts.hashCode)
+  override val hashCode: Int = {
+    41 * (
+      41 * (
+        41 + readGroup.hashCode
+      ) + quality.hashCode
+    ) + extras.hashCode
+  }
 }
 
 /**
@@ -123,7 +130,8 @@ class CovariateSpace(val extras: IndexedSeq[Covariate]) extends Serializable {
     case _                    => false
   }
 
-  override def hashCode = Util.hashCombine(0x48C35799, extras.hashCode)
+  override def hashCode = extras.hashCode
+
 }
 
 object CovariateSpace {

--- a/adam-core/src/main/scala/org/bdgenomics/adam/rdd/read/recalibration/Recalibrator.scala
+++ b/adam-core/src/main/scala/org/bdgenomics/adam/rdd/read/recalibration/Recalibrator.scala
@@ -35,7 +35,7 @@ class Recalibrator(val table: RecalibrationTable, val minAcceptableQuality: Qual
       build()
   }
 
-  def computeQual(read: DecadentRead): Seq[QualityScore] = {
+  def computeQual(read: DecadentRead): Seq[QualityScore] = ComputeQualityScore.time {
     val origQuals = read.residues.map(_.quality)
     val newQuals = table(read)
     origQuals.zip(newQuals).map {

--- a/adam-core/src/main/scala/org/bdgenomics/adam/util/QualityScore.scala
+++ b/adam-core/src/main/scala/org/bdgenomics/adam/util/QualityScore.scala
@@ -36,7 +36,7 @@ class QualityScore(val phred: Int) extends Ordered[QualityScore] with Serializab
     case _                  => false
   }
 
-  override def hashCode: Int = Util.hashCombine(0x26C2E0BA, phred.hashCode)
+  override def hashCode: Int = phred
 }
 
 object QualityScore {

--- a/adam-core/src/main/scala/org/bdgenomics/adam/util/Util.scala
+++ b/adam-core/src/main/scala/org/bdgenomics/adam/util/Util.scala
@@ -27,14 +27,4 @@ object Util {
     val rightMD5 = Option(right).map(_.getContigMD5)
     leftName == rightName && (leftMD5.isEmpty || rightMD5.isEmpty || leftMD5 == rightMD5)
   }
-
-  def hashCombine(parts: Int*): Int =
-    if (parts.tail == Nil)
-      parts.head
-    else
-      hashCombine2(parts.head, hashCombine(parts.tail: _*))
-
-  // Based on hash_combine from the C++ Boost library
-  private def hashCombine2(first: Int, second: Int) =
-    second + 0x9E3779B9 + (first << 6) + (first >> 2)
 }


### PR DESCRIPTION
Some notes:

 * When looking at the performance of BQSR the `Util.hashCombine` method appeared to perform poorly, so I have replaced its usage in `CovariateKey` and `QualityScore` with hash codes based on the recipe from Programming in Scala (http://www.artima.com/pins1ed/object-equality.html). 
 * On my small test data set of about 90,000 reads this change makes `ObservationAccumulator.+=` about 3.5 times faster, making BQSR about 50% faster in total (not including times for loading, saving files etc). I'm aware that this is not a particularly realistic test, but I think it's probably sufficient for such a low-risk change.
 * I have also removed `Util.hashCombine` method and replaced its other usages, since others may use it without being aware of the performance penalty.
 * This change also included some new timers in the `Timers` object