### PR TITLE
adam2vcf doesn't have info fields

### DIFF
--- a/adam-core/src/test/scala/org/bdgenomics/adam/converters/VariantContextConverterSuite.scala
+++ b/adam-core/src/test/scala/org/bdgenomics/adam/converters/VariantContextConverterSuite.scala
@@ -183,6 +183,11 @@ class VariantContextConverterSuite extends ADAMFunSuite {
       .setVariant(variant)
       .setSampleId("NA12878")
       .setAlleles(List(GenotypeAllele.Ref, GenotypeAllele.Alt))
+      .setVariantCallingAnnotations(VariantCallingAnnotations.newBuilder()
+        .setFisherStrandBiasPValue(3.0f)
+        .setRmsMapQ(0.0f)
+        .setMapq0Reads(5)
+        .build)
       .build
 
     val converter = new VariantContextConverter
@@ -192,6 +197,9 @@ class VariantContextConverterSuite extends ADAMFunSuite {
     assert(gatkVC.hasGenotype("NA12878"))
     val gatkGT = gatkVC.getGenotype("NA12878")
     assert(gatkGT.getType === GenotypeType.HET)
+    assert(gatkVC.hasAttribute("FS"))
+    assert(gatkVC.hasAttribute("MQ"))
+    assert(gatkVC.hasAttribute("MQ0"))
   }
 
   test("Convert GATK multi-allelic sites-only SNVs to ADAM") {


### PR DESCRIPTION
I added info fields only if the vcf is from a single sample.

What's the desired behavior if the vcf has multiple samples per site?