### PR TITLE
[ADAM-769] Fix serialization issue in known indel consensus model.

### DIFF
--- a/adam-core/src/main/scala/org/bdgenomics/adam/algorithms/consensus/ConsensusGeneratorFromKnowns.scala
+++ b/adam-core/src/main/scala/org/bdgenomics/adam/algorithms/consensus/ConsensusGeneratorFromKnowns.scala
@@ -24,8 +24,9 @@ import org.bdgenomics.adam.rdd.ADAMContext._
 import org.bdgenomics.adam.rdd.read.realignment.IndelRealignmentTarget
 import org.bdgenomics.adam.rich.RichAlignmentRecord
 import org.bdgenomics.formats.avro.Variant
+import scala.transient
 
-class ConsensusGeneratorFromKnowns(file: String, sc: SparkContext) extends ConsensusGenerator {
+class ConsensusGeneratorFromKnowns(file: String, @transient sc: SparkContext) extends ConsensusGenerator {
 
   val indelTable = sc.broadcast(IndelTable(file, sc))
 

--- a/adam-core/src/main/scala/org/bdgenomics/adam/models/Consensus.scala
+++ b/adam-core/src/main/scala/org/bdgenomics/adam/models/Consensus.scala
@@ -20,7 +20,7 @@ package org.bdgenomics.adam.models
 import htsjdk.samtools.{ Cigar, CigarOperator }
 import org.bdgenomics.adam.util.ImplicitJavaConversions._
 
-object Consensus {
+object Consensus extends Serializable {
 
   def generateAlternateConsensus(sequence: String, start: ReferencePosition, cigar: Cigar): Option[Consensus] = {
 


### PR DESCRIPTION
Resolves #769. There was a `SparkContext` in the known indel consensus model that was not annotated with transient, which caused the serialization issues.