### PR TITLE
Allow all IUPAC codes in BQSR

### DIFF
--- a/adam-core/src/main/java/org/bdgenomics/adam/io/BAMFilteredRecordReader.scala
+++ b/adam-core/src/main/java/org/bdgenomics/adam/io/BAMFilteredRecordReader.scala
@@ -1,0 +1,161 @@
+/**
+ * Licensed to Big Data Genomics (BDG) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The BDG licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.bdgenomics.adam.io
+
+import hbparquet.hadoop.util.ContextUtil
+import htsjdk.samtools.BAMRecordCodec
+import htsjdk.samtools.ValidationStringency
+import htsjdk.samtools.SAMRecord
+import htsjdk.samtools.util.BlockCompressedInputStream
+import org.apache.hadoop.conf.Configuration
+import org.apache.hadoop.fs.FileSystem
+import org.apache.hadoop.fs.FSDataInputStream
+import org.apache.hadoop.fs.Path
+import org.apache.hadoop.io.LongWritable
+import org.apache.hadoop.mapreduce.InputSplit
+import org.apache.hadoop.mapreduce.RecordReader
+import org.apache.hadoop.mapreduce.TaskAttemptContext
+import org.bdgenomics.adam.models.ReferenceRegion
+import org.seqdoop.hadoop_bam.util.SAMHeaderReader
+import org.seqdoop.hadoop_bam.util.WrapSeekable
+import org.seqdoop.hadoop_bam.SAMRecordWritable
+import org.seqdoop.hadoop_bam.BAMRecordReader
+import org.seqdoop.hadoop_bam.FileVirtualSplit
+import org.seqdoop.hadoop_bam.BAMInputFormat
+import scala.annotation.tailrec
+
+object BAMFilteredRecordReader {
+  private var optViewRegion: Option[ReferenceRegion] = None
+
+  def setRegion(viewRegion: ReferenceRegion) {
+    optViewRegion = Some(viewRegion)
+  }
+}
+
+/**
+ * Scala implementation of BAMRecordReader, but with
+ * nextKeyValue() that filters by ReferenceRegion
+ */
+class BAMFilteredRecordReader extends BAMRecordReader {
+
+  val key: LongWritable = new LongWritable()
+  val record: SAMRecordWritable = new SAMRecordWritable
+
+  var stringency: ValidationStringency = _
+
+  var bci: BlockCompressedInputStream = _
+  var codec: BAMRecordCodec = _
+  var fileStart: Long = _
+  var virtualEnd: Long = _
+  var isInitialized: Boolean = false
+
+  override def initialize(spl: InputSplit, ctx: TaskAttemptContext) {
+    // Check to ensure this method is only be called once (see Hadoop API)
+    if (isInitialized) {
+      close()
+    }
+    isInitialized = true
+
+    val conf: Configuration = ContextUtil.getConfiguration(ctx)
+
+    val split: FileVirtualSplit = spl.asInstanceOf[FileVirtualSplit]
+    val file: Path = split.getPath()
+    val fs: FileSystem = file.getFileSystem(conf)
+
+    this.stringency = SAMHeaderReader.getValidationStringency(conf)
+
+    val in: FSDataInputStream = fs.open(file)
+
+    // Sets codec to translate between in-memory and disk representation of record
+    codec = new BAMRecordCodec(SAMHeaderReader.readSAMHeaderFrom(in, conf))
+
+    in.seek(0)
+
+    bci = new BlockCompressedInputStream(
+      new WrapSeekable[FSDataInputStream](
+        in, fs.getFileStatus(file).getLen(), file))
+
+    // Gets BGZF virtual offset for the split
+    val virtualStart = split.getStartVirtualOffset()
+
+    fileStart = virtualStart >>> 16
+    virtualEnd = split.getEndVirtualOffset()
+
+    // Starts looking from the BGZF virtual offset
+    bci.seek(virtualStart)
+    // Reads records from this input stream
+    codec.setInputStream(bci)
+  }
+
+  override def close() = {
+    bci.close()
+  }
+
+  override def getCurrentKey(): LongWritable = {
+    key
+  }
+
+  override def getCurrentValue(): SAMRecordWritable = {
+    record
+  }
+
+  /**
+   * This method gets the nextKeyValue for our RecordReader, but filters by only
+   * returning records within a specified ReferenceRegion.
+   * This function is tail recursive to avoid stack overflow when predicate data
+   * can be sparse.
+   */
+  @tailrec final override def nextKeyValue(): Boolean = {
+    if (bci.getFilePointer() >= virtualEnd) {
+      false
+    } else {
+      val r: SAMRecord = codec.decode()
+
+      // Since we're reading from a BAMRecordCodec directly we have to set the
+      // validation stringency ourselves.
+      if (this.stringency != null) {
+        r.setValidationStringency(this.stringency)
+      }
+
+      // This if/else block pushes the predicate down onto a BGZIP block that 
+      // the index has said contains data in our specified region.
+      if (r == null) {
+        false
+      } else {
+        val start = r.getStart
+        val end = r.getEnd
+        val refReg = BAMFilteredRecordReader.optViewRegion.get
+        val regStart = refReg.start
+        val regEnd = refReg.end
+
+        if ((r.getContig() == refReg.referenceName) &&
+          (((start >= regStart) && (end <= regEnd))
+            || ((start <= regStart) && (end >= regStart) && (end <= regEnd))
+            || ((end >= regEnd) && (start >= regStart) && (start <= regEnd)))) {
+          key.set(BAMRecordReader.getKey(r))
+          record.set(r)
+          true
+        } else {
+          nextKeyValue()
+        }
+      }
+    }
+  }
+
+}

