### PR TITLE
[ADAM-666] Clean up key not found error in partitioner code.

### DIFF
--- a/adam-core/src/main/scala/org/bdgenomics/adam/rdd/GenomicPartitioners.scala
+++ b/adam-core/src/main/scala/org/bdgenomics/adam/rdd/GenomicPartitioners.scala
@@ -77,10 +77,15 @@ case class GenomicPositionPartitioner(numParts: Int, seqLengths: Map[String, Lon
       case ReferencePosition.UNMAPPED => parts
 
       // everything else gets assigned normally.
-      case refpos: ReferencePosition  => getPart(refpos.referenceName, refpos.pos)
+      case refpos: ReferencePosition => {
+        require(seqLengths.contains(refpos.referenceName),
+          "Received key (%s) that did not map to a known contig. Contigs are:\n%s".format(refpos,
+            seqLengths.keys.mkString("\n")))
+        getPart(refpos.referenceName, refpos.pos)
+      }
 
       // only ReferencePosition values are partitioned using this partitioner
-      case _                          => throw new IllegalArgumentException("Only ReferencePosition values can be partitioned by GenomicPositionPartitioner")
+      case _ => throw new IllegalArgumentException("Only ReferencePosition values can be partitioned by GenomicPositionPartitioner")
     }
   }
 
@@ -114,8 +119,13 @@ case class GenomicRegionPartitioner(partitionSize: Long, seqLengths: Map[String,
 
   override def getPartition(key: Any): Int = {
     key match {
-      case region: ReferenceRegion => computePartition(region)
-      case _                       => throw new IllegalArgumentException("Only ReferenceMappable values can be partitioned by GenomicRegionPartitioner")
+      case region: ReferenceRegion => {
+        require(seqLengths.contains(region.referenceName),
+          "Received key (%s) that did not map to a known contig. Contigs are:\n%s".format(region,
+            seqLengths.keys.mkString("\n")))
+        computePartition(region)
+      }
+      case _ => throw new IllegalArgumentException("Only ReferenceMappable values can be partitioned by GenomicRegionPartitioner")
     }
   }
 }

--- a/adam-core/src/test/scala/org/bdgenomics/adam/rdd/GenomicPositionPartitionerSuite.scala
+++ b/adam-core/src/test/scala/org/bdgenomics/adam/rdd/GenomicPositionPartitionerSuite.scala
@@ -36,6 +36,15 @@ class GenomicPositionPartitionerSuite extends ADAMFunSuite {
     assert(parter.getPartition(ReferencePosition.UNMAPPED) === 10)
   }
 
+  test("if we do not have a contig for a record, we throw an IAE") {
+    val parter = GenomicPositionPartitioner(10, SequenceDictionary(record("foo", 1000)))
+
+    assert(parter.numPartitions === 11)
+    intercept[IllegalArgumentException] {
+      parter.getPartition(ReferencePosition("chrFoo", 10))
+    }
+  }
+
   test("partitioning into N pieces on M total sequence length, where N > M, results in M partitions") {
     val parter = GenomicPositionPartitioner(10, SequenceDictionary(record("foo", 9)))
     assert(parter.numPartitions === 10)


### PR DESCRIPTION
Resolves #666. Checks sequence dictionary when partitioning keys and throws an `IllegalArgumentException` with the violating key and a list of known contigs.