### PR TITLE
[ADAM-857] Corrected handling of env vars in bin scripts

### DIFF
--- a/bin/adam-shell
+++ b/bin/adam-shell
@@ -56,7 +56,7 @@ NEW_OPTIONS=$("$SCRIPT_DIR"/bin/append_to_option.py , --jars "$ADAM_CLI_JAR" "$@
 echo "$NEW_OPTIONS"
 
 if [ -z "$SPARK_HOME" ]; then
-  SPARK_SHELL=$(which spark-shell)
+  SPARK_SHELL=$(which spark-shell || echo)
 else
   SPARK_SHELL="$SPARK_HOME"/bin/spark-shell
 fi

--- a/bin/adam-submit
+++ b/bin/adam-submit
@@ -84,7 +84,7 @@ echo "Using ADAM_MAIN=$ADAM_MAIN"
 
 # Find spark-submit script
 if [ -z "$SPARK_HOME" ]; then
-  SPARK_SUBMIT=$(which spark-submit)
+  SPARK_SUBMIT=$(which spark-submit || echo)
 else
   SPARK_SUBMIT="$SPARK_HOME"/bin/spark-submit
 fi


### PR DESCRIPTION
Because of `set -e`, the `which spark-submit` subshell command was causing the script to exit early.

Fixes #857.