--- a/adam-core/src/main/java/org/bdgenomics/adam/io/IndexedBamInputFormat.scala
+++ b/adam-core/src/main/java/org/bdgenomics/adam/io/IndexedBamInputFormat.scala
@@ -1,0 +1,102 @@
+/**
+ * Licensed to Big Data Genomics (BDG) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The BDG licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package htsjdk.samtools
+
+import htsjdk.samtools.util.BlockCompressedFilePointerUtil
+import java.io.File
+import java.io.FileNotFoundException
+import org.apache.hadoop.fs.{ FileSystem, Path }
+import org.apache.hadoop.io.LongWritable
+import org.apache.hadoop.mapreduce.JobContext
+import org.apache.hadoop.mapreduce.RecordReader
+import org.apache.hadoop.mapreduce.InputSplit
+import org.apache.hadoop.mapreduce.TaskAttemptContext
+import org.apache.hadoop.mapreduce.lib.input.FileSplit
+import org.bdgenomics.adam.models.ReferenceRegion
+import org.bdgenomics.adam.rdd.ADAMContext._
+import org.bdgenomics.adam.io.BAMFilteredRecordReader
+import org.seqdoop.hadoop_bam.BAMInputFormat
+import org.seqdoop.hadoop_bam.FileVirtualSplit
+import org.seqdoop.hadoop_bam.SAMRecordWritable
+import scala.collection.mutable
+
+object IndexedBamInputFormat {
+
+  private var optFilePath: Option[Path] = None
+  private var optIndexFilePath: Option[Path] = None
+  private var optViewRegion: Option[ReferenceRegion] = None
+  private var optDict: Option[SAMSequenceDictionary] = None
+
+  def setVars(filePath: Path, indexFilePath: Path, viewRegion: ReferenceRegion, dict: SAMSequenceDictionary) {
+    optFilePath = Some(filePath)
+    optIndexFilePath = Some(indexFilePath)
+    optViewRegion = Some(viewRegion)
+    optDict = Some(dict)
+  }
+
+}
+
+class IndexedBamInputFormat extends BAMInputFormat {
+
+  override def createRecordReader(split: InputSplit, ctx: TaskAttemptContext): RecordReader[LongWritable, SAMRecordWritable] = {
+    val rr: RecordReader[LongWritable, SAMRecordWritable] = new BAMFilteredRecordReader()
+    assert(IndexedBamInputFormat.optViewRegion.isDefined)
+    BAMFilteredRecordReader.setRegion(IndexedBamInputFormat.optViewRegion.get)
+    rr.initialize(split, ctx)
+    rr
+  }
+
+  override def getSplits(job: JobContext): java.util.List[InputSplit] = {
+    assert(IndexedBamInputFormat.optIndexFilePath.isDefined &&
+      IndexedBamInputFormat.optFilePath.isDefined &&
+      IndexedBamInputFormat.optViewRegion.isDefined &&
+      IndexedBamInputFormat.optDict.isDefined)
+
+    val indexFilePath = IndexedBamInputFormat.optIndexFilePath.get
+
+    val idxFile: File = new File(indexFilePath.toString)
+    if (!idxFile.exists()) {
+      throw new java.io.FileNotFoundException("Bam index file not provided")
+    } else {
+      // Use index to get the chunks for a specific region, then use them to create InputSplits
+      val filePath = IndexedBamInputFormat.optFilePath.get
+      val viewRegion = IndexedBamInputFormat.optViewRegion.get
+      val refName = viewRegion.referenceName
+      val dict = IndexedBamInputFormat.optDict.get
+      val start = viewRegion.start.toInt
+      val end = viewRegion.end.toInt
+      val dbbfi: DiskBasedBAMFileIndex = new DiskBasedBAMFileIndex(idxFile, dict)
+      val referenceIndex: Int = dict.getSequenceIndex(refName)
+      // Get the chunks in the region we want (chunks give start and end file pointers into a BAM file)
+      var regions: List[Chunk] = dbbfi.getSpanOverlapping(referenceIndex, start, end).getChunks
+
+      var splits = new mutable.ListBuffer[FileVirtualSplit]()
+      for (chunk <- regions) {
+        // Create InputSplits from chunks in a given region
+        val start: Long = chunk.getChunkStart()
+        val end: Long = chunk.getChunkEnd()
+        val locs = Array[String]()
+        val newSplit = new FileVirtualSplit(filePath, start, end, locs)
+        splits += newSplit
+      }
+      splits.toList
+    }
+  }
+
+}

--- a/adam-core/src/main/scala/org/bdgenomics/adam/rdd/read/recalibration/DinucCovariate.scala
+++ b/adam-core/src/main/scala/org/bdgenomics/adam/rdd/read/recalibration/DinucCovariate.scala
@@ -56,7 +56,7 @@ class DinucCovariate extends AbstractCovariate[(Char, Char)] {
       case 'T' => 'A'
       case 'C' => 'G'
       case 'G' => 'C'
-      case 'N' => 'N'
+      case 'W' | 'S' | 'Y' | 'R' | 'M' | 'K' | 'B' | 'D' | 'V' | 'H' | 'N' => 'N'
     }
   }
 

--- a/adam-core/src/main/scala/org/bdgenomics/adam/util/AttributeUtils.scala
+++ b/adam-core/src/main/scala/org/bdgenomics/adam/util/AttributeUtils.scala
@@ -93,7 +93,7 @@ object AttributeUtils {
       case TagType.Float        => java.lang.Float.valueOf(valueStr)
       case TagType.String       => valueStr
       case TagType.ByteSequence => valueStr.map(c => java.lang.Byte.valueOf("" + c))
-      case TagType.NumericSequence => valueStr.split(",").map(c => {
+      case TagType.NumericSequence => valueStr.substring(2).split(",").map(c => {
         if (c.contains(".")) java.lang.Float.valueOf(c)
         else Integer.valueOf(c)
       })

--- a/adam-core/src/test/scala/org/bdgenomics/adam/util/AttributeUtilsSuite.scala
+++ b/adam-core/src/test/scala/org/bdgenomics/adam/util/AttributeUtilsSuite.scala
@@ -39,6 +39,16 @@ class AttributeUtilsSuite extends FunSuite {
     assert(tags(1).value === "foo,bar")
   }
 
+  test("parseTags works with NumericSequence tagType") {
+    val tags = parseAttributes("jM:B:c,-1\tjI:B:i,-1,1")
+
+    assert(tags(0).tag === "jM")
+    assert(tags(0).tagType === TagType.NumericSequence)
+    assert(tags(0).value.asInstanceOf[Array[Number]].sameElements(Array(-1)))
+    assert(tags(1).value.asInstanceOf[Array[Number]].sameElements(Array(-1, 1)))
+
+  }
+
   test("empty string is parsed as zero tagStrings") {
     assert(parseAttributes("") === Seq[Attribute]())
   }

--- a/pom.xml
+++ b/pom.xml
@@ -19,7 +19,7 @@
   <properties>
     <java.version>1.7</java.version>
     <avro.version>1.7.6</avro.version>
-    <spark.version>1.2.0</spark.version>
+    <spark.version>1.4.1</spark.version>
     <parquet.version>1.8.1</parquet.version>
     <!-- Edit the following line to configure the Hadoop (HDFS) version. -->
     <hadoop.version>2.2.0</hadoop.version>


### PR DESCRIPTION
Match IUPAC codes other than ACTG to N to avoid match errors on older datasets.