### PR TITLE
[ADAM-946] Fixes to FlagStat for Samtools concordance issue

### DIFF
--- a/adam-cli/src/main/scala/org/bdgenomics/adam/cli/FlagStat.scala
+++ b/adam-cli/src/main/scala/org/bdgenomics/adam/cli/FlagStat.scala
@@ -61,7 +61,8 @@ class FlagStat(protected val args: FlagStatArgs) extends BDGSparkCommand[FlagSta
       AlignmentRecordField.readInFragment,
       AlignmentRecordField.properPair,
       AlignmentRecordField.mapq,
-      AlignmentRecordField.failedVendorQualityChecks
+      AlignmentRecordField.failedVendorQualityChecks,
+      AlignmentRecordField.supplementaryAlignment
     )
 
     val adamFile: RDD[AlignmentRecord] = sc.loadAlignments(args.inputPath, projection = Some(projection))

--- a/adam-core/src/main/scala/org/bdgenomics/adam/converters/SAMRecordConverter.scala
+++ b/adam-core/src/main/scala/org/bdgenomics/adam/converters/SAMRecordConverter.scala
@@ -104,26 +104,37 @@ class SAMRecordConverter extends Serializable with Logging {
           builder.setMapq(mapq)
         }
 
-        // set mapping flags
-        // oddly enough, it appears that reads can show up with mapping info (mapq, cigar, position)
-        // even if the read unmapped flag is set...
-        if (samRecord.getReadUnmappedFlag) {
-          builder.setReadMapped(false)
-        } else {
-          builder.setReadMapped(true)
-          if (samRecord.getReadNegativeStrandFlag) {
-            builder.setReadNegativeStrand(true)
-          }
-          if (!samRecord.getNotPrimaryAlignmentFlag) {
-            builder.setPrimaryAlignment(true)
-          } else {
-            // if the read is not a primary alignment, it can be either secondary or supplementary
-            // - secondary: not the best linear alignment
-            // - supplementary: part of a chimeric alignment
-            builder.setSupplementaryAlignment(samRecord.getSupplementaryAlignmentFlag)
-            builder.setSecondaryAlignment(!samRecord.getSupplementaryAlignmentFlag)
-          }
-        }
+      }
+
+      // set mapping flags
+      // oddly enough, it appears that reads can show up with mapping info (mapq, cigar, position)
+      // even if the read unmapped flag is set...
+
+      // While the meaning of the ReadMapped, ReadNegativeStand, PrimaryAlignmentFlag and SupplementaryAlignmentFlag
+      // are unclear when the read is not mapped or reference is not defined, it is nonetheless favorable
+      // to set these flags in the ADAM file in same way as they appear in the input BAM inorder to match exactly
+      // the statistics output by other programs, specifically Samtools Flagstat
+
+      if (samRecord.getReadUnmappedFlag) {
+        builder.setReadMapped(false)
+      } else {
+        builder.setReadMapped(true)
+      }
+
+      if (samRecord.getReadNegativeStrandFlag) {
+        builder.setReadNegativeStrand(true)
+      }
+
+      if (samRecord.getNotPrimaryAlignmentFlag) {
+        builder.setPrimaryAlignment(false)
+      } else {
+        builder.setPrimaryAlignment(true)
+      }
+
+      if (samRecord.getSupplementaryAlignmentFlag) {
+        builder.setSupplementaryAlignment(true)
+      } else {
+        builder.setSupplementaryAlignment(false)
       }
 
       // Position of the mate/next segment

--- a/adam-core/src/main/scala/org/bdgenomics/adam/converters/SAMRecordConverter.scala
+++ b/adam-core/src/main/scala/org/bdgenomics/adam/converters/SAMRecordConverter.scala
@@ -107,35 +107,21 @@ class SAMRecordConverter extends Serializable with Logging {
       }
 
       // set mapping flags
-      // oddly enough, it appears that reads can show up with mapping info (mapq, cigar, position)
+      // oddly enough, it appears that reads can show up with mapping
+      // info (mapq, cigar, position)
       // even if the read unmapped flag is set...
 
-      // While the meaning of the ReadMapped, ReadNegativeStand, PrimaryAlignmentFlag and SupplementaryAlignmentFlag
-      // are unclear when the read is not mapped or reference is not defined, it is nonetheless favorable
-      // to set these flags in the ADAM file in same way as they appear in the input BAM inorder to match exactly
+      // While the meaning of the ReadMapped, ReadNegativeStand,
+      // PrimaryAlignmentFlag and SupplementaryAlignmentFlag
+      // are unclear when the read is not mapped or reference is not defined,
+      // it is nonetheless favorable to set these flags in the ADAM file
+      // in same way as they appear in the input BAM inorder to match exactly
       // the statistics output by other programs, specifically Samtools Flagstat
 
-      if (samRecord.getReadUnmappedFlag) {
-        builder.setReadMapped(false)
-      } else {
-        builder.setReadMapped(true)
-      }
-
-      if (samRecord.getReadNegativeStrandFlag) {
-        builder.setReadNegativeStrand(true)
-      }
-
-      if (samRecord.getNotPrimaryAlignmentFlag) {
-        builder.setPrimaryAlignment(false)
-      } else {
-        builder.setPrimaryAlignment(true)
-      }
-
-      if (samRecord.getSupplementaryAlignmentFlag) {
-        builder.setSupplementaryAlignment(true)
-      } else {
-        builder.setSupplementaryAlignment(false)
-      }
+      builder.setReadMapped(!samRecord.getReadUnmappedFlag)
+      builder.setReadNegativeStrand(samRecord.getReadNegativeStrandFlag)
+      builder.setPrimaryAlignment(!samRecord.getNotPrimaryAlignmentFlag)
+      builder.setSupplementaryAlignment(samRecord.getSupplementaryAlignmentFlag)
 
       // Position of the mate/next segment
       val mateReference: Int = samRecord.getMateReferenceIndex
