### PR TITLE
adding --version command line option

### DIFF
--- a/adam-cli/pom.xml
+++ b/adam-cli/pom.xml
@@ -11,8 +11,35 @@
   <artifactId>adam-cli_2.10</artifactId>
   <packaging>jar</packaging>
   <name>ADAM_2.10: CLI</name>
+  <properties>
+    <maven.build.timestamp>${maven.build.timestamp}</maven.build.timestamp>
+    <maven.build.timestamp.format>yyyy-MM-dd</maven.build.timestamp.format>
+  </properties>
   <build>
     <plugins>
+      <plugin>
+        <groupId>org.codehaus.mojo</groupId>
+        <artifactId>templating-maven-plugin</artifactId>
+        <executions>
+          <execution>
+            <id>filter-src</id>
+            <goals>
+              <goal>filter-sources</goal>
+            </goals>
+          </execution>
+        </executions>
+      </plugin>
+      <plugin>
+        <groupId>pl.project13.maven</groupId>
+        <artifactId>git-commit-id-plugin</artifactId>
+        <executions>
+          <execution>
+            <goals>
+              <goal>revision</goal>
+            </goals>
+          </execution>
+        </executions>
+      </plugin>
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-shade-plugin</artifactId>
@@ -106,7 +133,6 @@
       </plugin>
     </plugins>
   </build>
-
   <dependencies>
     <dependency>
       <groupId>org.apache.hadoop</groupId>

--- a/adam-cli/src/main/java-templates/org/bdgenomics/adam/cli/About.java
+++ b/adam-cli/src/main/java-templates/org/bdgenomics/adam/cli/About.java
@@ -1,0 +1,93 @@
+/**
+ * Licensed to Big Data Genomics (BDG) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The BDG licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.bdgenomics.adam.cli;
+
+/**
+ * About.
+ */
+public final class About {
+    private static final String ARTIFACT_ID = "${project.artifactId}";
+    private static final String BUILD_TIMESTAMP = "${maven.build.timestamp}";
+    private static final String COMMIT = "${git.commit.id}";
+    private static final String HADOOP_VERSION = "${hadoop.version}";
+    private static final String SCALA_VERSION = "${scala.version}";
+    private static final String VERSION = "${project.version}";
+
+    /**
+     * Return the artifact id.
+     *
+     * @return the artifact id
+     */
+    public String artifactId() {
+        return ARTIFACT_ID;
+    }
+
+    /**
+     * Return the build timestamp.
+     *
+     * @return the build timestamp
+     */
+    public String buildTimestamp() {
+        return BUILD_TIMESTAMP;
+    }
+
+    /**
+     * Return the last commit.
+     *
+     * @return the last commit
+     */
+    public String commit() {
+        return COMMIT;
+    }
+
+    /**
+     * Return the Hadoop version.
+     *
+     * @return the Hadoop version
+     */
+    public String hadoopVersion() {
+        return HADOOP_VERSION;
+    }
+
+    /**
+     * Return the Scala version.
+     *
+     * @return the Scala version
+     */
+    public String scalaVersion() {
+        return SCALA_VERSION;
+    }
+
+    /**
+     * Return the version.
+     *
+     * @return the version
+     */
+    public String version() {
+        return VERSION;
+    }
+
+    /**
+     * Return true if the version is a snapshot.
+     *
+     * @return true if the version is a snapshot
+     */
+    public boolean isSnapshot() {
+        return VERSION.contains("SNAPSHOT");
+    }
+}

