### PR TITLE
[ADAM-891] Mark SparkContext as @transient.

### DIFF
--- a/adam-core/src/main/scala/org/bdgenomics/adam/rdd/ADAMContext.scala
+++ b/adam-core/src/main/scala/org/bdgenomics/adam/rdd/ADAMContext.scala
@@ -109,7 +109,7 @@ object ADAMContext {
 
 import org.bdgenomics.adam.rdd.ADAMContext._
 
-class ADAMContext(val sc: SparkContext) extends Serializable with Logging {
+class ADAMContext(@transient val sc: SparkContext) extends Serializable with Logging {
 
   private[rdd] def adamBamDictionaryLoad(filePath: String): SequenceDictionary = {
     val samHeader = SAMHeaderReader.readSAMHeaderFrom(new Path(filePath), sc.hadoopConfiguration)


### PR DESCRIPTION
Closes #891. In org.bdgenomics.adam.rdd.ADAMContext, the val sparkContext:
SparkContext is not marked as @transient, which causes serialization issues.
SparkContexts are not serializable and should only be called from the driver.