### PR TITLE
export valid fastq

### DIFF
--- a/adam-core/src/main/scala/org/bdgenomics/adam/converters/AlignmentRecordConverter.scala
+++ b/adam-core/src/main/scala/org/bdgenomics/adam/converters/AlignmentRecordConverter.scala
@@ -51,9 +51,23 @@ class AlignmentRecordConverter extends Serializable {
         ""
       }
 
+    //"B" is used to represent "unknown quality score"
+    //https://en.wikipedia.org/wiki/FASTQ_format#cite_note-7
+    //FastQ format quality score string must be the same length as the sequence string
+    //https://en.wikipedia.org/wiki/FASTQ_format#Format
+    val seqLength =
+      if (adamRecord.getSequence == null)
+        0
+      else
+        adamRecord.getSequence.length
     val qualityScores =
       if (outputOriginalBaseQualities && adamRecord.getOrigQual != null)
-        adamRecord.getOrigQual
+        if (adamRecord.getOrigQual == "*")
+          "B" * seqLength
+        else
+          adamRecord.getOrigQual
+      else if (adamRecord.getQual == null)
+        "B" * seqLength
       else
         adamRecord.getQual
 

--- a/adam-core/src/main/scala/org/bdgenomics/adam/rdd/ADAMContext.scala
+++ b/adam-core/src/main/scala/org/bdgenomics/adam/rdd/ADAMContext.scala
@@ -372,7 +372,7 @@ class ADAMContext(val sc: SparkContext) extends Serializable with Logging {
                 stringency: ValidationStringency = ValidationStringency.STRICT): RDD[AlignmentRecord] = {
     filePath2Opt match {
       case Some(filePath2) => loadPairedFastq(filePath1, filePath2, recordGroupOpt, stringency)
-      case None            => loadUnpairedFastq(filePath1)
+      case None            => loadUnpairedFastq(filePath1, stringency = stringency)
     }
   }
 
@@ -380,8 +380,8 @@ class ADAMContext(val sc: SparkContext) extends Serializable with Logging {
                       filePath2: String,
                       recordGroupOpt: Option[String],
                       stringency: ValidationStringency): RDD[AlignmentRecord] = {
-    val reads1 = loadUnpairedFastq(filePath1, setFirstOfPair = true)
-    val reads2 = loadUnpairedFastq(filePath2, setSecondOfPair = true)
+    val reads1 = loadUnpairedFastq(filePath1, setFirstOfPair = true, stringency = stringency)
+    val reads2 = loadUnpairedFastq(filePath2, setSecondOfPair = true, stringency = stringency)
 
     stringency match {
       case ValidationStringency.STRICT | ValidationStringency.LENIENT =>
@@ -406,7 +406,8 @@ class ADAMContext(val sc: SparkContext) extends Serializable with Logging {
   def loadUnpairedFastq(filePath: String,
                         recordGroupOpt: Option[String] = None,
                         setFirstOfPair: Boolean = false,
-                        setSecondOfPair: Boolean = false): RDD[AlignmentRecord] = {
+                        setSecondOfPair: Boolean = false,
+                        stringency: ValidationStringency = ValidationStringency.STRICT): RDD[AlignmentRecord] = {
 
     val job = HadoopUtil.newJob(sc)
     val records = sc.newAPIHadoopFile(
@@ -430,7 +431,8 @@ class ADAMContext(val sc: SparkContext) extends Serializable with Logging {
             recordGroup
         ),
         setFirstOfPair,
-        setSecondOfPair
+        setSecondOfPair,
+        stringency
       )
     )
   }

--- a/adam-core/src/test/resources/fastq_noqual.fq
+++ b/adam-core/src/test/resources/fastq_noqual.fq
@@ -1,0 +1,8 @@
+@noqual/1
+GATTACA
++
+*
+@noqual/2
+ACATTAG
++
+*


### PR DESCRIPTION
The adam2fastq exported in the case of a sam with "*" (unknown read quality) just exports the "*".  This is invalid fastq.

This PR addresses the issue by assigning quality value of "B" for each base - this is conventionally used for reads of unknown quality.

Additionally, reads loaded in from fastq are also assigned "B"-string for malformed records containing "*" for read quality.