### PR TITLE
[ADAM-610] Fix FASTQ input format split picking.

### DIFF
--- a/adam-core/src/main/java/org/bdgenomics/adam/io/FastqInputFormat.java
+++ b/adam-core/src/main/java/org/bdgenomics/adam/io/FastqInputFormat.java
@@ -1,0 +1,290 @@
+/**
+ * Licensed to Big Data Genomics (BDG) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The BDG licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.bdgenomics.adam.io;
+
+import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.fs.FSDataInputStream;
+import org.apache.hadoop.fs.FileSystem;
+import org.apache.hadoop.fs.Path;
+import org.apache.hadoop.io.Text;
+import org.apache.hadoop.io.compress.CompressionCodec;
+import org.apache.hadoop.io.compress.CompressionCodecFactory;
+import org.apache.hadoop.mapreduce.InputSplit;
+import org.apache.hadoop.mapreduce.JobContext;
+import org.apache.hadoop.mapreduce.RecordReader;
+import org.apache.hadoop.mapreduce.TaskAttemptContext;
+import org.apache.hadoop.mapreduce.lib.input.FileInputFormat;
+import org.apache.hadoop.mapreduce.lib.input.FileSplit;
+import org.apache.hadoop.util.LineReader;
+
+import java.io.EOFException;
+import java.io.IOException;
+import java.io.InputStream;
+
+/**
+ * This reader is based on the FastqInputFormat that's part of Hadoop-BAM,
+ * found at https://github.com/HadoopGenomics/Hadoop-BAM/blob/master/src/main/java/org/seqdoop/hadoop_bam/FastqInputFormat.java
+ *
+ * @author Jeremy Elson (jelson@microsoft.com)
+ * @author Frank Austin Nothaft (fnothaft@berkeley.edu)
+ * @date Feb 2015
+ */
+abstract public class FastqInputFormat extends FileInputFormat<Void,Text> {
+    
+    abstract public static class FastqRecordReader extends RecordReader<Void,Text> {
+        /*
+         * fastq format:
+         * <fastq>  :=  <block>+
+         * <block>  :=  @<seqname>\n<seq>\n\+[<seqname>]\n<qual>\n
+         * <seqname>  :=  [A-Za-z0-9_.:-]+
+         * <seq>  :=  [A-Za-z\n\.~]+
+         * <qual> :=  [!-~\n]+
+         */
+        
+        // start:  first valid data index
+        protected long start;
+        // end:  first index value beyond the slice, i.e. slice is in range [start,end)
+        protected long end;
+        // pos: current position in file
+        protected long pos;
+        // file:  the file being read
+        protected Path file;
+
+        protected FSDataInputStream inputStream;
+        protected Text currentValue;
+        protected byte[] newline = "\n".getBytes();
+
+        public FastqRecordReader(Configuration conf, FileSplit split) throws IOException {
+            file = split.getPath();
+            start = split.getStart();
+            end = start + split.getLength();
+
+            FileSystem fs = file.getFileSystem(conf);
+            inputStream = fs.open(file);
+            
+            CompressionCodecFactory codecFactory = new CompressionCodecFactory(conf);
+            CompressionCodec        codec        = codecFactory.getCodec(file);
+
+            if (codec == null) { // no codec.  Uncompressed file.
+                positionAtFirstRecord(inputStream);
+            } else { 
+                throw new IllegalArgumentException("We currently do not support compressed FASTQ.");
+            }
+        }
+
+        /**
+         * Position the input stream at the start of the first record.
+         */
+        abstract protected void positionAtFirstRecord(FSDataInputStream stream) throws IOException;
+
+        /**
+         * Added to use mapreduce API.
+         */
+        public void initialize(InputSplit split, TaskAttemptContext context) throws IOException, InterruptedException {}
+
+        /**
+         * Added to use mapreduce API.
+         */
+        public Void getCurrentKey() {
+            return null;
+        }
+
+        /**
+         * Added to use mapreduce API.
+         */
+        public Text getCurrentValue() {
+            return currentValue;
+        }
+
+        /**
+         * Added to use mapreduce API.
+         */
+        public boolean nextKeyValue() throws IOException, InterruptedException {
+            currentValue = new Text();
+
+            return next(currentValue);
+        }
+
+        /**
+         * Close this RecordReader to future operations.
+         */
+        public void close() throws IOException {
+            inputStream.close();
+        }
+
+        /**
+         * Create an object of the appropriate type to be used as a key.
+         */
+        public Text createKey() {
+            return new Text();
+        }
+
+        /**
+         * Create an object of the appropriate type to be used as a value.
+         */
+        public Text createValue() {
+            return new Text();
+        }
+
+        /**
+         * Returns the current position in the input.
+         */
+        public long getPos() { 
+            return pos; 
+        }
+
+        /**
+         * How much of the input has the RecordReader consumed i.e.
+         */
+        public float getProgress() {
+            if (start == end)
+                return 1.0f;
+            else
+                return Math.min(1.0f, (pos - start) / (float)(end - start));
+        }
+
+        public String makePositionMessage() {
+            return file.toString() + ":" + pos;
+        }
+
+        protected int getLineInfo(LineReader reader) throws IOException {
+            Text buffer = new Text();
+            int sequenceLines=1;
+            int bytesRead = 0;
+            
+            //starts at @title line. Read 2 lines and see if you have reached +secondTitle
+            bytesRead = reader.readLine(buffer);
+	    if (buffer.getBytes()[0] != '@') {
+		throw new IllegalStateException("Start was placed at " + buffer + ", not @.");
+	    }
+            bytesRead = reader.readLine(buffer);
+	    bytesRead = reader.readLine(buffer);
+            
+            if (bytesRead > 0 && buffer.getLength() > 0 && buffer.getBytes()[0] == '+') {
+                //read is 1 line. Read 2 more lines to position the reader at the next @title line
+                bytesRead = reader.readLine(buffer);
+                return sequenceLines; // all good!
+            } else {
+                String bufferString = buffer.toString();
+                
+                //regex string that matches only IUPAC codes
+                String iupacRegex = "[A-Y-[J,O,X]|.|-]+";
+
+                // check if the record is multiline and we are still reading the sequence data
+                while (bytesRead > 0 && buffer.getLength() > 0 && bufferString.matches(iupacRegex)) {
+                    // read another line, and count the number that are read.
+                    bytesRead = reader.readLine(buffer);
+                    sequenceLines++; 
+
+                    // check if we have reached the second title line
+                    if (bytesRead > 0 && buffer.getLength() > 0 && buffer.getBytes()[0] == '+') { 
+                        // number of lines has been determined. Set reader to next read's @title line.
+                        for (int x = 0; x<=sequenceLines; x++) {
+                            bytesRead = reader.readLine(buffer);
+                        }
+                        return sequenceLines; // all good!
+                    }
+                    bufferString = buffer.toString();
+                }
+            }
+            throw new IllegalStateException("Record does not seem to be FASTQ formatted.");
+        }
+
+        protected boolean lowLevelFastqRead(Text readName, Text value) throws IOException {
+            // construct line reader
+            inputStream.seek(pos);
+            LineReader lineReader = new LineReader(inputStream);
+            
+            // ID line
+            readName.clear();
+            long skipped = appendLineInto(readName, true);
+            if (skipped == 0)
+                return false; // EOF
+            if (readName.getBytes()[0] != '@')
+                throw new RuntimeException("unexpected fastq record didn't start with '@' at " + makePositionMessage() + ". Line: " + readName + ". \n");
+            pos += skipped;
+
+            value.append(readName.getBytes(), 0, readName.getLength());
+            Text tempReadBuffer = new Text();
+            int bytesRead = 0;
+            
+            // sequence
+            do {
+                if (tempReadBuffer.getLength() > 0) {
+                    value.append(tempReadBuffer.getBytes(), 0, tempReadBuffer.getLength());
+                    value.append(newline, 0, 1);
+                } else {
+                    tempReadBuffer.clear();
+                }
+                inputStream.seek(pos);
+                lineReader = new LineReader(inputStream);
+                bytesRead = lineReader.readLine(tempReadBuffer);
+                pos += bytesRead;
+            } while (bytesRead > 0 && tempReadBuffer.getLength() > 0 && tempReadBuffer.getBytes()[0] != '+');
+            
+            // separator line
+            if (bytesRead < 0) {
+                throw new EOFException();
+            }
+
+            // qualities
+            do {
+                if (tempReadBuffer.getLength() > 0) {
+                    value.append(tempReadBuffer.getBytes(), 0, tempReadBuffer.getLength());
+                    value.append(newline, 0, 1);
+                } else {
+                    tempReadBuffer.clear();
+                }
+                inputStream.seek(pos);
+                lineReader = new LineReader(inputStream);
+                bytesRead = lineReader.readLine(tempReadBuffer);
+                pos += bytesRead;
+            } while (bytesRead > 0 && tempReadBuffer.getLength() > 0 && tempReadBuffer.getBytes()[0] != '@');
+
+            // we must backtrack to the start of the last line, which is the start of the next record
+            pos -= bytesRead;
+
+            return true;
+        }
+
+        protected int appendLineInto(Text dest, boolean eofOk) throws EOFException, IOException {
+            Text buf = new Text();
+            LineReader lineReader = new LineReader(inputStream);
+            int bytesRead = lineReader.readLine(buf);
+
+            if (bytesRead < 0 || (bytesRead == 0 && !eofOk)) {
+                throw new EOFException();
+            }
+
+            dest.append(buf.getBytes(), 0, buf.getLength());
+            dest.append(newline, 0, 1);
+
+            return bytesRead;
+        }
+
+        /**
+         * Reads the next key/value pair from the input for processing.
+         */
+        abstract public boolean next(Text value) throws IOException;
+    }
+
+    abstract public RecordReader<Void, Text> createRecordReader(
+            InputSplit genericSplit,
+            TaskAttemptContext context) throws IOException, InterruptedException;
+}

