### PR TITLE
New release and pr-commit scripts

### DIFF
--- a/scripts/changelog.sh
+++ b/scripts/changelog.sh
@@ -17,6 +17,8 @@ fi
 
 echo "# ADAM #"
 
+echo "### Version $1 ###"
+
 git log | grep -E "Merge pull request|prepare release" | grep -vi "Revert" | uniq | while read l
 do 
   release=`echo $l | grep "prepare release" | grep -v 2.11 | awk -F'-' '{print $NF}' | awk -F'_' '{ print $1 }'`

--- a/scripts/commit-pr.sh
+++ b/scripts/commit-pr.sh
@@ -1,0 +1,94 @@
+#!/bin/bash
+
+# pick arguments
+pr=$1
+
+# do we have enough arguments?
+if [ $# != 1 ]; then
+    echo "Usage:"
+    echo
+    echo "./commit-pr.sh <pr-to-commit>"
+    exit 1
+fi
+
+# get origin urls
+fetch_url=$(git remote show origin | grep Fetch | awk '{ print $3 }')
+push_url=$(git remote show origin | grep Push | awk '{ print $3 }')
+
+
+# is origin pointing at the correct repo?
+ec=0
+if [ $fetch_url != "git@github.com:bigdatagenomics/adam.git" ] || [ $fetch_url != "https://github.com/bigdatagenomics/adam.git" ]
+then
+    echo "Fetch URL doesn't point at ADAM: ${fetch_url}"
+    ec=1
+fi
+if [ $push_url != "git@github.com:bigdatagenomics/adam.git" ] || [  $push_url != "https://github.com/bigdatagenomics/adam.git" ]
+then
+    echo "Push URL doesn't point at ADAM: ${push_url}"
+    ec=1
+fi
+if [ $ec != 0 ]; then
+    exit 1
+fi
+
+# get current branch
+branch=$(git status -bs | awk '{ print $2 }' | awk -F'.' '{ print $1 }' | head -n 1)
+
+# are we on master?
+if [ $branch != "master" ]; then
+    echo "Not on master: $branch"
+    exit 1
+fi
+
+# fetch latest changes from origin
+git fetch origin
+
+# rebase on ToT
+git rebase origin/master
+
+# master should be 0 ahead now
+numcommits=$(git rev-list --count --left-right master...origin/master | awk '{ sum = $1 + $2 } END { print sum }')
+if [ $numcommits != 0 ]; then
+    echo "Local master is not 1 commit ahead of remote master..."
+    exit 1
+fi
+
+# fetch pull request to a branch
+git fetch origin pull/${pr}/head:pr-${pr}
+
+# check out this branch
+git checkout pr-${pr}
+
+# rebase it on master
+git rebase origin/master
+
+# are we one ahead?
+numcommits=$(git rev-list --count --left-right pr-${pr}...origin/master  | awk '{ sum = $1 + $2 } END { print sum }')
+if [ $numcommits != 1 ]; then
+    echo "This PR is ahead by ${numcommits}. Do you want to continue with the merge? y/n"
+    read -n 1 -r
+    if [[ ! $REPLY =~ ^[Yy]$ ]]; then
+        echo "Exiting with commits unmerged on branch pr-${pr}."
+        echo "When issues are fixed, you can finish the merge by running:"
+        echo
+        echo "  git checkout master; git merge --ff-only pr-${pr}; git push origin master"
+        echo
+        exit 1
+    fi
+fi
+
+# check out master
+git checkout master
+
+# merge branch
+git merge --ff-only pr-${pr}
+
+# did merge succeed?
+if [ $? == 1 ]; then
+    echo "Merge failed with non-zero exit code."
+    exit 1
+fi
+
+# push to master
+git push origin master

--- a/scripts/release/release.sh
+++ b/scripts/release/release.sh
@@ -1,14 +1,71 @@
 #!/bin/sh
 
+# do we have enough arguments?
+if [ $# < 3 ]; then
+    echo "Usage:"
+    echo
+    echo "./release.sh <release version> <development version>"
+    exit 1
+fi
+
+# pick arguments
+release=$1
+devel=$2
+
+# get current branch
+branch=$(git status -bs | awk '{ print $2 }' | awk -F'.' '{ print $1 }' | head -n 1)
+
+./scripts/changelog.sh $1 | tee CHANGES.md
+git commit -a -m "Modifying changelog."
+
+commit=$(git log --pretty=format:"%H" | head -n 1)
+echo "releasing from ${commit} on branch ${branch}"
+
+git push origin ${branch}
+
 # do scala 2.10 release
-mvn -P distribution -Dresume=false release:clean release:prepare release:perform
+git checkout -b maint-2.10_${release} ${branch}
+mvn --batch-mode \
+  -P distribution \
+  -Dresume=false \
+  -Dtag=adam-parent-2.10_${release} \
+  -DreleaseVersion=${release} \
+  -DdevelopmentVersion=${devel} \
+  -DbranchName=adam-${release} \
+  release:clean \
+  release:prepare \
+  release:perform
+
+if [ $? != 0 ]; then
+  echo "Releasing Scala 2.10 version failed."
+  exit 1
+fi
 
 # do scala 2.11 release
+git checkout -b maint-2.11_${release} ${branch}
 ./scripts/move_to_scala_2.11.sh
 git commit -a -m "Modifying pom.xml files for 2.11 release."
-mvn -P distribution -Dresume=false release:clean release:prepare release:perform
+mvn --batch-mode \
+  -P distribution \
+  -Dresume=false \
+  -Dtag=adam-parent-2.11_${release} \
+  -DreleaseVersion=${release} \
+  -DdevelopmentVersion=${devel} \
+  -DbranchName=adam-2.11_${release} \
+  release:clean \
+  release:prepare \
+  release:perform
 
-# move back to 2.10 for development
-./scripts/move_to_scala_2.10.sh
-./scripts/changelog.sh | tee CHANGES.md
-git commit -a -m "Modifying pom.xml files to move back to Scala 2.10 for development."
+if [ $? != 0 ]; then
+  echo "Releasing Scala 2.11 version failed."
+  exit 1
+fi
+
+if [ $branch = "master" ]; then
+  # if original branch was master, update versions on original branch
+  git checkout ${branch}
+  mvn versions:set -DnewVersion=${devel} \
+    -DgenerateBackupPoms=false
+  git commit -a -m "Modifying pom.xml files for new development after ${release} release."
+  git push origin ${branch}
+fi


### PR DESCRIPTION
These two commits contain two changes:

1. The first commit modifies the release scripts to move to a branch-then-release model.
2. The second commit adds a script `script/commit-pr.sh` that automates the process of FF merging a PR from the command line.

## Branch-then-release model ##

Recently, someone (@ryan-williams?) mentioned the idea of moving to a branch-then-release model. Here, we would make a branch, and then make the release off of this branch. The release commits would not show up on the master branch. This would make it easier to make maintenance releases. Although the Maven release plugin contains a goal for releasing from a branch, the general consensus is that this goal works with SVN but not with Git (I tested this out and this does seem to be the case). It seems like many people advocate the "Gitflow" release approach; however, that seemed like a radical departure from our current model, so I decided not to go that route.

In this PR, we make an update on the starting branch (presumably master, but this is not hardcoded in the scripts, in case we want to make a maintenance release) to the `CHANGES.md` file. We then make a branch for the Scala 2.10 release, and run the typical Maven release process there. Finally, we make a branch from our starting branch for the Scala 2.11 release. On this branch, we move the pom.xml files from Scala 2.10 to Scala 2.11, and then run the Maven release process. If we start with this structure:

![screen shot 2015-10-08 at 2 41 20 pm](https://cloud.githubusercontent.com/assets/3752466/10380767/ae396214-6dca-11e5-8190-2ffaa7afd0a6.png)

Once the release completes, our repo will look like this:

<img width="263" alt="screen shot 2015-10-08 at 12 53 21 pm" src="https://cloud.githubusercontent.com/assets/3752466/10380772/b95f01c6-6dca-11e5-9c5b-83a1605423bd.png">

Once both Scala 2.10 and 2.11 releases succeed, the release script updates the pom.xml's on the master branch to the new development version.

## PR Commit scripts ##

There are two problems with the PR merge button in Github:

1. The button creates a merge commit per PR.
2. The hook does not require all merges to be fast-forwards; this means that changes can be merged even if they are not based on the latest commit on master.

The `./scripts/commit-pr.sh` script will checkout a single PR, rebase those changes on master, and then merge the changes into master as a fast-forward merge. If there are multiple commits in a pull request, the script will prompt the user as to whether they would like to continue with the merge. If it is a PR where the multiple commits should not be squashed down (like this one), the user can say `y` to continue, and the merge will go on. If the commits should be squashed, the user can say `n` to stop the merge, and then manually squash the commits from there. The script will print out the directions for finishing the merge, in the case that it aborts.

If we want to merge a pull request (`#1`) started from the `docs` branch in the picture below:

<img width="276" alt="screen shot 2015-10-08 at 12 54 06 pm" src="https://cloud.githubusercontent.com/assets/3752466/10380904/a872502e-6dcb-11e5-903d-48c89b810399.png">

We would run `./scripts/commit-pr.sh 1`, which will do the above, and lead to the following branch structure:

![screen shot 2015-10-08 at 1 43 23 pm](https://cloud.githubusercontent.com/assets/3752466/10380920/ce4f99c8-6dcb-11e5-8626-3e9bdb3ae400.png)

