### PR TITLE
Changed fisher strand bias field for VCF2Adam from SB to FS

### DIFF
--- a/adam-core/src/main/scala/org/bdgenomics/adam/converters/VariantAnnotationConverter.scala
+++ b/adam-core/src/main/scala/org/bdgenomics/adam/converters/VariantAnnotationConverter.scala
@@ -83,13 +83,13 @@ object VariantAnnotationConverter extends Serializable {
   )
 
   val INFO_KEYS: Seq[AttrKey] = Seq(
-    AttrKey("fisherStrandBiasPValue", attrAsFloat _, VCFStandardHeaderLines.getInfoLine(VCFConstants.STRAND_BIAS_KEY)),
     AttrKey("rmsMapQ", attrAsFloat _, VCFStandardHeaderLines.getInfoLine(VCFConstants.RMS_MAPPING_QUALITY_KEY)),
     AttrKey("mapq0Reads", attrAsInt _, VCFStandardHeaderLines.getInfoLine(VCFConstants.MAPPING_QUALITY_ZERO_KEY)),
     AttrKey("mqRankSum", attrAsFloat _, new VCFInfoHeaderLine("MQRankSum", 1, VCFHeaderLineType.Float, "Z-score From Wilcoxon rank sum test of Alt vs. Ref read mapping qualities")),
     AttrKey("readPositionRankSum", attrAsFloat _, new VCFInfoHeaderLine("ReadPosRankSum", 1, VCFHeaderLineType.Float, "Z-score from Wilcoxon rank sum test of Alt vs. Ref read position bias")),
     AttrKey("vqslod", attrAsFloat _, new VCFInfoHeaderLine("VQSLOD", 1, VCFHeaderLineType.Float, "Log odds ratio of being a true variant versus being false under the trained gaussian mixture model")),
-    AttrKey("culprit", attrAsString _, new VCFInfoHeaderLine("culprit", 1, VCFHeaderLineType.String, "The annotation which was the worst performing in the Gaussian mixture model, likely the reason why the variant was filtered out"))
+    AttrKey("culprit", attrAsString _, new VCFInfoHeaderLine("culprit", 1, VCFHeaderLineType.String, "The annotation which was the worst performing in the Gaussian mixture model, likely the reason why the variant was filtered out")),
+    AttrKey("fisherStrandBiasPValue", attrAsFloat _, new VCFInfoHeaderLine("FS", 1, VCFHeaderLineType.Float, "Phred-scaled p-value using Fisher's exact test to detect strand bias"))
   )
 
   val FORMAT_KEYS: Seq[AttrKey] = Seq(


### PR DESCRIPTION
Resolves #923. Tested on the cluster and works with VCF file generated from UnifiedGenotyper.