### PR TITLE
Add Avro LRU cache for strings to reduce memory use

### DIFF
--- a/adam-core/src/main/scala/org/bdgenomics/adam/serialization/BinaryDecoderWithLRUCache.scala
+++ b/adam-core/src/main/scala/org/bdgenomics/adam/serialization/BinaryDecoderWithLRUCache.scala
@@ -1,0 +1,120 @@
+/**
+ * Licensed to Big Data Genomics (BDG) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The BDG licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.bdgenomics.adam.serialization
+
+import java.io.{ IOException, InputStream }
+import java.nio.ByteBuffer
+import java.util
+import java.util.Map.Entry
+
+import org.apache.avro.io.{ BinaryDecoder, Decoder, DecoderFactory }
+import org.apache.avro.util.Utf8
+
+/**
+ * Note: A LinkedHashMap takes 40 * SIZE + 4 * CAPACITY bytes. If the size == capacity, then the memory
+ * footprint is CAPACITY * 44 bytes.
+ */
+private[serialization] class LRUCache[K, V](maxCapacity: Int, loadFactor: Double = 0.75f)
+    extends util.LinkedHashMap[K, V](maxCapacity, 0.75f, true) {
+  assert(maxCapacity > 0, "LRU cache maxCapacity should be greater than 0")
+  assert(0 < loadFactor && loadFactor <= 1.0, "LRU load factor must be (0,1.0]")
+  override def removeEldestEntry(eldest: Entry[K, V]): Boolean = {
+    size() > maxCapacity
+  }
+}
+
+/**
+ * An Avro binary decoder that keep a LRU cache of strings to minimize memory pressure.
+ *
+ * WARNING: This class is not thread-safe! This isn't an issue since Spark guarantees that only
+ * a single thread will access it.
+ *
+ * A amount of memory strings take in Java is 8 * (int) ((((#chars) * 2) + 45) / 8) bytes, e.g. a string that is
+ * 128 characters long will take, 8 * ((((128) * 2) + 45) / 8) = 296 bytes. This BinaryDecoder is not for general
+ * use but is optimized for ADAM -omics data, where strings are typically ~128 characters long.
+ *
+ * The default cache capacity size of 64K elements, equates to a maximum memory use of (44*64K) for the cache and
+ * (296*64K) for the strings, a total of ~22 MB when full.
+ *
+ * @param in The input stream of Avro data
+ */
+private[serialization] class BinaryDecoderWithLRUCache(in: InputStream, cache: LRUCache[Utf8, Utf8]) extends Decoder {
+
+  def this(in: InputStream, cacheCapacity: Int = 65535) = this(in, new LRUCache[Utf8, Utf8](cacheCapacity))
+
+  val wrappedDecoder = DecoderFactory.get().directBinaryDecoder(in, null.asInstanceOf[BinaryDecoder])
+
+  private val scratchUtf8: Utf8 = new Utf8
+
+  @throws(classOf[IOException])
+  override def readString: String = {
+    readString(scratchUtf8).toString
+  }
+
+  @throws(classOf[IOException])
+  override def readString(old: Utf8): Utf8 = {
+    // NOTE: The 'old' parameter is intentionally being ignored. We always reuse 'scratchUtf8' to keep
+    // from creating a new Utf8 object every time we read a string. This isn't thread-safe, of course,
+    // but Spark ensures that each thread has its own serialization infrastructure.
+    val readValue = wrappedDecoder.readString(scratchUtf8)
+    if (!cache.containsKey(readValue)) {
+      val valueCopy = new Utf8(readValue)
+      cache.put(valueCopy, valueCopy)
+    }
+    cache.get(readValue)
+  }
+
+  override def readLong(): Long = wrappedDecoder.readLong()
+
+  override def readFloat(): Float = wrappedDecoder.readFloat()
+
+  override def readNull(): Unit = wrappedDecoder.readNull()
+
+  override def skipArray(): Long = wrappedDecoder.skipArray()
+
+  override def skipMap(): Long = wrappedDecoder.skipMap()
+
+  override def arrayNext(): Long = wrappedDecoder.arrayNext()
+
+  override def mapNext(): Long = wrappedDecoder.mapNext()
+
+  override def readFixed(bytes: Array[Byte], start: Int, length: Int): Unit =
+    wrappedDecoder.readFixed(bytes, start, length)
+
+  override def readEnum(): Int = wrappedDecoder.readEnum()
+
+  override def readMapStart(): Long = wrappedDecoder.readMapStart()
+
+  override def readInt(): Int = wrappedDecoder.readInt()
+
+  override def readBytes(old: ByteBuffer): ByteBuffer = wrappedDecoder.readBytes(old)
+
+  override def skipFixed(length: Int): Unit = wrappedDecoder.skipFixed(length)
+
+  override def readArrayStart(): Long = wrappedDecoder.readArrayStart()
+
+  override def skipBytes(): Unit = wrappedDecoder.skipBytes()
+
+  override def readBoolean(): Boolean = wrappedDecoder.readBoolean()
+
+  override def readIndex(): Int = wrappedDecoder.readIndex()
+
+  override def skipString(): Unit = wrappedDecoder.skipString()
+
+  override def readDouble(): Double = wrappedDecoder.readDouble()
+}

