### PR TITLE
[ADAM-540] Move to new HTSJDK release; should support Java 8.

### DIFF
--- a/adam-core/pom.xml
+++ b/adam-core/pom.xml
@@ -178,11 +178,7 @@
       <artifactId>hadoop-bam</artifactId>
     </dependency>
     <dependency>
-      <groupId>org.seqdoop</groupId>
-      <artifactId>cofoja</artifactId>
-    </dependency>
-    <dependency>
-      <groupId>org.seqdoop</groupId>
+      <groupId>com.github.samtools</groupId>
       <artifactId>htsjdk</artifactId>
     </dependency>
     <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -27,6 +27,7 @@
     <hadoop.version>2.2.0</hadoop.version>
     <scoverage.version>0.99.2</scoverage.version>
     <utils.version>0.1.1</utils.version>
+    <htsjdk.version>1.129</htsjdk.version>
   </properties>
   
   <modules>
@@ -432,16 +433,17 @@
         <groupId>org.seqdoop</groupId>
         <artifactId>hadoop-bam</artifactId>
         <version>7.0.0</version>
+        <exclusions>
+          <exclusion>
+            <groupId>com.seqdoop</groupId>
+            <artifactId>htsjdk</artifactId>
+          </exclusion>
+        </exclusions>
       </dependency>
       <dependency>
-        <groupId>org.seqdoop</groupId>
-        <artifactId>cofoja</artifactId>
-        <version>1.1-r150</version>
-      </dependency>
-      <dependency>
-        <groupId>org.seqdoop</groupId>
+        <groupId>com.github.samtools</groupId>
         <artifactId>htsjdk</artifactId>
-        <version>1.118</version>
+        <version>${htsjdk.version}</version>
       </dependency>
       <dependency>
         <groupId>args4j</groupId>


### PR DESCRIPTION
Resolves #540. Moves to the new HTSJDK release which removes the Cofoja dependency that was blocking Java 8 support. A few notes:

* I have not tested this on Java 8 as I don't have a system with Java 8 on it; @antonkulaga would you mind trying to build this?
* I want to test this a bit further. It requires some funny shading in Hadoop-BAM; I'm _optimistic_ that we don't need to do anything more than the funny shading, but I realize that optimism is likely wrong.