### PR TITLE
add "file" cmd for running multiple cmds at once

### DIFF
--- a/adam-cli/src/main/scala/org/bdgenomics/adam/cli/ADAMMain.scala
+++ b/adam-cli/src/main/scala/org/bdgenomics/adam/cli/ADAMMain.scala
@@ -66,8 +66,24 @@ object ADAMMain extends Logging {
           BuildInformation,
           View
         )
+      ),
+      CommandGroup(
+        "META",
+        List(
+          ExecCommandsFromFile
+        )
       )
     )
+
+  val commands =
+    for {
+      grp <- commandGroups
+      cmd <- grp.commands
+    } yield cmd
+
+  def getCommand(commandName: String): Option[BDGCommandCompanion] = {
+    commands.find(_.commandName == commandName)
+  }
 
   private def printCommands() {
     println("\n")
@@ -93,13 +109,7 @@ object ADAMMain extends Logging {
       printCommands()
     } else {
 
-      val commands =
-        for {
-          grp <- commandGroups
-          cmd <- grp.commands
-        } yield cmd
-
-      commands.find(_.commandName == args(0)) match {
+      getCommand(args(0)) match {
         case None => printCommands()
         case Some(cmd) =>
           init(Args4j[InitArgs](args drop 1, ignoreCmdLineExceptions = true))

--- a/adam-cli/src/main/scala/org/bdgenomics/adam/cli/ExecCommandsFromFile.scala
+++ b/adam-cli/src/main/scala/org/bdgenomics/adam/cli/ExecCommandsFromFile.scala
@@ -1,0 +1,59 @@
+/**
+ * Licensed to Big Data Genomics (BDG) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The BDG licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.bdgenomics.adam.cli
+
+import org.apache.hadoop.fs.FileSystem
+import org.apache.spark.{ SparkContext, Logging }
+import org.bdgenomics.utils.cli.{ BDGSparkCommand, Args4jBase, BDGCommand, Args4j, BDGCommandCompanion }
+import org.kohsuke.args4j.Argument
+
+object ExecCommandsFromFile extends BDGCommandCompanion {
+  val commandName = "file"
+  val commandDescription = "Run a sequence of ADAM commands provided in a file"
+
+  def apply(cmdLine: Array[String]) = {
+    new ExecCommandsFromFile(Args4j[ExecCommandsFromFileArgs](cmdLine))
+  }
+}
+
+class ExecCommandsFromFileArgs extends Args4jBase {
+  @Argument(required = true, metaVar = "INPUT", usage = "A file to read commands from, one per line, including all the arguments and flags that would normally be passed to 'adam-{shell,submit}'.", index = 0)
+  var inputPath: String = null
+}
+
+class ExecCommandsFromFile(protected val args: ExecCommandsFromFileArgs)
+    extends BDGSparkCommand[ExecCommandsFromFileArgs]
+    with Logging {
+  override val companion: BDGCommandCompanion = ExecCommandsFromFile
+
+  override def run(sc: SparkContext): Unit = {
+    val conf = sc.hadoopConfiguration
+    val fs = FileSystem.get(conf)
+    for {
+      line <- sc.textFile(args.inputPath).collect().map(_.trim)
+      if line.nonEmpty
+      commandName :: args = line.split(' ').toList
+      command <- ADAMMain.getCommand(commandName)
+    } {
+      command.apply(args.toArray) match {
+        case sparkCommand: BDGSparkCommand[_] => sparkCommand.run(sc)
+        case bdgCommand                       => bdgCommand.run()
+      }
+    }
+  }
+}


### PR DESCRIPTION
fixes #833 

Example use:

```sh
$ cat cmds
transform /Users/ryan/c/adam/adam-core/src/test/resources/reads12.sam /Users/ryan/c/adam/adam-core/src/test/resources/reads12.adam
transform /Users/ryan/c/adam/adam-core/src/test/resources/bqsr1.sam /Users/ryan/c/adam/adam-core/src/test/resources/bqsr1.adam

# "find-suffix" bash helper of mine, equivalent to: find . -name "*$1"
$ fns .adam  

$ bin/adam-submit file cmds

# The two .adam files exist where there were none previously
$ fns .adam
adam-core/src/test/resources/bqsr1.adam
adam-core/src/test/resources/reads12.adam
```