### PR TITLE
[ADAM-785] Add support for all numeric array (TYPE=B) tags, fixes #785

### DIFF
--- a/adam-core/src/main/scala/org/bdgenomics/adam/models/Attribute.scala
+++ b/adam-core/src/main/scala/org/bdgenomics/adam/models/Attribute.scala
@@ -29,7 +29,22 @@ package org.bdgenomics.adam.models
  * @param value The 'value' half of the pair.
  */
 case class Attribute(tag: String, tagType: TagType.Value, value: Any) {
-  override def toString: String = "%s:%s:%s".format(tag, tagType, value.toString)
+  override def toString: String = {
+    val byteSequenceTypes = Array(TagType.NumericByteSequence, TagType.NumericUnsignedByteSequence)
+    val intSequenceTypes = Array(TagType.NumericIntSequence, TagType.NumericUnsignedIntSequence)
+    val shortSequenceTypes = Array(TagType.NumericShortSequence, TagType.NumericUnsignedShortSequence)
+    if (byteSequenceTypes contains tagType) {
+      "%s:%s,%s".format(tag, tagType, value.asInstanceOf[Array[Byte]].mkString(","))
+    } else if (shortSequenceTypes contains tagType) {
+      "%s:%s,%s".format(tag, tagType, value.asInstanceOf[Array[Short]].mkString(","))
+    } else if (intSequenceTypes contains tagType) {
+      "%s:%s,%s".format(tag, tagType, value.asInstanceOf[Array[Int]].mkString(","))
+    } else if (tagType == TagType.NumericFloatSequence) {
+      "%s:%s,%s".format(tag, tagType, value.asInstanceOf[Array[Float]].mkString(","))
+    } else {
+      "%s:%s:%s".format(tag, tagType, value.toString)
+    }
+  }
 }
 
 object TagType extends Enumeration {
@@ -45,6 +60,12 @@ object TagType extends Enumeration {
   val Float = TypeValue("f")
   val String = TypeValue("Z")
   val ByteSequence = TypeValue("H")
-  val NumericSequence = TypeValue("B")
+  val NumericByteSequence = TypeValue("B:c")
+  val NumericIntSequence = TypeValue("B:i")
+  val NumericShortSequence = TypeValue("B:s")
+  val NumericUnsignedByteSequence = TypeValue("B:C")
+  val NumericUnsignedIntSequence = TypeValue("B:I")
+  val NumericUnsignedShortSequence = TypeValue("B:S")
+  val NumericFloatSequence = TypeValue("B:f")
 
 }

--- a/adam-core/src/main/scala/org/bdgenomics/adam/util/AttributeUtils.scala
+++ b/adam-core/src/main/scala/org/bdgenomics/adam/util/AttributeUtils.scala
@@ -81,11 +81,10 @@ object AttributeUtils {
   private def createAttribute(attrTuple: (String, String, String, String)): Attribute = {
     val tagName = attrTuple._1
     val tagTypeString = attrTuple._2
-    val tagArrayString = attrTuple._3
+    val tagArrayString: Option[String] = Option(attrTuple._3)
     val valueStr = attrTuple._4
 
-    val fullTagString = if (tagArrayString == null) tagTypeString else
-      tagTypeString ++ ":" ++ tagArrayString
+    val fullTagString = tagArrayString.fold(tagTypeString)(arrayString => "%s:%s".format(tagTypeString, arrayString))
 
     // partial match, but these letters should be (per the SAM file format spec)
     // the only legal values of the tagTypeString anyway.

--- a/adam-core/src/test/resources/tags.sam
+++ b/adam-core/src/test/resources/tags.sam
@@ -1,0 +1,9 @@
+@HD	VN:1.4	SO:coordinate
+@SQ	SN:1	LN:1000
+StandardTags	0	1	1	255	10M	*	0	0	ACACACACAC	**********	NM:i:0	MD:Z:10 XS:A:-
+MDTagWithEdits	0	1	1	255	10M	*	0	0	ACAGACACTC	**********	NM:i:2	MD:Z:3G4T1
+HexByteArray	0	1	1	255	10M	*	0	0	ACACACACAC	**********	NM:i:0	MD:Z:10	XB:H:010203
+LengthOneArrays	0	1	1	255	10M	*	0	0	ACACACACAC	**********	NM:i:0	MD:Z:10	XB:B:c,1	XI:B:i,1	XS:B:s,1	XF:B:f,1
+LongerArrays	0	1	1	255	10M	*	0	0	ACACACACAC	**********	NM:i:0	MD:Z:10	XB:B:c,1,2,3	XI:B:i,1,2,3	XS:B:s,1,2,3	XS:B:f,1,2,3
+SignedArrays	0	1	1	255	10M	*	0	0	ACACACACAC	**********	NM:i:0	MD:Z:10	XB:B:c,-1	XI:B:i,-1	XS:B:s,-1
+UnsignedArrays	0	1	1	255	10M	*	0	0	ACACACACAC	**********	NM:i:0	MD:Z:10	XB:B:C,1,2,3	XI:B:I,1,2,3	XS:B:S,1,2,3

--- a/adam-core/src/test/scala/org/bdgenomics/adam/rdd/ADAMContextSuite.scala
+++ b/adam-core/src/test/scala/org/bdgenomics/adam/rdd/ADAMContextSuite.scala
@@ -63,6 +63,12 @@ class ADAMContextSuite extends ADAMFunSuite {
     assert(reads.count() === 20)
   }
 
+  sparkTest("can read a small .SAM with all attribute tag types") {
+    val path = ClassLoader.getSystemClassLoader.getResource("tags.sam").getFile
+    val reads: RDD[AlignmentRecord] = sc.loadAlignments(path)
+    assert(reads.count() === 7)
+  }
+
   sparkTest("can filter a .SAM file based on quality") {
     val path = ClassLoader.getSystemClassLoader.getResource("small.sam").getFile
     val reads: RDD[AlignmentRecord] = sc.loadAlignments(path)

--- a/adam-core/src/test/scala/org/bdgenomics/adam/util/AttributeUtilsSuite.scala
+++ b/adam-core/src/test/scala/org/bdgenomics/adam/util/AttributeUtilsSuite.scala
@@ -19,6 +19,7 @@ package org.bdgenomics.adam.util
 
 import org.scalatest._
 import htsjdk.samtools.SAMRecord.SAMTagAndValue
+import htsjdk.samtools.TextTagCodec
 import org.bdgenomics.adam.models.{ Attribute, TagType }
 
 class AttributeUtilsSuite extends FunSuite {
@@ -43,7 +44,7 @@ class AttributeUtilsSuite extends FunSuite {
     val tags = parseAttributes("jM:B:c,-1\tjI:B:i,-1,1")
 
     assert(tags(0).tag === "jM")
-    assert(tags(0).tagType === TagType.NumericSequence)
+    assert(tags(0).tagType === TagType.NumericByteSequence)
     assert(tags(0).value.asInstanceOf[Array[Number]].sameElements(Array(-1)))
     assert(tags(1).value.asInstanceOf[Array[Number]].sameElements(Array(-1, 1)))
 
@@ -73,18 +74,68 @@ class AttributeSuite extends FunSuite {
   import AttributeUtils._
 
   test("test SAMTagAndValue parsing") {
-    assert(convertSAMTagAndValue(new SAMTagAndValue("XY", 3)) === Attribute("XY", TagType.Integer, 3))
-    assert(convertSAMTagAndValue(new SAMTagAndValue("XY", "foo")) === Attribute("XY", TagType.String, "foo"))
-    assert(convertSAMTagAndValue(new SAMTagAndValue("XY", 3.0f)) === Attribute("XY", TagType.Float, 3.0f))
-    assert(convertSAMTagAndValue(new SAMTagAndValue("XY", 'a')) === Attribute("XY", TagType.Character, 'a'))
+    // Build SAMTagAndValue using the same string parser as htsjdk
+    def createSAMTagAndValue(tagString: String): SAMTagAndValue = {
+      val tagMap = new TextTagCodec().decode(tagString)
+      new SAMTagAndValue(tagMap.getKey(), tagMap.getValue())
+    }
+    // Simple tag types
+    assert(convertSAMTagAndValue(createSAMTagAndValue("XY:i:3")) === Attribute("XY", TagType.Integer, 3))
+    assert(convertSAMTagAndValue(createSAMTagAndValue("XY:Z:foo")) === Attribute("XY", TagType.String, "foo"))
+    assert(convertSAMTagAndValue(createSAMTagAndValue("XY:f:3.0")) === Attribute("XY", TagType.Float, 3.0f))
+    assert(convertSAMTagAndValue(createSAMTagAndValue("XY:A:a")) === Attribute("XY", TagType.Character, 'a'))
+
+    // Array tag types
+    val intArray = Array(1, 2, 3)
+    assert(convertSAMTagAndValue(createSAMTagAndValue("XY:B:i,1,2,3")).toString ===
+      Attribute("XY", TagType.NumericIntSequence, intArray).toString)
+
+    val shortArray: Array[Short] = Array(1, 2, 3).map(_.toShort)
+    assert(convertSAMTagAndValue(createSAMTagAndValue("XY:B:s,1,2,3")).toString ===
+      Attribute("XY", TagType.NumericShortSequence, shortArray).toString)
+
+    val floatArray = Array(1.0f, 2.0f, 3.0f)
+    assert(convertSAMTagAndValue(createSAMTagAndValue("XY:B:f,1.0,2.0,3.0")).toString ===
+      Attribute("XY", TagType.NumericFloatSequence, floatArray).toString)
+
+    // Two forms of Byte arrays, type B:c and type H, indistinguishable by SAMTagAndValue
+    val byteArray: Array[Byte] = Array(1, 2, 3).map(_.toByte)
+    assert(convertSAMTagAndValue(createSAMTagAndValue("XY:B:c,1,2,3")).toString ===
+      Attribute("XY", TagType.NumericByteSequence, byteArray).toString)
+    assert(convertSAMTagAndValue(createSAMTagAndValue("XY:H:010203")).toString ===
+      Attribute("XY", TagType.NumericByteSequence, byteArray).toString)
+
+    // Unsigned int arrays, note the capitalized leading character in the value
+    assert(convertSAMTagAndValue(createSAMTagAndValue("XY:B:C,1,2,3")).toString ===
+      Attribute("XY", TagType.NumericUnsignedByteSequence, byteArray).toString)
+    assert(convertSAMTagAndValue(createSAMTagAndValue("XY:B:I,1,2,3")).toString ===
+      Attribute("XY", TagType.NumericUnsignedIntSequence, intArray).toString)
+    assert(convertSAMTagAndValue(createSAMTagAndValue("XY:B:S,1,2,3")).toString ===
+      Attribute("XY", TagType.NumericUnsignedShortSequence, shortArray).toString)
+  }
+
+  test("Attributes can be correctly re-encoded as text SAM tags") {
+    assert(Attribute("XY", TagType.Integer, 3).toString === "XY:i:3")
+    assert(Attribute("XY", TagType.String, "foo").toString === "XY:Z:foo")
+    assert(Attribute("XY", TagType.Float, 3.0f).toString === "XY:f:3.0")
+    assert(Attribute("XY", TagType.Character, 'a').toString === "XY:A:a")
 
     val intArray = Array(1, 2, 3)
-    assert(
-      convertSAMTagAndValue(new SAMTagAndValue("XY", intArray)) ===
-        Attribute("XY", TagType.NumericSequence, intArray)
-    )
+    assert(Attribute("XY", TagType.NumericIntSequence, intArray).toString === "XY:B:i,1,2,3")
 
-    val byteArray: Array[java.lang.Byte] = Seq(java.lang.Byte.valueOf("0"), java.lang.Byte.valueOf("1")).toArray
-    assert(convertSAMTagAndValue(new SAMTagAndValue("XY", byteArray)) === Attribute("XY", TagType.ByteSequence, byteArray))
+    val shortArray: Array[Short] = Array(1, 2, 3).map(_.toShort)
+    assert(Attribute("XY", TagType.NumericShortSequence, shortArray).toString === "XY:B:s,1,2,3")
+
+    val floatArray = Array(1.0f, 2.0f, 3.0f)
+    assert(Attribute("XY", TagType.NumericFloatSequence, floatArray).toString === "XY:B:f,1.0,2.0,3.0")
+
+    val byteArray: Array[Byte] = Array(1, 2, 3).map(_.toByte)
+    assert(Attribute("XY", TagType.NumericByteSequence, byteArray).toString === "XY:B:c,1,2,3")
+
+    // Unsigned int arrays, note the capitalized leading character in the value
+    assert(Attribute("XY", TagType.NumericUnsignedByteSequence, byteArray).toString === "XY:B:C,1,2,3")
+    assert(Attribute("XY", TagType.NumericUnsignedIntSequence, intArray).toString === "XY:B:I,1,2,3")
+    assert(Attribute("XY", TagType.NumericUnsignedShortSequence, shortArray).toString === "XY:B:S,1,2,3")
+
   }
 }


### PR DESCRIPTION
Please review carefully, I'm a Scala beginner! Advice welcome for better, more Scala-ish patterns

- Extends `Attribute` model and `AttributeUtils.convertSAMTagAndValue` to cover the 7 numeric array types [cCsSiIf] described in SAM spec
- Updates tests to use `TextTagCodec` used natively by samtools parser
- Adds a small SAM file with all tag types and tests with loadAlignments