### PR TITLE
Fixed bug preventing use of TLEN attribute

### DIFF
--- a/adam-core/src/main/scala/org/bdgenomics/adam/util/AttributeUtils.scala
+++ b/adam-core/src/main/scala/org/bdgenomics/adam/util/AttributeUtils.scala
@@ -27,7 +27,7 @@ import org.bdgenomics.adam.models.{ TagType, Attribute }
  */
 object AttributeUtils {
 
-  val attrRegex = RegExp("([^:]{2}):([AifZHB]):(.*)")
+  val attrRegex = RegExp("([^:]{2,4}):([AifZHB]):(.*)")
 
   def convertSAMTagAndValue(attr: SAMTagAndValue): Attribute = {
     attr.value match {


### PR DESCRIPTION
Expanded definition of attribute strings to allow for attribute names of up to four characters. 