### PR TITLE
[ADAM-729] Stuff TLEN into attributes.

### DIFF
--- a/adam-core/src/main/scala/org/bdgenomics/adam/converters/AlignmentRecordConverter.scala
+++ b/adam-core/src/main/scala/org/bdgenomics/adam/converters/AlignmentRecordConverter.scala
@@ -163,7 +163,11 @@ class AlignmentRecordConverter extends Serializable {
     if (adamRecord.getAttributes != null) {
       val mp = RichAlignmentRecord(adamRecord).tags
       mp.foreach(a => {
-        builder.setAttribute(a.tag, a.value)
+        if (a.tag == "TLEN") {
+          builder.setInferredInsertSize(a.value.asInstanceOf[Integer])
+        } else {
+          builder.setAttribute(a.tag, a.value)
+        }
       })
     }
 

--- a/adam-core/src/main/scala/org/bdgenomics/adam/converters/SAMRecordConverter.scala
+++ b/adam-core/src/main/scala/org/bdgenomics/adam/converters/SAMRecordConverter.scala
@@ -28,7 +28,8 @@ import org.bdgenomics.adam.models.{
   Attribute,
   RecordGroupDictionary,
   SequenceDictionary,
-  SequenceRecord
+  SequenceRecord,
+  TagType
 }
 import org.bdgenomics.adam.util.AttributeUtils
 import org.bdgenomics.formats.avro.AlignmentRecord
@@ -168,8 +169,12 @@ class SAMRecordConverter extends Serializable with Logging {
         }
       }
 
+      var tags = List[Attribute]()
+      val tlen = samRecord.getInferredInsertSize
+      if (tlen != 0) {
+        tags ::= Attribute("TLEN", TagType.Integer, tlen)
+      }
       if (samRecord.getAttributes != null) {
-        var tags = List[Attribute]()
         samRecord.getAttributes.asScala.foreach {
           attr =>
             if (attr.tag == "MD") {
@@ -178,6 +183,8 @@ class SAMRecordConverter extends Serializable with Logging {
               tags ::= AttributeUtils.convertSAMTagAndValue(attr)
             }
         }
+      }
+      if (!tags.isEmpty) {
         builder.setAttributes(tags.mkString("\t"))
       }
 


### PR DESCRIPTION
Resolves #729. Ensures that TLEN is pushed back into the correct place in SAM on conversion back.