--- a/adam-core/src/main/java/org/bdgenomics/adam/io/InterleavedFastqInputFormat.java
+++ b/adam-core/src/main/java/org/bdgenomics/adam/io/InterleavedFastqInputFormat.java
@@ -48,280 +48,53 @@ import java.io.InputStream;
  * cannot be split, and thus there is no reason to use the interleaved
  * format.
  *
- * This reader is based on the FastqInputFormat that's part of Hadoop-BAM,
- * found at https://github.com/HadoopGenomics/Hadoop-BAM/blob/master/src/main/java/org/seqdoop/hadoop_bam/FastqInputFormat.java
- *
  * @author Jeremy Elson (jelson@microsoft.com)
- * @date Feb 2014
+ * @author Frank Austin Nothaft (fnothaft@berkeley.edu)
+ * @date Feb 2015
  */
-public class InterleavedFastqInputFormat extends FileInputFormat<Void,Text> {
+public class InterleavedFastqInputFormat extends FastqInputFormat {
     
-    public static class InterleavedFastqRecordReader extends RecordReader<Void,Text> {
-        /*
-         * fastq format:
-         * <fastq>  :=  <block>+
-         * <block>  :=  @<seqname>\n<seq>\n\+[<seqname>]\n<qual>\n
-         * <seqname>  :=  [A-Za-z0-9_.:-]+
-         * <seq>  :=  [A-Za-z\n\.~]+
-         * <qual> :=  [!-~\n]+
-         *
-         * LP: this format is broken, no?  You can have multi-line sequence and quality strings,
-         * and the quality encoding includes '@' in its valid character range.  So how should one
-         * distinguish between \n@ as a record delimiter and and \n@ as part of a multi-line
-         * quality string?
-         *
-         * For now I'm going to assume single-line sequences.  This works for our sequencing
-         * application.  We'll see if someone complains in other applications.
-         */
-        
-        // start:  first valid data index
-        private long start;
-        // end:  first index value beyond the slice, i.e. slice is in range [start,end)
-        private long end;
-        // pos: current position in file
-        private long pos;
-        // file:  the file being read
-        private Path file;
-        //number of lines in first read
-        private int readLines;
-
-        
-        private LineReader lineReader;
-        private LineReader reader;
-
-        private InputStream inputStream;
-        private Text currentValue;
-        private byte[] newline = "\n".getBytes();
-
-        // How long can a read get?
-        private static final int MAX_LINE_LENGTH = 10000;
+    public static class InterleavedFastqRecordReader extends FastqRecordReader {
 
         public InterleavedFastqRecordReader(Configuration conf, FileSplit split) throws IOException {
-            file = split.getPath();
-            start = split.getStart();
-            end = start + split.getLength();
-
-            FileSystem fs = file.getFileSystem(conf);
-            FSDataInputStream fileIn = fs.open(file);
-
-            CompressionCodecFactory codecFactory = new CompressionCodecFactory(conf);
-            CompressionCodec        codec        = codecFactory.getCodec(file);
-
-            if (codec == null) { // no codec.  Uncompressed file.
-                positionAtFirstRecord(fileIn);
-                inputStream = fileIn;
-            } else { 
-                // compressed file
-                if (start != 0) {
-                    throw new RuntimeException("Start position for compressed file is not 0! (found " + start + ")");
-                }
-
-                inputStream = codec.createInputStream(fileIn);
-                end = Long.MAX_VALUE; // read until the end of the file
-            }
-            lineReader = new LineReader(inputStream);
+            super(conf, split);
         }
 
         /**
          * Position the input stream at the start of the first record.
          */
-        private void positionAtFirstRecord(FSDataInputStream stream) throws IOException {
+        protected void positionAtFirstRecord(FSDataInputStream stream) throws IOException {
             Text buffer = new Text();
             int bytesRead = 0;
             
-                // Advance to the start of the first record that ends with /1
-                // We use a temporary LineReader to read lines until we find the
-                // position of the right one.  We then seek the file to that position.
-                stream.seek(start);
-                reader = new LineReader(stream);
-                do {
-                    bytesRead = reader.readLine(buffer, (int)Math.min(MAX_LINE_LENGTH, end - start));
-                    int bufferLength = buffer.getLength();
-                    if (bytesRead > 0 && (bufferLength <= 0 ||
-                                          buffer.getBytes()[0] != '@' ||
-                                          (bufferLength >= 2 && buffer.getBytes()[bufferLength - 2] != '/') ||
-                                          (bufferLength >= 1 && buffer.getBytes()[bufferLength - 1] != '1'))) {
-                        start += bytesRead;
-                    } else {
-                        // line starts with @.  Read two more and verify that it starts with a +
-                        //
-                        // If this isn't the start of a record, we want to backtrack to its end
-                        long backtrackPosition = start + bytesRead;
-
-                        //determines if read is fastq and if it is single/multi lined. Returns number of lines, and -1 if not fastq format.
-                        int lines = getLineInfo();
-                        
-                        if(lines==-1){
-                                // backtrack to the end of the record we thought was the start.
-                            start = backtrackPosition;
-                            stream.seek(start);
-                            reader = new LineReader(stream);
-                            
-                        }else{
-                                readLines = lines; //to avoid calling getLineInfo on the first read again, the line info is saved
-                                break; //all good!
-                            }
-
-                    }
-
-                } while (bytesRead > 0);
-
-                stream.seek(start);
-
+	    // Advance to the start of the first record that ends with /1
+	    // We use a temporary LineReader to read lines until we find the
+	    // position of the right one.  We then seek the file to that position.
+	    stream.seek(start);
+	    LineReader reader = new LineReader(stream);
+	    do {
+		bytesRead = reader.readLine(buffer);
+		int bufferLength = buffer.getLength();
+		if (bytesRead > 0 && (bufferLength <= 0 ||
+				      buffer.getBytes()[0] != '@' ||
+				      (bufferLength >= 2 && buffer.getBytes()[bufferLength - 2] != '/') ||
+				      (bufferLength >= 1 && buffer.getBytes()[bufferLength - 1] != '1'))) {
+		    start += bytesRead;
+		} else {
+		    // line starts with @.  Read two more and verify that it starts with a +
+		    //
+		    // If this isn't the start of a record, we want to backtrack to its end
+		    long backtrackPosition = start; // + bytesRead;
+		    
+		    //determines if read is fastq and if it is single/multi lined. Returns number of lines, and -1 if not fastq format.
+		    stream.seek(start);
+                    start = backtrackPosition;
+                    break; //all good!
+		}
+	    } while (bytesRead > 0);
+            
             pos = start;
         }
-
-        /**
-         * Added to use mapreduce API.
-         */
-        public void initialize(InputSplit split, TaskAttemptContext context) throws IOException, InterruptedException {}
-
-        /**
-         * Added to use mapreduce API.
-         */
-        public Void getCurrentKey() {
-            return null;
-        }
-
-        /**
-         * Added to use mapreduce API.
-         */
-        public Text getCurrentValue() {
-            return currentValue;
-        }
-
-        /**
-         * Added to use mapreduce API.
-         */
-        public boolean nextKeyValue() throws IOException, InterruptedException {
-            currentValue = new Text();
-
-            return next(currentValue);
-        }
-
-        /**
-         * Close this RecordReader to future operations.
-         */
-        public void close() throws IOException {
-            inputStream.close();
-        }
-
-        /**
-         * Create an object of the appropriate type to be used as a key.
-         */
-        public Text createKey() {
-            return new Text();
-        }
-
-        /**
-         * Create an object of the appropriate type to be used as a value.
-         */
-        public Text createValue() {
-            return new Text();
-        }
-
-        /**
-         * Returns the current position in the input.
-         */
-        public long getPos() { 
-            return pos; 
-        }
-
-        /**
-         * How much of the input has the RecordReader consumed i.e.
-         */
-        public float getProgress() {
-            if (start == end)
-                return 1.0f;
-            else
-                return Math.min(1.0f, (pos - start) / (float)(end - start));
-        }
-
-        public String makePositionMessage() {
-            return file.toString() + ":" + pos;
-        }
-        private int getLineInfo() throws IOException {
-            Text buffer = new Text();
-            int sequenceLines=1;
-            int bytesRead = 0;
-
-            //starts at @title line. Read 2 lines and see if you have reached +secondTitle
-            bytesRead = reader.readLine(buffer,(int)Math.min(MAX_LINE_LENGTH, end - start));
-            bytesRead = reader.readLine(buffer,(int)Math.min(MAX_LINE_LENGTH, end - start));
-
-            if (bytesRead > 0 && buffer.getLength() > 0 && buffer.getBytes()[0] == '+') {
-
-                //read is 1 line. Read 2 more lines to position the reader at the next @title line
-                bytesRead = reader.readLine(buffer,(int)Math.min(MAX_LINE_LENGTH, end - start));
-                bytesRead = reader.readLine(buffer,(int)Math.min(MAX_LINE_LENGTH, end - start));
-                return sequenceLines; // all good!
-
-            } else {
-                String bufferString = buffer.toString();
-                
-                //regex string that matches only IUPAC codes
-                String iupacRegex = "[A-Y-[J,O,X]|.|-]+";
-
-                //check if the record is multiline and we are still reading the sequence data
-                while(bytesRead > 0 && buffer.getLength() > 0 && bufferString.matches(iupacRegex)){ 
-
-                    //read another line, and count the number that are read.
-                    bytesRead = reader.readLine(buffer, (int)Math.min(MAX_LINE_LENGTH, end - start));
-                    sequenceLines++; 
-
-                    //check if we have reached the second title line
-                    if (bytesRead > 0 && buffer.getLength() > 0 && buffer.getBytes()[0] == '+') { 
-
-                        //number of lines has been determined. Set reader to next read's @title line.
-                        for(int x = 0; x<=sequenceLines; x++){
-                            bytesRead = reader.readLine(buffer, (int)Math.min(MAX_LINE_LENGTH, end - start)); 
-                        }
-                        return sequenceLines; // all good!
-                    }
-                    bufferString = buffer.toString();
-                }
-            }
-            return -1;
-        }
-        protected boolean lowLevelFastqRead(Text readName, Text value) throws IOException {
-            // ID line
-            readName.clear();
-            long skipped = appendLineInto(readName, true);
-            pos += skipped;
-            if (skipped == 0)
-                return false; // EOF
-            if (readName.getBytes()[0] != '@')
-                throw new RuntimeException("unexpected fastq record didn't start with '@' at " + makePositionMessage() + ". Line: " + readName + ". \n");
-
-            value.append(readName.getBytes(), 0, readName.getLength());
-            int sequenceLines;
-            
-            //check if getLineInfo has already been called on this read
-            if(readLines==-2){
-                //it has not yet been called
-                sequenceLines = getLineInfo();
-            }else{
-                //it has been called. Take line info from readLines and set it to -2.
-                sequenceLines=readLines;
-                readLines=-2;
-            }
-
-            // sequence
-            for(int x = 0; x<sequenceLines; x++){
-            appendLineInto(value, false);
-            }
-
-            // separator line
-            appendLineInto(value, false);
-
-            // quality
-            for(int x = 0; x<sequenceLines; x++){
-            appendLineInto(value, false);
-            }
-
-            return true;
-        }
-
 
         /**
          * Reads the next key/value pair from the input for processing.
@@ -332,19 +105,16 @@ public class InterleavedFastqInputFormat extends FileInputFormat<Void,Text> {
             try {
                 Text readName1 = new Text();
                 Text readName2 = new Text();
-
                 value.clear();
+
                 // first read of the pair
                 boolean gotData = lowLevelFastqRead(readName1, value);
-
 
                 if (!gotData)
                     return false;
 
                 // second read of the pair
-
                 gotData = lowLevelFastqRead(readName2, value);
-
 
                 if (!gotData)
                     return false;
@@ -353,21 +123,6 @@ public class InterleavedFastqInputFormat extends FileInputFormat<Void,Text> {
             } catch (EOFException e) {
                 throw new RuntimeException("unexpected end of file in fastq record at " + makePositionMessage());
             }
-        }
-
-
-        private int appendLineInto(Text dest, boolean eofOk) throws EOFException, IOException {
-            Text buf = new Text();
-            int bytesRead = lineReader.readLine(buf, MAX_LINE_LENGTH);
-
-            if (bytesRead < 0 || (bytesRead == 0 && !eofOk))
-                throw new EOFException();
-
-            dest.append(buf.getBytes(), 0, buf.getLength());
-            dest.append(newline, 0, 1);
-            pos += bytesRead;
-
-            return bytesRead;
         }
     }
 

--- a/adam-core/src/main/java/org/bdgenomics/adam/io/SingleFastqInputFormat.java
+++ b/adam-core/src/main/java/org/bdgenomics/adam/io/SingleFastqInputFormat.java
@@ -40,284 +40,50 @@ import java.io.InputStream;
 /**
  * This class is a Hadoop reader for single read fastq.
  *
- * This reader is based on the FastqInputFormat that's part of Hadoop-BAM,
- * found at https://github.com/HadoopGenomics/Hadoop-BAM/blob/master/src/main/java/org/seqdoop/hadoop_bam/FastqInputFormat.java
- *
  * @author Frank Austin Nothaft (fnothaft@berkeley.edu)
- * @date September 2014
+ * @date February 2015
  */
-public class SingleFastqInputFormat extends FileInputFormat<Void,Text> {
+public class SingleFastqInputFormat extends FastqInputFormat {
     
-    public static class SingleFastqRecordReader extends RecordReader<Void,Text> {
-        /*
-         * fastq format:
-         * <fastq>  :=  <block>+
-         * <block>  :=  @<seqname>\n<seq>\n\+[<seqname>]\n<qual>\n
-         * <seqname>  :=  [A-Za-z0-9_.:-]+
-         * <seq>  :=  [A-Za-z\n\.~]+
-         * <qual> :=  [!-~\n]+
-         *
-         * LP: this format is broken, no?  You can have multi-line sequence and quality strings,
-         * and the quality encoding includes '@' in its valid character range.  So how should one
-         * distinguish between \n@ as a record delimiter and and \n@ as part of a multi-line
-         * quality string?
-         *
-         * For now I'm going to assume single-line sequences.  This works for our sequencing
-         * application.  We'll see if someone complains in other applications.
-         *
-         * Multiline sequences are now supported. A separate line reader determines the number 
-         * of lines in the read before lineReader parses them.
-         */
-        
-        // start:  first valid data index
-        private long start;
-        // end:  first index value beyond the slice, i.e. slice is in range [start,end)
-        private long end;
-        // pos: current position in file
-        private long pos;
-        // file:  the file being read
-        private Path file;
-        //number of lines in the first read
-        private int readLines;
-
-        /*reader is used to determine the position of the first record and to determine the number of lines in 
-        *each record before they are parsed by lineReader
-        */
-        private LineReader reader; 
-        private LineReader lineReader;
-       
-        private InputStream inputStream;
-        private Text currentValue;
-        private byte[] newline = "\n".getBytes();
-
-        // How long can a read get?
-        private static final int MAX_LINE_LENGTH = 10000;
+    public static class SingleFastqRecordReader extends FastqRecordReader {
 
         public SingleFastqRecordReader(Configuration conf, FileSplit split) throws IOException {
-            file = split.getPath();
-            start = split.getStart();
-            end = start + split.getLength();
-
-            FileSystem fs = file.getFileSystem(conf);
-            FSDataInputStream fileIn = fs.open(file);
-
-            CompressionCodecFactory codecFactory = new CompressionCodecFactory(conf);
-            CompressionCodec        codec        = codecFactory.getCodec(file);
-
-            if (codec == null) { // no codec.  Uncompressed file.
-                positionAtFirstRecord(fileIn);
-                inputStream = fileIn;
-            } else { 
-                // compressed file
-                if (start != 0) {
-                    throw new RuntimeException("Start position for compressed file is not 0! (found " + start + ")");
-                }
-
-                inputStream = codec.createInputStream(fileIn);
-                end = Long.MAX_VALUE; // read until the end of the file
-            }
-            lineReader = new LineReader(inputStream);
+            super(conf, split);
         }
 
         /**
          * Position the input stream at the start of the first record.
          */
-        private void positionAtFirstRecord(FSDataInputStream stream) throws IOException {
+        protected void positionAtFirstRecord(FSDataInputStream stream) throws IOException {
             Text buffer = new Text();
             int bytesRead = 0;
-
-                // Advance to the start of the first record
-                // We use reader to read lines until we find the
-                // position of the right one.  We then seek the file to that position.
-                stream.seek(start);
-                reader = new LineReader(stream);
-
-                do {
-                    bytesRead = reader.readLine(buffer, (int)Math.min(MAX_LINE_LENGTH, end - start)); 
-                    int bufferLength = buffer.getLength();
-                    if (bytesRead > 0 && (bufferLength <= 0 ||
-                                          buffer.getBytes()[0] != '@')) {
-                        start += bytesRead;
-                    } else {
-                        // line starts with @.  Read two more and verify that it starts with a +
-                        //
-                        // If this isn't the start of a record, we want to backtrack to its end
-                        long backtrackPosition = start + bytesRead; 
-
-                        //determines if read is fastq and if it is single/multi lined. Returns number of lines, and -1 if not fastq format.
-                        int lines = getLineInfo();
-                        
-                        if(lines==-1){
-                            // backtrack to the end of the record we thought was the start.
-                            start = backtrackPosition;
-                            stream.seek(start);
-                            reader = new LineReader(stream);
-                            
-                        }else{
-                                readLines = lines; //to avoid calling getLineInfo on the first read again, the line info is saved
-                                break; //all good!
-                            }
-                        
-                    }
-
-                } while (bytesRead > 0);
-
-                stream.seek(start);
-
+            
+	    // Advance to the start of the first record that ends with /1
+	    // We use a temporary LineReader to read lines until we find the
+	    // position of the right one.  We then seek the file to that position.
+	    stream.seek(start);
+	    LineReader reader = new LineReader(stream);
+	    do {
+		bytesRead = reader.readLine(buffer);
+		int bufferLength = buffer.getLength();
+		if (bytesRead > 0 && (bufferLength <= 0 ||
+				      buffer.getBytes()[0] != '@')) {
+		    start += bytesRead;
+		} else {
+		    // line starts with @.  Read two more and verify that it starts with a +
+		    //
+		    // If this isn't the start of a record, we want to backtrack to its end
+		    long backtrackPosition = start; // + bytesRead;
+		    
+		    //determines if read is fastq and if it is single/multi lined. Returns number of lines, and -1 if not fastq format.
+		    stream.seek(start);
+                    start = backtrackPosition;
+                    break; //all good!
+		}
+	    } while (bytesRead > 0);
+            
             pos = start;
         }
-
-        /**
-         * Added to use mapreduce API.
-         */
-        public void initialize(InputSplit split, TaskAttemptContext context) throws IOException, InterruptedException {}
-
-        /**
-         * Added to use mapreduce API.
-         */
-        public Void getCurrentKey() {
-            return null;
-        }
-
-        /**
-         * Added to use mapreduce API.
-         */
-        public Text getCurrentValue() {
-            return currentValue;
-        }
-
-        /**
-         * Added to use mapreduce API.
-         */
-        public boolean nextKeyValue() throws IOException, InterruptedException {
-            currentValue = new Text();
-
-            return next(currentValue);
-        }
-
-        /**
-         * Close this RecordReader to future operations.
-         */
-        public void close() throws IOException {
-            inputStream.close();
-        }
-
-        /**
-         * Create an object of the appropriate type to be used as a key.
-         */
-        public Text createKey() {
-            return new Text();
-        }
-
-        /**
-         * Create an object of the appropriate type to be used as a value.
-         */
-        public Text createValue() {
-            return new Text();
-        }
-
-        /**
-         * Returns the current position in the input.
-         */
-        public long getPos() { 
-            return pos; 
-        }
-
-        /**
-         * How much of the input has the RecordReader consumed i.e.
-         */
-        public float getProgress() {
-            if (start == end)
-                return 1.0f;
-            else
-                return Math.min(1.0f, (pos - start) / (float)(end - start));
-        }
-
-        public String makePositionMessage() {
-            return file.toString() + ":" + pos;
-        }
-        private int getLineInfo() throws IOException {
-            Text buffer = new Text();
-            int sequenceLines=1;
-            int bytesRead = 0;
-
-            //starts at @title line. Read 2 lines and see if you have reached +secondTitle
-            bytesRead = reader.readLine(buffer,(int)Math.min(MAX_LINE_LENGTH, end - start));
-            bytesRead = reader.readLine(buffer,(int)Math.min(MAX_LINE_LENGTH, end - start));
-
-            if (bytesRead > 0 && buffer.getLength() > 0 && buffer.getBytes()[0] == '+') {
-
-                //read is 1 line. Read 2 more lines to position the reader at the next @title line
-                bytesRead = reader.readLine(buffer,(int)Math.min(MAX_LINE_LENGTH, end - start));
-                bytesRead = reader.readLine(buffer,(int)Math.min(MAX_LINE_LENGTH, end - start));
-                return sequenceLines; // all good!
-
-            } else {
-                String bufferString = buffer.toString();
-                
-                //regex string that matches only IUPAC codes
-                String iupacRegex = "[A-Y-[J,O,X]|.|-]+";
-
-                //check if the record is multiline and we are still reading the sequence data
-                while(bytesRead > 0 && buffer.getLength() > 0 && bufferString.matches(iupacRegex)){ 
-
-                    //read another line, and count the number that are read.
-                    bytesRead = reader.readLine(buffer, (int)Math.min(MAX_LINE_LENGTH, end - start));
-                    sequenceLines++; 
-
-                    //check if we have reached the second title line
-                    if (bytesRead > 0 && buffer.getLength() > 0 && buffer.getBytes()[0] == '+') { 
-
-                        //number of lines has been determined. Set reader to next read's @title line.
-                        for(int x = 0; x<=sequenceLines; x++){
-                            bytesRead = reader.readLine(buffer, (int)Math.min(MAX_LINE_LENGTH, end - start)); 
-                        }
-                        return sequenceLines; // all good!
-                    }
-                    bufferString = buffer.toString();
-                }
-            }
-            return -1;
-        }
-        protected boolean lowLevelFastqRead(Text readName, Text value) throws IOException {
-            // ID line
-            readName.clear();
-            long skipped = appendLineInto(readName, true);
-            pos += skipped;
-            if (skipped == 0)
-                return false; // EOF
-            if (readName.getBytes()[0] != '@')
-                throw new RuntimeException("unexpected fastq record didn't start with '@' at " + makePositionMessage() + ". Line: " + readName + ". \n");
-
-            value.append(readName.getBytes(), 0, readName.getLength());
-            int sequenceLines;
-            //check if getLineInfo has already been called on this read
-            if(readLines==-2){
-                //it has not been called
-                sequenceLines = getLineInfo();
-            }else{
-                //it has been called. Take line info from readLines and set it to -2.
-                sequenceLines=readLines;
-                readLines=-2;
-            }
-
-            // sequence
-            for(int x = 0; x<sequenceLines; x++) {
-            appendLineInto(value, false);
-            }
-
-            // separator line
-            appendLineInto(value, false);
-
-            // quality
-            for(int x = 0; x<sequenceLines; x++) {
-            appendLineInto(value, false);
-            }
-            
-
-            return true;
-        }
-
 
         /**
          * Reads the next key/value pair from the input for processing.
@@ -327,7 +93,7 @@ public class SingleFastqInputFormat extends FileInputFormat<Void,Text> {
                 return false; // past end of slice
             try {
                 Text readName = new Text();
-
+                
                 value.clear();
 
                 // first read of the pair
@@ -337,21 +103,6 @@ public class SingleFastqInputFormat extends FileInputFormat<Void,Text> {
             } catch (EOFException e) {
                 throw new RuntimeException("unexpected end of file in fastq record at " + makePositionMessage());
             }
-        }
-
-
-        private int appendLineInto(Text dest, boolean eofOk) throws EOFException, IOException {
-            Text buf = new Text();
-            int bytesRead = lineReader.readLine(buf, MAX_LINE_LENGTH);
-
-            if (bytesRead < 0 || (bytesRead == 0 && !eofOk))
-                throw new EOFException();
-
-            dest.append(buf.getBytes(), 0, buf.getLength());
-            dest.append(newline, 0, 1);
-            pos += bytesRead;
-
-            return bytesRead;
         }
     }
 

--- a/adam-core/src/main/scala/org/bdgenomics/adam/converters/FastqRecordConverter.scala
+++ b/adam-core/src/main/scala/org/bdgenomics/adam/converters/FastqRecordConverter.scala
@@ -30,10 +30,11 @@ class FastqRecordConverter extends Serializable with Logging {
     //true if read is multiline
     if (temp.length > 8) {
       lines = parseMultiLine(element._2.toString)
+      assert(lines.length == 8, "Multiline record has wrong format:\n" + lines(0) + " " + lines(1) + " " + lines.length + " from " + temp.mkString(";"))
     } else {
       lines = temp
+      assert(lines.length == 8, "Record has wrong format:\n" + lines(0) + " " + lines(1) + " " + lines.length + " from " + temp.mkString(";"))
     }
-    assert(lines.length == 8, "Record has wrong format:\n" + lines(0) + " " + lines(1) + " " + lines.length)
 
     // get fields for first read in pair
     val firstReadName = lines(0).drop(1)
@@ -41,7 +42,8 @@ class FastqRecordConverter extends Serializable with Logging {
     val firstReadQualities = lines(3)
 
     assert(firstReadSequence.length == firstReadQualities.length,
-      "Read " + firstReadName + " has different sequence and qual length.")
+      "First of pair read " + firstReadName + " has different sequence (" + firstReadSequence +
+        ") and qual (" + firstReadQualities + " length.")
 
     // get fields for second read in pair
     val secondReadName = lines(4).drop(1)
@@ -49,7 +51,8 @@ class FastqRecordConverter extends Serializable with Logging {
     val secondReadQualities = lines(7)
 
     assert(secondReadSequence.length == secondReadQualities.length,
-      "Read " + secondReadName + " has different sequence and qual length.")
+      "Second of pair read " + secondReadName + " has different sequence (" + secondReadSequence +
+        ") and qual (" + secondReadQualities + ") length.")
 
     // build and return iterators
     Iterable(AlignmentRecord.newBuilder()

--- a/adam-core/src/test/scala/org/bdgenomics/adam/io/InterleavedFastqInputFormatSuite.scala
+++ b/adam-core/src/test/scala/org/bdgenomics/adam/io/InterleavedFastqInputFormatSuite.scala
@@ -50,6 +50,7 @@ class InterleavedFastqInputFormatSuite extends ADAMFunSuite {
       assert(testOutput.toString() == expectedOutputData)
     }
   }
+
   sparkTest("interleaved multiline FASTQ hadoop reader") {
     val inputName = "interleaved_multiline_fastq.ifq"
     val expectedOutputName = inputName + ".output"
@@ -74,7 +75,6 @@ class InterleavedFastqInputFormatSuite extends ADAMFunSuite {
     })
 
     assert(testOutput.toString() == expectedOutputData)
-
   }
 }
 

--- a/adam-core/src/test/scala/org/bdgenomics/adam/io/SingleFastqInputFormatSuite.scala
+++ b/adam-core/src/test/scala/org/bdgenomics/adam/io/SingleFastqInputFormatSuite.scala
@@ -50,6 +50,7 @@ class SingleFastqInputFormatSuite extends ADAMFunSuite {
       assert(testOutput.toString() == expectedOutputData)
     }
   }
+
   sparkTest("multiline FASTQ hadoop reader") {
     val inputName = "multiline_fastq.fq"
     val expectedOutputName = "single_" + inputName + ".output"
@@ -73,7 +74,6 @@ class SingleFastqInputFormatSuite extends ADAMFunSuite {
     })
 
     assert(testOutput.toString() == expectedOutputData)
-
   }
 }
 

--- a/pom.xml
+++ b/pom.xml
@@ -24,7 +24,7 @@
     <spark.version>1.2.0</spark.version>
     <parquet.version>1.6.0rc4</parquet.version>
     <!-- Edit the following line to configure the Hadoop (HDFS) version. -->
-    <hadoop.version>2.2.0</hadoop.version>
+    <hadoop.version>1.0.4</hadoop.version>
     <scoverage.version>0.99.2</scoverage.version>
     <utils.version>0.1.1</utils.version>
   </properties>


### PR DESCRIPTION
Resolves #610. This is a fairly extensive rewrite of the FASTQ input format code. I started debugging said bug, and found a lot of cruft and repeated code in the FASTQ input formats. I don't _love_ the new code, but I think it is substantially cleaner and has the plus side of working. I'm going to revalidate it on the ERR000096 FASTQs tomorrow; I had a cluster up, but alas they were spot nodes and disappeared into the EC2 mist.