### PR TITLE
[ADAM-864] Don't force shuffle if reducing partition count.

### DIFF
--- a/adam-cli/src/main/scala/org/bdgenomics/adam/cli/Vcf2ADAM.scala
+++ b/adam-cli/src/main/scala/org/bdgenomics/adam/cli/Vcf2ADAM.scala
@@ -48,6 +48,9 @@ class Vcf2ADAMArgs extends Args4jBase with ParquetSaveArgs {
   @Args4jOption(required = false, name = "-coalesce", usage = "Set the number of partitions written to the ADAM output directory")
   var coalesce: Int = -1
 
+  @Args4jOption(required = false, name = "-force_shuffle_coalesce", usage = "Even if the repartitioned RDD has fewer partitions, force a shuffle.")
+  var forceShuffle: Boolean = false
+
   @Args4jOption(required = false, name = "-onlyvariants", usage = "Output Variant objects instead of Genotypes")
   var onlyvariants: Boolean = false
 }
@@ -63,7 +66,11 @@ class Vcf2ADAM(val args: Vcf2ADAMArgs) extends BDGSparkCommand[Vcf2ADAMArgs] wit
 
     var adamVariants: RDD[VariantContext] = sc.loadVcf(args.vcfPath, sd = dictionary)
     if (args.coalesce > 0) {
-      adamVariants = adamVariants.coalesce(args.coalesce, true)
+      if (args.coalesce > adamVariants.partitions.size || args.forceShuffle) {
+        adamVariants = adamVariants.coalesce(args.coalesce, shuffle = true)
+      } else {
+        adamVariants = adamVariants.coalesce(args.coalesce, shuffle = false)
+      }
     }
 
     if (args.onlyvariants) {


### PR DESCRIPTION
Resolves #864. In Spark, coalescing will reduce the number of partitions in an
RDD without performing a shuffle, but coalescing will only increase the number
of partitions if a shuffle is performed. This PR modifies Transform and Vcf2ADAM
to check whether the coalesce option will increase or decrease the partition
count. Additionally, it adds a flag that allows the user to force a shuffle;
this may be desirable as this causes a HashPartitioned shuffle, which may
improve the balance of records across partitions.