@@ -152,7 +138,8 @@ class SAMRecordConverter extends Serializable with Logging {
         }
       }
 
-      // The Avro scheme defines all flags as defaulting to 'false'. We only need to set the flags that are true.
+      // The Avro scheme defines all flags as defaulting to 'false'. We only
+      // need to set the flags that are true.
       if (samRecord.getFlags != 0) {
         if (samRecord.getReadPairedFlag) {
           builder.setReadPaired(true)

--- a/adam-core/src/main/scala/org/bdgenomics/adam/rdd/read/FlagStat.scala
+++ b/adam-core/src/main/scala/org/bdgenomics/adam/rdd/read/FlagStat.scala
@@ -103,14 +103,14 @@ object FlagStat {
           1,
           primaryDuplicates, secondaryDuplicates,
           b2i(b(p.getReadMapped)),
-          b2i(b(p.getReadPaired)),
-          b2i(b(p.getReadPaired) && p.getReadInFragment == 0),
-          b2i(b(p.getReadPaired) && p.getReadInFragment == 1),
-          b2i(b(p.getReadPaired) && b(p.getProperPair)),
-          b2i(b(p.getReadPaired) && b(p.getReadMapped) && b(p.getMateMapped)),
-          b2i(b(p.getReadPaired) && b(p.getReadMapped) && b(!p.getMateMapped)),
-          b2i(b(mateMappedToDiffChromosome)),
-          b2i(b(mateMappedToDiffChromosome && i(p.getMapq) >= 5)),
+          b2i(b(p.getReadPaired) && b(!p.getSupplementaryAlignment) && p.getPrimaryAlignment),
+          b2i(b(p.getReadPaired) && p.getReadInFragment == 0 && b(!p.getSupplementaryAlignment) && p.getPrimaryAlignment),
+          b2i(b(p.getReadPaired) && p.getReadInFragment == 1 && b(!p.getSupplementaryAlignment) && p.getPrimaryAlignment),
+          b2i(b(p.getReadPaired) && b(p.getProperPair) && b(!p.getSupplementaryAlignment) && p.getPrimaryAlignment),
+          b2i(b(p.getReadPaired) && b(p.getReadMapped) && b(p.getMateMapped) && b(!p.getSupplementaryAlignment) && p.getPrimaryAlignment),
+          b2i(b(p.getReadPaired) && b(p.getReadMapped) && b(!p.getMateMapped) && b(!p.getSupplementaryAlignment) && p.getPrimaryAlignment),
+          b2i(b(mateMappedToDiffChromosome) && b(!p.getSupplementaryAlignment) && p.getPrimaryAlignment),
+          b2i(b(mateMappedToDiffChromosome && i(p.getMapq) >= 5) && b(!p.getSupplementaryAlignment) && p.getPrimaryAlignment),
           p.getFailedVendorQualityChecks
         )
     }.aggregate((FlagStatMetrics.emptyFailedQuality, FlagStatMetrics.emptyPassedQuality))(

--- a/adam-core/src/main/scala/org/bdgenomics/adam/rich/DecadentRead.scala
+++ b/adam-core/src/main/scala/org/bdgenomics/adam/rich/DecadentRead.scala
@@ -78,7 +78,7 @@ private[adam] object DecadentRead extends Logging with Serializable {
 @deprecated("Use RichAlignmentRecord wherever possible in new development.", since = "0.18.0")
 private[adam] class DecadentRead(val record: RichAlignmentRecord) extends Logging {
   // Can't be a primary alignment unless it has been aligned
-  require(!record.getPrimaryAlignment || record.getReadMapped, "Unaligned read can't be a primary alignment")
+  //require(!record.getPrimaryAlignment || record.getReadMapped, "Unaligned read can't be a primary alignment")
 
   // Should have quality scores for all residues
   require(record.getQual == null ||

--- a/adam-core/src/main/scala/org/bdgenomics/adam/rich/DecadentRead.scala
+++ b/adam-core/src/main/scala/org/bdgenomics/adam/rich/DecadentRead.scala
@@ -77,9 +77,6 @@ private[adam] object DecadentRead extends Logging with Serializable {
 
 @deprecated("Use RichAlignmentRecord wherever possible in new development.", since = "0.18.0")
 private[adam] class DecadentRead(val record: RichAlignmentRecord) extends Logging {
-  // Can't be a primary alignment unless it has been aligned
-  //require(!record.getPrimaryAlignment || record.getReadMapped, "Unaligned read can't be a primary alignment")
-
   // Should have quality scores for all residues
   require(record.getQual == null ||
     record.getSequence.length == record.qualityScores.length, "sequence and qualityScores must be same length")

--- a/adam-core/src/test/scala/org/bdgenomics/adam/converters/AlignmentRecordConverterSuite.scala
+++ b/adam-core/src/test/scala/org/bdgenomics/adam/converters/AlignmentRecordConverterSuite.scala
@@ -249,7 +249,7 @@ class AlignmentRecordConverterSuite extends FunSuite {
       .split('\n')
 
     assert(!secondRecord.getReadMapped)
-    assert(!secondRecord.getReadNegativeStrand)
+    assert(secondRecord.getReadNegativeStrand)
     assert(secondRecordFastq(0) === "@SRR062634.10448889/1")
     assert(secondRecordFastq(1) === secondRecord.getSequence)
     assert(secondRecordFastq(2) === "+")


### PR DESCRIPTION
These changes result in perfect concordance between ADAM and Samtools flagstat output stats, addressing corner cases around secondary, supplemental, and unmapped reads as described in #946 