### PR TITLE
We should print a warning message if the user has ADAM_OPTS set.

### DIFF
--- a/bin/adam-shell
+++ b/bin/adam-shell
@@ -22,6 +22,12 @@ ADAM_REPO="$(cd `dirname $0`/..; pwd)"
 
 ADAM_JARS=$("$ADAM_REPO"/bin/compute-adam-jars.sh)
 
+# does the user have ADAM_OPTS set? if yes, then warn
+if [[ -z $@ && -n "$ADAM_OPTS" ]]; then
+    echo "WARNING: Passing Spark arguments via ADAM_OPTS was recently removed."
+    echo "Run adam-shell instead as adam-shell <spark-args>"
+fi
+
 # append ADAM_JARS to the --jars option, if any
 NEW_OPTIONS=$("$ADAM_REPO"/bin/append_to_option.py , --jars "$ADAM_JARS" "$@")
 

--- a/bin/adam-submit
+++ b/bin/adam-submit
@@ -43,6 +43,12 @@ else
   ADAM_ARGS="${PRE_DD[@]}"
 fi
 
+# does the user have ADAM_OPTS set? if yes, then warn
+if [[ $DD == False && -n "$ADAM_OPTS" ]]; then
+    echo "WARNING: Passing Spark arguments via ADAM_OPTS was recently removed."
+    echo "Run adam-submit instead as adam-submit <spark-args> -- <adam-args>"
+fi
+
 # Figure out where ADAM is installed
 SCRIPT_DIR="$(cd `dirname $0`/..; pwd)"
 


### PR DESCRIPTION
Since we removed `ADAM_OPTS` in #754, we should warn the user if they have ADAM_OPTS set and aren't passing any Spark options otherwise.