### PR TITLE
Fix imports for RealignIndels to allow instrumentation to work

### DIFF
--- a/adam-core/src/main/scala/org/bdgenomics/adam/rdd/read/realignment/RealignIndels.scala
+++ b/adam-core/src/main/scala/org/bdgenomics/adam/rdd/read/realignment/RealignIndels.scala
@@ -19,7 +19,7 @@ package org.bdgenomics.adam.rdd.read.realignment
 
 import htsjdk.samtools.{ Cigar, CigarElement, CigarOperator }
 import org.apache.spark.Logging
-import org.apache.spark.SparkContext._
+import org.apache.spark.rdd.MetricsContext._
 import org.apache.spark.rdd.RDD
 import org.bdgenomics.adam.algorithms.consensus.{ ConsensusGenerator, ConsensusGeneratorFromReads }
 import org.bdgenomics.adam.models.ReferenceRegion._

--- a/adam-core/src/main/scala/org/bdgenomics/adam/rdd/read/realignment/RealignmentTargetFinder.scala
+++ b/adam-core/src/main/scala/org/bdgenomics/adam/rdd/read/realignment/RealignmentTargetFinder.scala
@@ -19,12 +19,10 @@ package org.bdgenomics.adam.rdd.read.realignment
 
 import org.apache.spark.Logging
 import org.apache.spark.rdd.RDD
-import org.bdgenomics.adam.rdd.ADAMContext._
 import org.bdgenomics.adam.rich.RichAlignmentRecord
 import org.bdgenomics.adam.instrumentation.Timers._
 import scala.annotation.tailrec
 import scala.collection.immutable.TreeSet
-import com.sun.xml.internal.bind.v2.TODO
 
 object RealignmentTargetFinder {
 

--- a/adam-core/src/main/scala/org/bdgenomics/adam/rdd/read/recalibration/BaseQualityRecalibration.scala
+++ b/adam-core/src/main/scala/org/bdgenomics/adam/rdd/read/recalibration/BaseQualityRecalibration.scala
@@ -22,7 +22,6 @@ import org.apache.spark.SparkContext._
 import org.apache.spark.Logging
 import org.apache.spark.broadcast.Broadcast
 import org.apache.spark.rdd.RDD
-import org.bdgenomics.adam.rdd.ADAMContext._
 import org.bdgenomics.adam.models.SnpTable
 import org.bdgenomics.adam.rich.DecadentRead
 import org.bdgenomics.adam.rich.DecadentRead._


### PR DESCRIPTION
This removes an import of org.apache.spark.SparkContext._ which was causing indel realignment not to be instrumented, and replaces it with an import of org.apache.spark.rdd.MetricsContext._

Note that enabling instrumentation for indel realignment exposes a bug in BDG utils which leads to errors with negative durations. This bug is fixed in this PR: https://github.com/bigdatagenomics/utils/pull/35 but we will need to merge that and do another release of BDG utils before instrumentation will work properly for indel realignment.

I've also removed a couple of stray unused imports I added in a previous commit.