--- a/adam-cli/src/main/scala/org/bdgenomics/adam/cli/ADAMMain.scala
+++ b/adam-cli/src/main/scala/org/bdgenomics/adam/cli/ADAMMain.scala
@@ -84,14 +84,28 @@ private class InitArgs extends Args4jBase with ParquetArgs {}
 
 class ADAMMain @Inject() (commandGroups: List[CommandGroup]) extends Logging {
 
+  private def printLogo() {
+    print("\n")
+    println("""       e         888~-_          e             e    e
+               |      d8b        888   \        d8b           d8b  d8b
+               |     /Y88b       888    |      /Y88b         d888bdY88b
+               |    /  Y88b      888    |     /  Y88b       / Y88Y Y888b
+               |   /____Y88b     888   /     /____Y88b     /   YY   Y888b
+               |  /      Y88b    888_-~     /      Y88b   /          Y888b""".stripMargin('|'))
+  }
+
+  private def printVersion() {
+    printLogo()
+    val about = new About()
+    println("\nADAM version: %s".format(about.version()))
+    if (about.isSnapshot()) {
+      println("Commit: %s Build: %s".format(about.commit(), about.buildTimestamp()))
+    }
+    println("Built for: Scala %s and Hadoop %s".format(about.scalaVersion(), about.hadoopVersion()))
+  }
+
   private def printCommands() {
-    println("\n")
-    println("""     e            888~-_              e                 e    e
-               |    d8b           888   \            d8b               d8b  d8b
-               |   /Y88b          888    |          /Y88b             d888bdY88b
-               |  /  Y88b         888    |         /  Y88b           / Y88Y Y888b
-               | /____Y88b        888   /         /____Y88b         /   YY   Y888b
-               |/      Y88b       888_-~         /      Y88b       /          Y888b""".stripMargin('|'))
+    printLogo()
     println("\nUsage: adam-submit [<spark-args> --] <adam-args>")
     println("\nChoose one of the following commands:")
     commandGroups.foreach { grp =>
@@ -106,6 +120,8 @@ class ADAMMain @Inject() (commandGroups: List[CommandGroup]) extends Logging {
     log.info("ADAM invoked with args: %s".format(argsToString(args)))
     if (args.size < 1) {
       printCommands()
+    } else if (args.contains("--version") || args.contains("-version")) {
+      printVersion()
     } else {
 
       val commands =

--- a/adam-cli/src/test/scala/org/bdgenomics/adam/cli/AboutSuite.scala
+++ b/adam-cli/src/test/scala/org/bdgenomics/adam/cli/AboutSuite.scala
@@ -1,0 +1,53 @@
+/**
+ * Licensed to Big Data Genomics (BDG) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The BDG licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.bdgenomics.adam.cli
+
+import org.scalatest.FunSuite
+
+class AboutSuite extends FunSuite {
+  val about = new About()
+
+  test("template variables have been replaced") {
+    assert(about.artifactId() !== "${project.artifactId}")
+    assert(about.buildTimestamp() !== "${maven.build.timestamp}")
+    assert(about.commit() !== "${git.commit.id}")
+    assert(about.hadoopVersion() !== "${hadoop.version}")
+    assert(about.scalaVersion() !== "${scala.version}")
+    assert(about.version() !== "${version}")
+  }
+
+  test("templated values are not empty") {
+    assert(about.artifactId() !== null)
+    assert(!about.artifactId().isEmpty)
+
+    assert(about.buildTimestamp() !== null)
+    assert(!about.buildTimestamp().isEmpty)
+
+    assert(about.commit() !== null)
+    assert(!about.commit().isEmpty)
+
+    assert(about.hadoopVersion() !== null)
+    assert(!about.hadoopVersion().isEmpty)
+
+    assert(about.scalaVersion() !== null)
+    assert(!about.scalaVersion().isEmpty)
+
+    assert(about.version() !== null)
+    assert(!about.version().isEmpty())
+  }
+}

--- a/pom.xml
+++ b/pom.xml
@@ -19,6 +19,8 @@
   <properties>
     <java.version>1.7</java.version>
     <avro.version>1.7.7</avro.version>
+    <!-- informative only, used in about template substitution -->
+    <scala.version>2.10</scala.version>
     <spark.version>1.4.1</spark.version>
     <parquet.version>1.8.1</parquet.version>
     <!-- Edit the following line to configure the Hadoop (HDFS) version. -->
@@ -170,6 +172,11 @@
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-surefire-plugin</artifactId>
           <version>2.18.1</version>
+        </plugin>
+        <plugin>
+          <groupId>org.codehaus.mojo</groupId>
+          <artifactId>templating-maven-plugin</artifactId>
+          <version>1.0-alpha-3</version>
         </plugin>
         <plugin>
           <groupId>org.scalatest</groupId>


### PR DESCRIPTION
For snapshot builds:
```bash
$ ./bin/adam-submit --version
Using ADAM_MAIN=org.bdgenomics.adam.cli.ADAMMain
Using SPARK_SUBMIT=/usr/local/bin/spark-submit

       e         888~-_          e             e    e
      d8b        888   \        d8b           d8b  d8b
     /Y88b       888    |      /Y88b         d888bdY88b
    /  Y88b      888    |     /  Y88b       / Y88Y Y888b
   /____Y88b     888   /     /____Y88b     /   YY   Y888b
  /      Y88b    888_-~     /      Y88b   /          Y888b

ADAM version: 0.18.3-SNAPSHOT
Commit: 704d2ccd6eaad2e856fdec2d5ed2395edef98c04 Build: 2015-11-24
Built for: Scala 2.11 and Hadoop 2.2.0
```

For release versions:
```bash
$ adam-submit --version
Using ADAM_MAIN=org.bdgenomics.adam.cli.ADAMMain
Using SPARK_SUBMIT=/usr/local/bin/spark-submit

       e         888~-_          e             e    e
      d8b        888   \        d8b           d8b  d8b
     /Y88b       888    |      /Y88b         d888bdY88b
    /  Y88b      888    |     /  Y88b       / Y88Y Y888b
   /____Y88b     888   /     /____Y88b     /   YY   Y888b
  /      Y88b    888_-~     /      Y88b   /          Y888b

ADAM version: 0.18.3
Built for: Scala 2.11 and Hadoop 2.2.0
```

Any properties available to Maven via ```pom.xml``` could be added.  I also fixed the kerning with our logo.