### PR TITLE
[ADAM-646] Special case reads with '*' quality during BQSR.

### DIFF
--- a/adam-core/src/main/scala/org/bdgenomics/adam/converters/AlignmentRecordConverter.scala
+++ b/adam-core/src/main/scala/org/bdgenomics/adam/converters/AlignmentRecordConverter.scala
@@ -79,7 +79,10 @@ class AlignmentRecordConverter extends Serializable {
     // set canonically necessary fields
     builder.setReadName(adamRecord.getReadName.toString)
     builder.setReadString(adamRecord.getSequence)
-    builder.setBaseQualityString(adamRecord.getQual)
+    adamRecord.getQual match {
+      case null      => builder.setBaseQualityString("*")
+      case s: String => builder.setBaseQualityString(s)
+    }
 
     // set read group flags
     Option(adamRecord.getRecordGroupName)

--- a/adam-core/src/main/scala/org/bdgenomics/adam/converters/SAMRecordConverter.scala
+++ b/adam-core/src/main/scala/org/bdgenomics/adam/converters/SAMRecordConverter.scala
@@ -65,8 +65,14 @@ class SAMRecordConverter extends Serializable with Logging {
         .setCigar(cigar)
         .setBasesTrimmedFromStart(startTrim)
         .setBasesTrimmedFromEnd(endTrim)
-        .setQual(samRecord.getBaseQualityString)
         .setOrigQual(SAMUtils.phredToFastq(samRecord.getOriginalBaseQualities))
+
+      // if the quality string is "*", then we null it in the record
+      // or, in other words, we only set the quality string if it is not "*"
+      val qual = samRecord.getBaseQualityString
+      if (qual != "*") {
+        builder.setQual(qual)
+      }
 
       // Only set the reference information if the read is aligned, matching the mate reference
       // This prevents looking up a -1 in the sequence dictionary

--- a/adam-core/src/main/scala/org/bdgenomics/adam/rdd/read/recalibration/BaseQualityRecalibration.scala
+++ b/adam-core/src/main/scala/org/bdgenomics/adam/rdd/read/recalibration/BaseQualityRecalibration.scala
@@ -55,6 +55,7 @@ class BaseQualityRecalibration(
   val dataset: RDD[(CovariateKey, Residue)] = {
     def shouldIncludeRead(read: DecadentRead) =
       read.isCanonicalRecord &&
+        read.record.record.getQual != null &&
         read.alignmentQuality.exists(_ > QualityScore.zero) &&
         read.passedQualityChecks
 

--- a/adam-core/src/main/scala/org/bdgenomics/adam/rdd/read/recalibration/Recalibrator.scala
+++ b/adam-core/src/main/scala/org/bdgenomics/adam/rdd/read/recalibration/Recalibrator.scala
@@ -30,10 +30,14 @@ class Recalibrator(val table: RecalibrationTable, val minAcceptableQuality: Qual
 
   def apply(read: DecadentRead): AlignmentRecord = RecalibrateRead.time {
     val record: AlignmentRecord = read.record
-    AlignmentRecord.newBuilder(record).
-      setQual(QualityScore.toString(computeQual(read))).
-      setOrigQual(record.getQual).
-      build()
+    if (record.getQual != null) {
+      AlignmentRecord.newBuilder(record)
+        .setQual(QualityScore.toString(computeQual(read)))
+        .setOrigQual(record.getQual)
+        .build()
+    } else {
+      record
+    }
   }
 
   def computeQual(read: DecadentRead): Seq[QualityScore] = ComputeQualityScore.time {

--- a/adam-core/src/main/scala/org/bdgenomics/adam/rich/DecadentRead.scala
+++ b/adam-core/src/main/scala/org/bdgenomics/adam/rich/DecadentRead.scala
@@ -58,7 +58,8 @@ class DecadentRead(val record: RichAlignmentRecord) extends Logging {
   require(!record.getPrimaryAlignment || record.getReadMapped, "Unaligned read can't be a primary alignment")
 
   // Should have quality scores for all residues
-  require(record.getSequence.length == record.qualityScores.length, "sequence and qualityScores must be same length")
+  require(record.getQual == null ||
+    record.getSequence.length == record.qualityScores.length, "sequence and qualityScores must be same length")
 
   // MapQ should be valid
   require(record.getMapq == null || (record.getMapq >= 0 && record.getMapq <= 93), "MapQ must be in [0, 255]")

--- a/adam-core/src/test/scala/org/bdgenomics/adam/converters/SAMRecordConverterSuite.scala
+++ b/adam-core/src/test/scala/org/bdgenomics/adam/converters/SAMRecordConverterSuite.scala
@@ -17,12 +17,11 @@
  */
 package org.bdgenomics.adam.converters
 
+import htsjdk.samtools._
+import java.io.File
 import org.scalatest.FunSuite
 import org.bdgenomics.adam.models.{ SequenceRecord, Attribute, RecordGroupDictionary, SequenceDictionary }
 import org.bdgenomics.adam.rdd.ADAMContext._
-import java.io.File
-import htsjdk.samtools._
-
 import scala.collection.JavaConversions._
 
 class SAMRecordConverterSuite extends FunSuite {
@@ -33,30 +32,29 @@ class SAMRecordConverterSuite extends FunSuite {
     val testFileString = getClass.getClassLoader.getResource("reads12.sam").getFile
     val testFile = new File(testFileString)
 
-    //Iterator of SamReads in the file that each have a samRecord for conversion
+    // Iterator of SamReads in the file that each have a samRecord for conversion
     val testIterator = SamReaderFactory.makeDefault().open(testFile)
     val testSAMRecord = testIterator.iterator().next()
 
-    //Creating the two SequenceRecords in file for SequenceDictionary
+    // Creating the two SequenceRecords in file for SequenceDictionary
     val testSequenceRecord1 = new SequenceRecord("1", 249250621L)
     val testSequenceRecord2 = new SequenceRecord("2", 243199373L)
 
-    //SequenceDictionary to be used as parameter during conversion
+    // SequenceDictionary to be used as parameter during conversion
     val testSequenceDict = SequenceDictionary(testSequenceRecord1, testSequenceRecord2)
 
-    //RecordGroupDictionary to be used as a parameter during conversion
+    // RecordGroupDictionary to be used as a parameter during conversion
     val testRecordGroupDict = new RecordGroupDictionary(Seq())
 
-    //Convert samRecord to alignmentRecord
+    // Convert samRecord to alignmentRecord
     val testAlignmentRecord = testRecordConverter.convert(testSAMRecord, testSequenceDict, testRecordGroupDict)
 
-    //Validating Conversion
+    // Validating Conversion
     assert(testAlignmentRecord.getCigar === testSAMRecord.getCigarString)
     assert(testAlignmentRecord.getDuplicateRead === testSAMRecord.getDuplicateReadFlag)
     assert(testAlignmentRecord.getEnd.toInt === testSAMRecord.getAlignmentEnd)
     assert(testAlignmentRecord.getMapq.toInt === testSAMRecord.getMappingQuality)
     assert(testAlignmentRecord.getStart.toInt === (testSAMRecord.getAlignmentStart - 1))
-    assert(testAlignmentRecord.getQual === testSAMRecord.getBaseQualityString)
     assert(!testAlignmentRecord.getFirstOfPair)
     assert(testAlignmentRecord.getFailedVendorQualityChecks === testSAMRecord.getReadFailsVendorQualityCheckFlag)
     assert(!testAlignmentRecord.getPrimaryAlignment === testSAMRecord.getNotPrimaryAlignmentFlag)
@@ -66,47 +64,78 @@ class SAMRecordConverterSuite extends FunSuite {
     assert(!testAlignmentRecord.getReadPaired)
     assert(!testAlignmentRecord.getSecondOfPair)
     assert(testAlignmentRecord.getSupplementaryAlignment === testSAMRecord.getSupplementaryAlignmentFlag)
-
   }
 
   test("testing the fields in an alignmentRecord obtained from an unmapped samRecord conversion") {
+
+    val testRecordConverter = new SAMRecordConverter
+    val testFileString = getClass.getClassLoader.getResource("reads12.sam").getFile
+    val testFile = new File(testFileString)
+
+    // Iterator of SamReads in the file that each have a samRecord for conversion
+    val testIterator = SamReaderFactory.makeDefault().open(testFile)
+    val testSAMRecord = testIterator.iterator().next()
+
+    // Creating the two SequenceRecords in file for SequenceDictionary
+    val testSequenceRecord1 = new SequenceRecord("1", 249250621L)
+    val testSequenceRecord2 = new SequenceRecord("2", 243199373L)
+
+    // SequenceDictionary to be used as parameter during conversion
+    val testSequenceDict = SequenceDictionary(testSequenceRecord1, testSequenceRecord2)
+
+    // RecordGroupDictionary to be used as a parameter during conversion
+    val testRecordGroupDict = new RecordGroupDictionary(Seq())
+
+    // Convert samRecord to alignmentRecord
+    val testAlignmentRecord = testRecordConverter.convert(testSAMRecord, testSequenceDict, testRecordGroupDict)
+
+    // Validating Conversion
+    assert(testAlignmentRecord.getCigar === testSAMRecord.getCigarString)
+    assert(testAlignmentRecord.getDuplicateRead === testSAMRecord.getDuplicateReadFlag)
+    assert(testAlignmentRecord.getEnd.toInt === testSAMRecord.getAlignmentEnd)
+    assert(testAlignmentRecord.getMapq.toInt === testSAMRecord.getMappingQuality)
+    assert(testAlignmentRecord.getStart.toInt === (testSAMRecord.getAlignmentStart - 1))
+    assert(!testAlignmentRecord.getFirstOfPair)
+    assert(testAlignmentRecord.getFailedVendorQualityChecks === testSAMRecord.getReadFailsVendorQualityCheckFlag)
+    assert(!testAlignmentRecord.getPrimaryAlignment === testSAMRecord.getNotPrimaryAlignmentFlag)
+    assert(!testAlignmentRecord.getReadMapped === testSAMRecord.getReadUnmappedFlag)
+    assert(testAlignmentRecord.getReadName === testSAMRecord.getReadName)
+    assert(testAlignmentRecord.getReadNegativeStrand === testSAMRecord.getReadNegativeStrandFlag)
+    assert(!testAlignmentRecord.getReadPaired)
+    assert(!testAlignmentRecord.getSecondOfPair)
+    assert(testAlignmentRecord.getSupplementaryAlignment === testSAMRecord.getSupplementaryAlignmentFlag)
+  }
+
+  test("'*' quality gets nulled out") {
 
     val newRecordConverter = new SAMRecordConverter
     val newTestFile = new File(getClass.getClassLoader.getResource("unmapped.sam").getFile)
     val newSAMReader = SamReaderFactory.makeDefault().open(newTestFile)
 
-    //Obtain SAMRecord
+    // Obtain SAMRecord
     val newSAMRecordIter = {
       val samIter = asScalaIterator(newSAMReader.iterator())
       samIter.toIterable.dropWhile(!_.getReadUnmappedFlag())
     }
     val newSAMRecord = newSAMRecordIter.toIterator.next()
 
-    //SequenceRecord to be put into SequenceDictionary
+    // null out quality
+    newSAMRecord.setBaseQualityString("*")
+
+    // SequenceRecord to be put into SequenceDictionary
     val newSequenceRecord = new SequenceRecord("1", 249250621L)
 
-    //SequenceDictionary for conversion method
+    // SequenceDictionary for conversion method
     val newSequenceDictionary = SequenceDictionary(newSequenceRecord)
 
-    //No RecordGroup present in file so I'll just make the RecordGroupDictionary Empty
+    // No RecordGroup present in file so I'll just make the RecordGroupDictionary Empty
     val newTestRecordGroupDictionary = new RecordGroupDictionary(Seq())
 
-    //Conversion
+    // Conversion
     val newAlignmentRecord = newRecordConverter.convert(newSAMRecord, newSequenceDictionary, newTestRecordGroupDictionary)
 
-    //Validating Conversion
-    assert(newAlignmentRecord.getCigar === newSAMRecord.getCigarString)
-    assert(newAlignmentRecord.getDuplicateRead === newSAMRecord.getDuplicateReadFlag)
-    assert(newAlignmentRecord.getEnd === null)
-    assert(newAlignmentRecord.getMapq === null)
-    assert(newAlignmentRecord.getStart === null)
-    assert(newAlignmentRecord.getQual === newSAMRecord.getBaseQualityString)
-    assert(!newAlignmentRecord.getFirstOfPair)
-    assert(newAlignmentRecord.getFailedVendorQualityChecks === newSAMRecord.getReadFailsVendorQualityCheckFlag)
-    assert(!newAlignmentRecord.getReadMapped === newSAMRecord.getReadUnmappedFlag)
-    assert(newAlignmentRecord.getReadName === newSAMRecord.getReadName)
-    assert(newAlignmentRecord.getReadNegativeStrand === newSAMRecord.getReadNegativeStrandFlag)
-
+    // Validating Conversion
+    assert(newAlignmentRecord.getQual === null)
   }
 
 }

--- a/adam-core/src/test/scala/org/bdgenomics/adam/rich/DecadentReadSuite.scala
+++ b/adam-core/src/test/scala/org/bdgenomics/adam/rich/DecadentReadSuite.scala
@@ -68,4 +68,21 @@ class DecadentReadSuite extends FunSuite {
     assert(residueSeq.head.referencePosition === ReferencePosition("chr1", 1000))
   }
 
+  test("build a decadent read from a read with null qual") {
+    val contig = Contig.newBuilder
+      .setContigName("chr1")
+      .build
+
+    val hardClippedRead = RichAlignmentRecord(AlignmentRecord
+      .newBuilder()
+      .setReadMapped(true)
+      .setStart(1000)
+      .setContig(contig)
+      .setMismatchingPositions("10")
+      .setSequence("AACCTTGGC")
+      .setCigar("9M1H").build())
+
+    val record = DecadentRead(hardClippedRead)
+    assert(record.residues.size === 9)
+  }
 }


### PR DESCRIPTION
Resolves #646. Allows the creation of `DecadentRead`s with `*` quality scores. These reads are then not observed or corrected during BQSR.