### PR TITLE
[ADAM-631] Allow VCF conversion to sort on output after coalescing.

### DIFF
--- a/adam-core/src/test/scala/org/bdgenomics/adam/rdd/variation/VariationRDDFunctionsSuite.scala
+++ b/adam-core/src/test/scala/org/bdgenomics/adam/rdd/variation/VariationRDDFunctionsSuite.scala
@@ -101,7 +101,7 @@ class ADAMVariationRDDFunctionsSuite extends ADAMFunSuite {
 
   sparkTest("can write, then read in .vcf file") {
     val path = new File(tempDir, "test.vcf")
-    variants.adamVCFSave(path.getAbsolutePath)
+    variants.saveAsVcf(path.getAbsolutePath)
     assert(path.exists)
   }
 }


### PR DESCRIPTION
Resolves #631. Renames `adamVCFSave` to `saveAsVcf` and adds hooks to optionally coalesce and sort during save. Sort is performed _after_ coalescing. Sort and coalesce are independent.