### PR TITLE
[ADAM-851] Slienced Parquet logging.

### DIFF
--- a/adam-core/src/main/scala/org/bdgenomics/adam/util/ParquetLogger.scala
+++ b/adam-core/src/main/scala/org/bdgenomics/adam/util/ParquetLogger.scala
@@ -22,7 +22,7 @@ import java.util.logging.{ Level, Logger }
 object ParquetLogger {
 
   val hadoopLoggerLevel = (level: Level) => {
-    val parquetHadoopLogger = Logger.getLogger("parquet.hadoop")
+    val parquetHadoopLogger = Logger.getLogger("org.apache.parquet.hadoop")
     parquetHadoopLogger.setLevel(level)
   }
 


### PR DESCRIPTION
Fixed the ParquetLogger utility so that it silences `org.apache.parquet.hadoop`
instead of `parquet.hadoop`. All is quiet again. Resolves #851.