### PR TITLE
Add support for converting contigs into reads

### DIFF
--- a/adam-core/src/main/scala/org/bdgenomics/adam/converters/FragmentConverter.scala
+++ b/adam-core/src/main/scala/org/bdgenomics/adam/converters/FragmentConverter.scala
@@ -1,0 +1,105 @@
+/**
+ * Licensed to Big Data Genomics (BDG) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The BDG licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.bdgenomics.adam.converters
+
+import org.apache.spark.SparkContext._
+import org.apache.spark.rdd.RDD
+import org.bdgenomics.adam.models.ReferenceRegion
+import org.bdgenomics.formats.avro._
+import scala.annotation.tailrec
+
+private[converters] object FragmentCollector extends Serializable {
+  def apply(fragment: NucleotideContigFragment): (Contig, FragmentCollector) = {
+    (fragment.getContig,
+      FragmentCollector(Seq((ReferenceRegion(fragment).get, fragment.getFragmentSequence))))
+  }
+}
+
+private[converters] case class FragmentCollector(fragments: Seq[(ReferenceRegion, String)]) {
+}
+
+object FragmentConverter extends Serializable {
+
+  private def mergeFragments(f1: FragmentCollector,
+                             f2: FragmentCollector): FragmentCollector = {
+    assert(!(f1.fragments.isEmpty || f2.fragments.isEmpty))
+
+    // join fragments from each and sort
+    val fragments = (f1.fragments ++ f2.fragments).sortBy(_._1)
+
+    var fragmentList = List[(ReferenceRegion, String)]()
+
+    @tailrec def fragmentCombiner(lastFragment: (ReferenceRegion, String),
+                                  iter: Iterator[(ReferenceRegion, String)]) {
+      if (!iter.hasNext) {
+        // prepend fragment to list
+        fragmentList = lastFragment :: fragmentList
+      } else {
+        // extract our next fragment, and our last fragment
+        val (lastRegion, lastString) = lastFragment
+        val (thisRegion, thisString) = iter.next
+
+        // are our fragments adjacent?
+        val newLastFragment = if (lastRegion.isAdjacent(thisRegion)) {
+          // if they are, merge the fragments
+          // we have sorted these fragments before we started, so the orientation is already known
+          (lastRegion.hull(thisRegion), lastString + thisString)
+        } else {
+          // if they aren't, prepend the last fragment to the list
+          // and use the current fragment as the new last fragment
+          fragmentList = lastFragment :: fragmentList
+          (thisRegion, thisString)
+        }
+
+        // recurse
+        fragmentCombiner(newLastFragment, iter)
+      }
+    }
+
+    // convert to an iterator and peek at the first element and recurse
+    val fragmentIter = fragments.toIterator
+    fragmentCombiner(fragmentIter.next, fragmentIter)
+
+    // create a new collector
+    FragmentCollector(fragmentList.toSeq)
+  }
+
+  private[converters] def convertFragment(kv: (Contig, FragmentCollector)): Seq[AlignmentRecord] = {
+    // extract kv pair
+    val (contig, fragment) = kv
+
+    // extract the fragment string and region
+    fragment.fragments.map(p => {
+      val (fragmentRegion, fragmentString) = p
+
+      // build record
+      AlignmentRecord.newBuilder()
+        .setContig(contig)
+        .setStart(fragmentRegion.start)
+        .setEnd(fragmentRegion.end)
+        .setSequence(fragmentString)
+        .build()
+    })
+  }
+
+  def convertRdd(rdd: RDD[NucleotideContigFragment]): RDD[AlignmentRecord] = {
+    rdd.map(FragmentCollector(_))
+      .reduceByKey(mergeFragments)
+      .flatMap(convertFragment)
+  }
+}

--- a/adam-core/src/main/scala/org/bdgenomics/adam/rdd/contig/NucleotideContigFragmentRDDFunctions.scala
+++ b/adam-core/src/main/scala/org/bdgenomics/adam/rdd/contig/NucleotideContigFragmentRDDFunctions.scala
@@ -22,6 +22,7 @@ import org.apache.avro.specific.SpecificRecord
 import org.apache.spark.Logging
 import org.apache.spark.SparkContext._
 import org.apache.spark.rdd.RDD
+import org.bdgenomics.adam.converters.FragmentConverter
 import org.bdgenomics.adam.models._
 import org.bdgenomics.adam.rdd.ADAMContext._
 import org.bdgenomics.adam.rdd.ADAMSequenceDictionaryRDDAggregator
@@ -38,6 +39,16 @@ import scala.math.max
 import scala.Some
 
 class NucleotideContigFragmentRDDFunctions(rdd: RDD[NucleotideContigFragment]) extends ADAMSequenceDictionaryRDDAggregator[NucleotideContigFragment](rdd) {
+
+  /**
+   * Converts an RDD of nucleotide contig fragments into reads. Adjacent contig fragments are
+   * combined.
+   *
+   * @return Returns an RDD of reads.
+   */
+  def toReads(): RDD[AlignmentRecord] = {
+    FragmentConverter.convertRdd(rdd)
+  }
 
   /**
    * From a set of contigs, returns the base sequence that corresponds to a region of the reference.

--- a/adam-core/src/test/scala/org/bdgenomics/adam/converters/FragmentConverterSuite.scala
+++ b/adam-core/src/test/scala/org/bdgenomics/adam/converters/FragmentConverterSuite.scala
@@ -1,0 +1,168 @@
+/**
+ * Licensed to Big Data Genomics (BDG) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The BDG licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.bdgenomics.adam.converters
+
+import org.bdgenomics.adam.models.ReferenceRegion
+import org.bdgenomics.adam.util.ADAMFunSuite
+import org.bdgenomics.formats.avro._
+
+class FragmentConverterSuite extends ADAMFunSuite {
+
+  test("build a fragment collector and convert to a read") {
+    val (builtContig, builtFragment) = FragmentCollector(NucleotideContigFragment.newBuilder()
+      .setContig(Contig.newBuilder().setContigName("ctg").build())
+      .setFragmentSequence("ACACACAC")
+      .setFragmentStartPosition(0L)
+      .build())
+
+    assert(builtContig.getContigName === "ctg")
+    assert(builtFragment.fragments.length === 1)
+    val (fragmentRegion, fragmentString) = builtFragment.fragments.head
+    assert(fragmentRegion === ReferenceRegion("ctg", 0L, 8L))
+    assert(fragmentString === "ACACACAC")
+
+    val convertedReads = FragmentConverter.convertFragment((builtContig, builtFragment))
+    assert(convertedReads.size === 1)
+    val convertedRead = convertedReads.head
+
+    assert(convertedRead.getSequence === "ACACACAC")
+    assert(convertedRead.getContig.getContigName === "ctg")
+    assert(convertedRead.getStart === 0L)
+    assert(convertedRead.getEnd === 8L)
+  }
+
+  sparkTest("convert an rdd of discontinuous fragments, all from the same contig") {
+    val rdd = sc.parallelize(Seq(NucleotideContigFragment.newBuilder()
+      .setContig(Contig.newBuilder().setContigName("ctg").build())
+      .setFragmentSequence("ACACACAC")
+      .setFragmentStartPosition(0L)
+      .build(), NucleotideContigFragment.newBuilder()
+      .setContig(Contig.newBuilder().setContigName("ctg").build())
+      .setFragmentSequence("AATTCCGGCCTTAA")
+      .setFragmentStartPosition(14L)
+      .build()))
+
+    val reads = FragmentConverter.convertRdd(rdd)
+      .collect()
+
+    assert(reads.length === 2)
+    val firstRead = reads.filter(_.getStart == 0L).head
+    val secondRead = reads.filter(_.getStart != 0L).head
+
+    assert(firstRead.getSequence === "ACACACAC")
+    assert(firstRead.getContig.getContigName === "ctg")
+    assert(firstRead.getStart === 0L)
+    assert(firstRead.getEnd === 8L)
+    assert(secondRead.getSequence === "AATTCCGGCCTTAA")
+    assert(secondRead.getContig.getContigName === "ctg")
+    assert(secondRead.getStart === 14L)
+    assert(secondRead.getEnd === 28L)
+  }
+
+  sparkTest("convert an rdd of contiguous fragments, all from the same contig") {
+    val rdd = sc.parallelize(Seq(NucleotideContigFragment.newBuilder()
+      .setContig(Contig.newBuilder().setContigName("ctg").build())
+      .setFragmentSequence("ACACACAC")
+      .setFragmentStartPosition(0L)
+      .build(), NucleotideContigFragment.newBuilder()
+      .setContig(Contig.newBuilder().setContigName("ctg").build())
+      .setFragmentSequence("TGTGTG")
+      .setFragmentStartPosition(8L)
+      .build(), NucleotideContigFragment.newBuilder()
+      .setContig(Contig.newBuilder().setContigName("ctg").build())
+      .setFragmentSequence("AATTCCGGCCTTAA")
+      .setFragmentStartPosition(14L)
+      .build()))
+
+    val reads = FragmentConverter.convertRdd(rdd)
+      .collect()
+
+    assert(reads.length === 1)
+    val read = reads(0)
+    assert(read.getSequence === "ACACACACTGTGTGAATTCCGGCCTTAA")
+    assert(read.getContig.getContigName === "ctg")
+    assert(read.getStart === 0L)
+    assert(read.getEnd === 28L)
+  }
+
+  sparkTest("convert an rdd of varied fragments from multiple contigs") {
+    val rdd = sc.parallelize(Seq(NucleotideContigFragment.newBuilder()
+      .setContig(Contig.newBuilder().setContigName("ctg1").build())
+      .setFragmentSequence("ACACACAC")
+      .setFragmentStartPosition(0L)
+      .build(), NucleotideContigFragment.newBuilder()
+      .setContig(Contig.newBuilder().setContigName("ctg1").build())
+      .setFragmentSequence("TGTGTG")
+      .setFragmentStartPosition(8L)
+      .build(), NucleotideContigFragment.newBuilder()
+      .setContig(Contig.newBuilder().setContigName("ctg1").build())
+      .setFragmentSequence("AATTCCGGCCTTAA")
+      .setFragmentStartPosition(14L)
+      .build(), NucleotideContigFragment.newBuilder()
+      .setContig(Contig.newBuilder().setContigName("ctg2").build())
+      .setFragmentSequence("ACACACAC")
+      .setFragmentStartPosition(0L)
+      .build(), NucleotideContigFragment.newBuilder()
+      .setContig(Contig.newBuilder().setContigName("ctg2").build())
+      .setFragmentSequence("AATTCCGGCCTTAA")
+      .setFragmentStartPosition(14L)
+      .build(), NucleotideContigFragment.newBuilder()
+      .setContig(Contig.newBuilder().setContigName("ctg3").build())
+      .setFragmentSequence("AATTCCGGCCTTAA")
+      .setFragmentStartPosition(14L)
+      .build()))
+
+    val reads = FragmentConverter.convertRdd(rdd)
+      .collect()
+
+    assert(reads.length === 4)
+
+    val ctg1Reads = reads.filter(_.getContig.getContigName == "ctg1")
+    assert(ctg1Reads.length === 1)
+
+    val ctg1Read = ctg1Reads.head
+    assert(ctg1Read.getSequence === "ACACACACTGTGTGAATTCCGGCCTTAA")
+    assert(ctg1Read.getContig.getContigName === "ctg1")
+    assert(ctg1Read.getStart === 0L)
+    assert(ctg1Read.getEnd === 28L)
+
+    val ctg2Reads = reads.filter(_.getContig.getContigName == "ctg2")
+    assert(ctg2Reads.length === 2)
+
+    val firstCtg2Read = ctg2Reads.filter(_.getStart == 0L).head
+    val secondCtg2Read = ctg2Reads.filter(_.getStart != 0L).head
+
+    assert(firstCtg2Read.getSequence === "ACACACAC")
+    assert(firstCtg2Read.getContig.getContigName === "ctg2")
+    assert(firstCtg2Read.getStart === 0L)
+    assert(firstCtg2Read.getEnd === 8L)
+    assert(secondCtg2Read.getSequence === "AATTCCGGCCTTAA")
+    assert(secondCtg2Read.getContig.getContigName === "ctg2")
+    assert(secondCtg2Read.getStart === 14L)
+    assert(secondCtg2Read.getEnd === 28L)
+
+    val ctg3Reads = reads.filter(_.getContig.getContigName == "ctg3")
+    assert(ctg3Reads.length === 1)
+
+    val ctg3Read = ctg3Reads.head
+    assert(ctg3Read.getSequence === "AATTCCGGCCTTAA")
+    assert(ctg3Read.getContig.getContigName === "ctg3")
+    assert(ctg3Read.getStart === 14L)
+    assert(ctg3Read.getEnd === 28L)
+  }
+}


### PR DESCRIPTION
Resolves #571. Adds support for loadings FASTA files and `*.contig.adam` files in as `AlignmentRecords`. Depends on #567.