### PR TITLE
improve SW performance by replacing functional reductions with imperative ones

### DIFF
--- a/adam-core/src/main/scala/org/bdgenomics/adam/algorithms/smithwaterman/SmithWaterman.scala
+++ b/adam-core/src/main/scala/org/bdgenomics/adam/algorithms/smithwaterman/SmithWaterman.scala
@@ -48,38 +48,23 @@ abstract class SmithWaterman(xSequence: String, ySequence: String) extends Seria
    * @return Tuple of (i, j) coordinates.
    */
   private[smithwaterman] final def maxCoordinates(matrix: Array[Array[Double]]): (Int, Int) = {
-    def maxInCol(col: Array[Double]): (Double, Int) = {
-      def takeMax(a: (Double, Int), b: (Double, Int)): (Double, Int) = {
-        if (a._1 > b._1) {
-          a
-        } else {
-          b
+    var xMax = 0
+    var yMax = 0
+    var max = Double.MinValue
+    var x = 0
+    while (x < matrix.length) {
+      var y = 0
+      while (y < matrix(x).length) {
+        if (matrix(x)(y) >= max) {
+          max = matrix(x)(y)
+          xMax = x
+          yMax = y
         }
+        y += 1
       }
-
-      val c: Array[(Double, Int)] = col.zipWithIndex
-
-      c.reduce(takeMax)
+      x += 1
     }
-
-    def maxCol(cols: Array[(Double, Int)]): (Int, Int) = {
-      def takeMax(a: (Double, Int, Int), b: (Double, Int, Int)): (Double, Int, Int) = {
-        if (a._1 > b._1) {
-          a
-        } else {
-          b
-        }
-      }
-
-      val c: Array[((Double, Int), Int)] = cols.zipWithIndex
-
-      val m: (Double, Int, Int) = c.map(kv => (kv._1._1, kv._1._2, kv._2))
-        .reduce(takeMax)
-
-      (m._2, m._3)
-    }
-
-    maxCol(matrix.map(maxInCol))
+    (yMax, xMax)
   }
 
   /**

--- a/adam-core/src/main/scala/org/bdgenomics/adam/algorithms/smithwaterman/SmithWatermanGapScoringFromFn.scala
+++ b/adam-core/src/main/scala/org/bdgenomics/adam/algorithms/smithwaterman/SmithWatermanGapScoringFromFn.scala
@@ -46,8 +46,10 @@ abstract class SmithWatermanGapScoringFromFn(
     }
 
     // score matrix
-    for (i <- 1 to x) {
-      for (j <- 1 to y) {
+    var i = 1
+    while (i <= x) {
+      var j = 1
+      while (j <= y) {
         val m = scoreMatrix(i - 1)(j - 1) + scoreFn(i, j, xSequence(i - 1), ySequence(j - 1))
         val d = scoreMatrix(i - 1)(j) + scoreFn(i, j, xSequence(i - 1), '_')
         val in = scoreMatrix(i)(j - 1) + scoreFn(i, j, '_', ySequence(j - 1))
@@ -64,7 +66,9 @@ abstract class SmithWatermanGapScoringFromFn(
 
         scoreMatrix(i)(j) = scoreUpdate
         moveMatrix(i)(j) = moveUpdate
+        j += 1
       }
+      i += 1
     }
 
     (scoreMatrix, moveMatrix)

--- a/adam-core/src/test/scala/org/bdgenomics/adam/algorithms/smithwaterman/SmithWatermanSuite.scala
+++ b/adam-core/src/test/scala/org/bdgenomics/adam/algorithms/smithwaterman/SmithWatermanSuite.scala
@@ -19,6 +19,7 @@ package org.bdgenomics.adam.algorithms.smithwaterman
 
 import org.scalatest.FunSuite
 import scala.math.abs
+import scala.util.Random
 
 class SmithWatermanSuite extends FunSuite {
 
@@ -235,6 +236,15 @@ class SmithWatermanSuite extends FunSuite {
     assert(sw.cigarX.toString === "9M2I9M")
     assert(sw.cigarY.toString === "9M2D9M")
     assert(sw.xStart === 8)
+  }
+
+  test("smithWaterman - simple alignment") {
+    val sw = new SmithWatermanConstantGapScoring("AAA",
+      "AAT",
+      1.0, 0.0, -0.333, -0.333)
+    assert(sw.cigarX.toString === "3M")
+    assert(sw.cigarY.toString === "3M")
+    assert(sw.xStart === 0)
   }
 
 }


### PR DESCRIPTION
while running Smith-Waterman on large data sets over Spark we noticed "hot spots" in Scala's for-loops, hence the change below replaces the elegant functional calculations with the far less-elegant but slightly more efficient while-loops. 
We've seen a ~30% improvement in performance with this change.