### PR TITLE
[ADAM-718] Use filesystem path to get underlying file system.

### DIFF
--- a/adam-core/src/main/scala/org/bdgenomics/adam/rdd/ADAMContext.scala
+++ b/adam-core/src/main/scala/org/bdgenomics/adam/rdd/ADAMContext.scala
@@ -232,8 +232,8 @@ class ADAMContext(val sc: SparkContext) extends Serializable with Logging {
   def loadBam(
     filePath: String): RDD[AlignmentRecord] = {
 
-    val fs = FileSystem.get(sc.hadoopConfiguration)
     val path = new Path(filePath)
+    val fs = FileSystem.get(path.toUri, sc.hadoopConfiguration)
     val bamFiles = if (fs.isDirectory(path)) fs.listStatus(path) else fs.globStatus(path)
     val (seqDict, readGroups) = bamFiles
       .map(fs => fs.getPath)


### PR DESCRIPTION
Resolves #718. Uses @jfeala's proposed fix. @jfeala, let me know if you'd like credit on the commit and I'll modify the commit author.