### PR TITLE
fixed an issue where bytes corresponding to read name were being counted twice

### DIFF
--- a/adam-core/src/main/java/org/bdgenomics/adam/io/SingleFastqInputFormat.java
+++ b/adam-core/src/main/java/org/bdgenomics/adam/io/SingleFastqInputFormat.java
@@ -283,7 +283,6 @@ public class SingleFastqInputFormat extends FileInputFormat<Void,Text> {
             // ID line
             readName.clear();
             long skipped = appendLineInto(readName, true);
-            pos += skipped;
             if (skipped == 0)
                 return false; // EOF
             if (readName.getBytes()[0] != '@')


### PR DESCRIPTION
Issue : In 'SingleFastqInputFormat' class, bytes length corresponding to readname is skipped twice.
Impact : Recordreader will not read all the records. Records towards the end will be skipped because of range check (pos>=end) in next method.

Fix : Removed the redundant increment.