### PR TITLE
Upgrade to Parquet 1.8.1.

### DIFF
--- a/adam-core/src/main/scala/org/bdgenomics/adam/rdd/ADAMRDDFunctions.scala
+++ b/adam-core/src/main/scala/org/bdgenomics/adam/rdd/ADAMRDDFunctions.scala
@@ -144,6 +144,6 @@ class ADAMSpecificRecordSequenceDictionaryRDDAggregator[T <% IndexedRecord: Mani
 }
 
 class InstrumentedADAMAvroParquetOutputFormat extends InstrumentedOutputFormat[Void, IndexedRecord] {
-  override def outputFormatClass(): Class[_ <: NewOutputFormat[Void, IndexedRecord]] = classOf[AvroParquetOutputFormat]
+  override def outputFormatClass(): Class[_ <: NewOutputFormat[Void, IndexedRecord]] = classOf[AvroParquetOutputFormat[IndexedRecord]]
   override def timerName(): String = WriteADAMRecord.timerName
 }

--- a/pom.xml
+++ b/pom.xml
@@ -20,7 +20,7 @@
     <java.version>1.7</java.version>
     <avro.version>1.7.6</avro.version>
     <spark.version>1.2.0</spark.version>
-    <parquet.version>1.7.0</parquet.version>
+    <parquet.version>1.8.1</parquet.version>
     <!-- Edit the following line to configure the Hadoop (HDFS) version. -->
     <hadoop.version>2.2.0</hadoop.version>
     <scoverage.version>0.99.2</scoverage.version>


### PR DESCRIPTION
This fixes an issue that appears when using `and`ed predicates to drop blocks on statistics; specifically, there is a bug pre-1.8.0 where fewer blocks are dropped than should be, which leads to bad performance.