### PR TITLE
Revert "[ADAM-699] upgrade to htsjdk 1.133"

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -25,7 +25,7 @@
     <hadoop.version>2.2.0</hadoop.version>
     <scoverage.version>0.99.2</scoverage.version>
     <utils.version>0.2.1</utils.version>
-    <htsjdk.version>1.133</htsjdk.version>
+    <htsjdk.version>1.129</htsjdk.version>
   </properties>
   
   <modules>


### PR DESCRIPTION
This reverts commit 1adc0db7700c4d9d435fcda35e6306ef97d2c098. I believe this change is causing https://groups.google.com/forum/#!topic/adam-developers/IxbS4WW3luY. I think we need to fix the VCF file splitter upstream in Hadoop-BAM. CC @ryan-williams