### PR TITLE
Fix SAM Attribute parser for numeric array tags

### DIFF
--- a/adam-core/src/main/scala/org/bdgenomics/adam/util/AttributeUtils.scala
+++ b/adam-core/src/main/scala/org/bdgenomics/adam/util/AttributeUtils.scala
@@ -93,7 +93,7 @@ object AttributeUtils {
       case TagType.Float        => java.lang.Float.valueOf(valueStr)
       case TagType.String       => valueStr
       case TagType.ByteSequence => valueStr.map(c => java.lang.Byte.valueOf("" + c))
-      case TagType.NumericSequence => valueStr.split(",").map(c => {
+      case TagType.NumericSequence => valueStr.substring(2).split(",").map(c => {
         if (c.contains(".")) java.lang.Float.valueOf(c)
         else Integer.valueOf(c)
       })

--- a/adam-core/src/test/scala/org/bdgenomics/adam/util/AttributeUtilsSuite.scala
+++ b/adam-core/src/test/scala/org/bdgenomics/adam/util/AttributeUtilsSuite.scala
@@ -39,6 +39,16 @@ class AttributeUtilsSuite extends FunSuite {
     assert(tags(1).value === "foo,bar")
   }
 
+  test("parseTags works with NumericSequence tagType") {
+    val tags = parseAttributes("jM:B:c,-1\tjI:B:i,-1,1")
+
+    assert(tags(0).tag === "jM")
+    assert(tags(0).tagType === TagType.NumericSequence)
+    assert(tags(0).value.asInstanceOf[Array[Number]].sameElements(Array(-1)))
+    assert(tags(1).value.asInstanceOf[Array[Number]].sameElements(Array(-1, 1)))
+
+  }
+
   test("empty string is parsed as zero tagStrings") {
     assert(parseAttributes("") === Seq[Attribute]())
   }


### PR DESCRIPTION
Page 6 of the SAMv1 specs allow for numeric array tags (TYPE="B"), with values matching:
```
[cCsSiIf](,[-+]?[0-9]*\.?[0-9]+([eE][-+]?[0-9]+)?)+
```
This update of `org.bdgenomics.adam.util.AttributeUtils.typedStringToValue` skips the first character (a numeric type specifier) plus the leading comma, before trying to convert to a numeric array. This bug was breaking `loadAlignments` for BAM files generated by the STAR RNA-Seq aligner, which creates type "B" tags by default.