--- a/adam-core/src/main/scala/org/bdgenomics/adam/serialization/BinaryDecoderWithLRUCache.scala
+++ b/adam-core/src/main/scala/org/bdgenomics/adam/serialization/BinaryDecoderWithLRUCache.scala
@@ -55,7 +55,7 @@ private[serialization] class LRUCache[K, V](maxCapacity: Int, loadFactor: Double
  */
 private[serialization] class BinaryDecoderWithLRUCache(
     in: InputStream,
-    maxCachableStringSize: Int,
+    maxCacheableStringSize: Int,
     cache: LRUCache[Utf8, Utf8]) extends Decoder {
 
   def this(in: InputStream, maxCacheableStringSize: Int = 50, cacheCapacity: Int = 65535) =
@@ -76,7 +76,7 @@ private[serialization] class BinaryDecoderWithLRUCache(
     // from creating a new Utf8 object every time we read a string. This isn't thread-safe, of course,
     // but Spark ensures that each thread has its own serialization infrastructure.
     val readValue = wrappedDecoder.readString(scratchUtf8)
-    if (readValue.length() > maxCachableStringSize) {
+    if (readValue.length() > maxCacheableStringSize) {
       if (old == null) {
         new Utf8(readValue)
       } else {

--- a/adam-core/src/test/scala/org/bdgenomics/adam/serialization/SerializationSuite.scala
+++ b/adam-core/src/test/scala/org/bdgenomics/adam/serialization/SerializationSuite.scala
@@ -1,0 +1,79 @@
+/**
+ * Licensed to Big Data Genomics (BDG) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The BDG licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.bdgenomics.adam.serialization
+
+import it.unimi.dsi.fastutil.io.{ FastByteArrayInputStream, FastByteArrayOutputStream }
+import org.apache.avro.io.{ BinaryEncoder, EncoderFactory }
+import org.apache.avro.specific.{ SpecificDatumReader, SpecificDatumWriter }
+import org.apache.avro.util.Utf8
+import org.bdgenomics.adam.util.ADAMFunSuite
+import org.bdgenomics.formats.avro.AlignmentRecord
+
+class SerializationSuite extends ADAMFunSuite {
+
+  test("LRU cache maxCapacity is enforced and LRU is evicted") {
+    val capacity = 10
+    val cache = new LRUCache[Int, Int](capacity)
+    0 to capacity * 2 map (i => cache.put(i, i))
+    assert(cache.size() == capacity)
+    0 to capacity foreach (i => assert(!cache.containsKey(i)))
+    capacity + 1 to capacity * 2 foreach (i => assert(cache.containsKey(i)))
+  }
+
+  test("BinaryDecoderWithLRUCache evicts LRU strings") {
+    val cacheCapacity = 10
+    val cache = new LRUCache[Utf8, Utf8](cacheCapacity)
+    val outstream = new FastByteArrayOutputStream()
+    val encoder = EncoderFactory.get().directBinaryEncoder(outstream, null.asInstanceOf[BinaryEncoder])
+    val writer = new SpecificDatumWriter[AlignmentRecord](AlignmentRecord.SCHEMA$)
+
+    val sequences = Array.tabulate(cacheCapacity * 2 + 1) {
+      i => s"${i}ACTGACTGACTGACTGACTG"
+    }
+
+    val recordsIn = Array.tabulate(cacheCapacity * 2 + 1) {
+      i =>
+        {
+          AlignmentRecord.newBuilder()
+            .setSequence(sequences(i))
+            .build()
+        }
+    }
+
+    for (record <- recordsIn) {
+      writer.write(record, encoder)
+    }
+
+    val inputStream = new FastByteArrayInputStream(outstream.array)
+    val decoder = new BinaryDecoderWithLRUCache(inputStream, cache)
+    val reader = new SpecificDatumReader[AlignmentRecord](AlignmentRecord.SCHEMA$)
+
+    val recordsOut = Array.tabulate(cacheCapacity * 2 + 1) {
+      i =>
+        {
+          reader.read(null.asInstanceOf[AlignmentRecord], decoder)
+        }
+    }
+
+    assert(recordsIn sameElements recordsOut)
+    assert(cache.size() == cacheCapacity)
+    0 to cacheCapacity foreach { i => assert(!cache.containsKey(new Utf8(sequences(i)))) }
+    cacheCapacity + 1 to cacheCapacity * 2 foreach { i => assert(cache.containsKey(new Utf8(sequences(i)))) }
+  }
+
+}


### PR DESCRIPTION
This commit adds a new Avro Binary Decoder that uses an LRU cache
of Utf8 (string) objects to minimize the creation of Uft8 objects.
If a Utf8 exists in the cache, its reference is used instead of
creating a new object. Moreover, the decoder readString() method
reuses a single Utf8 object when reading strings instead of
creating a new Utf8 object on each read.

The read() method in AvroSerializer was synchronized which isn't
necessary since Spark ensures that only a single thread will
call read. That sychronization is removed with this commit.