### PR TITLE
A few improvements

### DIFF
--- a/adam-cli/src/main/scala/org/bdgenomics/adam/cli/Features2ADAM.scala
+++ b/adam-cli/src/main/scala/org/bdgenomics/adam/cli/Features2ADAM.scala
@@ -17,13 +17,10 @@
  */
 package org.bdgenomics.adam.cli
 
-import org.apache.hadoop.mapreduce.Job
 import org.apache.spark.SparkContext
-import org.apache.spark.rdd.RDD
 import org.bdgenomics.adam.rdd.ADAMContext._
-import org.bdgenomics.formats.avro.Feature
 import org.bdgenomics.utils.cli._
-import org.kohsuke.args4j.Argument
+import org.kohsuke.args4j.{ Argument, Option ⇒ Args4jOption }
 
 object Features2ADAM extends BDGCommandCompanion {
   val commandName = "features2adam"
@@ -41,6 +38,9 @@ class Features2ADAMArgs extends Args4jBase with ParquetSaveArgs {
   @Argument(required = true, metaVar = "ADAM",
     usage = "Location to write ADAM features data", index = 1)
   var outputPath: String = null
+  @Args4jOption(required = false, name = "-num_partitions",
+    usage = "Number of partitions to load an interval file using.")
+  var numPartitions: Int = 10
 }
 
 class Features2ADAM(val args: Features2ADAMArgs)
@@ -48,6 +48,6 @@ class Features2ADAM(val args: Features2ADAMArgs)
   val companion = Features2ADAM
 
   def run(sc: SparkContext) {
-    sc.loadFeatures(args.featuresFile).adamParquetSave(args)
+    sc.loadFeatures(args.featuresFile, None, args.numPartitions).adamParquetSave(args)
   }
 }

--- a/adam-core/src/main/scala/org/bdgenomics/adam/converters/FastqRecordConverter.scala
+++ b/adam-core/src/main/scala/org/bdgenomics/adam/converters/FastqRecordConverter.scala
@@ -178,8 +178,11 @@ class FastqRecordConverter extends Serializable with Logging {
 
     require(
       readSequence.length == readQualities.length,
-      "Read " + readName + " has different sequence and qual length: " +
-        "\n\tsequence=" + readSequence + "\n\tqual=" + readQualities
+      List(
+        s"Read $readName has different sequence and qual length:",
+        s"sequence=$readSequence",
+        s"qual=$readQualities"
+      ).mkString("\n\t")
     )
 
     val builder = AlignmentRecord.newBuilder()

--- a/adam-core/src/main/scala/org/bdgenomics/adam/models/SnpTable.scala
+++ b/adam-core/src/main/scala/org/bdgenomics/adam/models/SnpTable.scala
@@ -40,7 +40,7 @@ class SnpTable(private val table: Map[String, Set[Long]]) extends Serializable w
   def contains(location: ReferencePosition): Boolean = {
     val bucket = table.get(location.referenceName)
     if (bucket.isEmpty) unknownContigWarning(location.referenceName)
-    bucket.map(_.contains(location.pos)).getOrElse(false)
+    bucket.exists(_.contains(location.pos))
   }
 
   private val unknownContigs = new mutable.HashSet[String]

--- a/adam-core/src/main/scala/org/bdgenomics/adam/rdd/ADAMContext.scala
+++ b/adam-core/src/main/scala/org/bdgenomics/adam/rdd/ADAMContext.scala
@@ -516,7 +516,7 @@ class ADAMContext(@transient val sc: SparkContext) extends Serializable with Log
     stringency: ValidationStringency = ValidationStringency.STRICT): AlignmentRecordRDD = {
     filePath2Opt match {
       case Some(filePath2) => loadPairedFastq(filePath1, filePath2, recordGroupOpt, stringency)
-      case None            => loadUnpairedFastq(filePath1, stringency = stringency)
+      case None            => loadUnpairedFastq(filePath1, recordGroupOpt, stringency = stringency)
     }
   }
 

--- a/adam-core/src/main/scala/org/bdgenomics/adam/rdd/ADAMContext.scala
+++ b/adam-core/src/main/scala/org/bdgenomics/adam/rdd/ADAMContext.scala
@@ -727,10 +727,10 @@ class ADAMContext(@transient val sc: SparkContext) extends Serializable with Log
     projection: Option[Schema] = None,
     sd: Option[SequenceDictionary] = None): RDD[DatabaseVariantAnnotation] = {
     if (filePath.endsWith(".vcf")) {
-      log.info("Loading " + filePath + " as VCF, and converting to variant annotations. Projection is ignored.")
+      log.info(s"Loading $filePath as VCF, and converting to variant annotations. Projection is ignored.")
       loadVcfAnnotations(filePath, sd)
     } else {
-      log.info("Loading " + filePath + " as Parquet containing DatabaseVariantAnnotations.")
+      log.info(s"Loading $filePath as Parquet containing DatabaseVariantAnnotations.")
       sd.foreach(sd => log.warn("Sequence dictionary for translation ignored if loading ADAM from Parquet."))
       loadParquetVariantAnnotations(filePath, None, projection)
     }
@@ -782,13 +782,13 @@ class ADAMContext(@transient val sc: SparkContext) extends Serializable with Log
     fragmentLength: Long = 10000): RDD[NucleotideContigFragment] = {
     if (filePath.endsWith(".fa") ||
       filePath.endsWith(".fasta")) {
-      log.info("Loading " + filePath + " as FASTA and converting to NucleotideContigFragment. Projection is ignored.")
+      log.info(s"Loading $filePath as FASTA and converting to NucleotideContigFragment. Projection is ignored.")
       loadFasta(
         filePath,
         fragmentLength
       )
     } else {
-      log.info("Loading " + filePath + " as Parquet containing NucleotideContigFragments.")
+      log.info(s"Loading $filePath as Parquet containing NucleotideContigFragments.")
       loadParquetContigFragments(filePath, None, projection)
     }
   }
@@ -798,10 +798,10 @@ class ADAMContext(@transient val sc: SparkContext) extends Serializable with Log
     projection: Option[Schema] = None,
     sd: Option[SequenceDictionary] = None): RDD[Genotype] = {
     if (filePath.endsWith(".vcf")) {
-      log.info("Loading " + filePath + " as VCF, and converting to Genotypes. Projection is ignored.")
+      log.info(s"Loading $filePath as VCF, and converting to Genotypes. Projection is ignored.")
       loadVcf(filePath, sd).flatMap(_.genotypes)
     } else {
-      log.info("Loading " + filePath + " as Parquet containing Genotypes. Sequence dictionary for translation is ignored.")
+      log.info(s"Loading $filePath as Parquet containing Genotypes. Sequence dictionary for translation is ignored.")
       loadParquetGenotypes(filePath, None, projection)
     }
   }
@@ -811,10 +811,10 @@ class ADAMContext(@transient val sc: SparkContext) extends Serializable with Log
     projection: Option[Schema] = None,
     sd: Option[SequenceDictionary] = None): RDD[Variant] = {
     if (filePath.endsWith(".vcf")) {
-      log.info("Loading " + filePath + " as VCF, and converting to Variants. Projection is ignored.")
+      log.info(s"Loading $filePath as VCF, and converting to Variants. Projection is ignored.")
       loadVcf(filePath, sd).map(_.variant.variant)
     } else {
-      log.info("Loading " + filePath + " as Parquet containing Variants. Sequence dictionary for translation is ignored.")
+      log.info(s"Loading $filePath as Parquet containing Variants. Sequence dictionary for translation is ignored.")
       loadParquetVariants(filePath, None, projection)
     }
   }
@@ -859,27 +859,26 @@ class ADAMContext(@transient val sc: SparkContext) extends Serializable with Log
 
     if (filePath.endsWith(".sam") ||
       filePath.endsWith(".bam")) {
-      log.info("Loading " + filePath + " as SAM/BAM and converting to AlignmentRecords. Projection is ignored.")
+      log.info(s"Loading $filePath as SAM/BAM and converting to AlignmentRecords. Projection is ignored.")
       loadBam(filePath, stringency)
     } else if (filePath.endsWith(".ifq")) {
-      log.info("Loading " + filePath + " as interleaved FASTQ and converting to AlignmentRecords. Projection is ignored.")
+      log.info(s"Loading $filePath as interleaved FASTQ and converting to AlignmentRecords. Projection is ignored.")
       loadInterleavedFastq(filePath)
     } else if (filePath.endsWith(".fq") ||
       filePath.endsWith(".fastq")) {
-      log.info("Loading " + filePath + " as unpaired FASTQ and converting to AlignmentRecords. Projection is ignored.")
+      log.info(s"Loading $filePath as unpaired FASTQ and converting to AlignmentRecords. Projection is ignored.")
       loadFastq(filePath, filePath2Opt, recordGroupOpt, stringency)
     } else if (filePath.endsWith(".fa") ||
       filePath.endsWith(".fasta")) {
-      log.info("Loading " + filePath + " as FASTA and converting to AlignmentRecords. Projection is ignored.")
+      log.info(s"Loading $filePath as FASTA and converting to AlignmentRecords. Projection is ignored.")
       import ADAMContext._
       UnalignedReadRDD(loadFasta(filePath, fragmentLength = 10000).toReads,
         RecordGroupDictionary.empty)
     } else if (filePath.endsWith("contig.adam")) {
-      log.info("Loading " + filePath + " as Parquet of NucleotideContigFragment and converting to AlignmentRecords. Projection is ignored.")
-      UnalignedReadRDD(loadParquet[NucleotideContigFragment](filePath).toReads,
-        RecordGroupDictionary.empty)
+      log.info(s"Loading $filePath as Parquet of NucleotideContigFragment and converting to AlignmentRecords. Projection is ignored.")
+      UnalignedReadRDD(loadParquet[NucleotideContigFragment](filePath).toReads, RecordGroupDictionary.empty)
     } else {
-      log.info("Loading " + filePath + " as Parquet of AlignmentRecords.")
+      log.info(s"Loading $filePath as Parquet of AlignmentRecords.")
       loadParquetAlignments(filePath, None, projection)
     }
   }
@@ -887,10 +886,10 @@ class ADAMContext(@transient val sc: SparkContext) extends Serializable with Log
   def loadFragments(filePath: String): RDD[Fragment] = LoadFragments.time {
     if (filePath.endsWith(".sam") ||
       filePath.endsWith(".bam")) {
-      log.info("Loading " + filePath + " as SAM/BAM and converting to Fragments.")
+      log.info(s"Loading $filePath as SAM/BAM and converting to Fragments.")
       loadBam(filePath).rdd.toFragments
     } else if (filePath.endsWith(".reads.adam")) {
-      log.info("Loading " + filePath + " as ADAM AlignmentRecords and converting to Fragments.")
+      log.info(s"Loading $filePath as ADAM AlignmentRecords and converting to Fragments.")
       loadAlignments(filePath).rdd.toFragments
     } else if (filePath.endsWith(".ifq")) {
       log.info("Loading interleaved FASTQ " + filePath + " and converting to Fragments.")

--- a/adam-core/src/main/scala/org/bdgenomics/adam/rdd/ADAMContext.scala
+++ b/adam-core/src/main/scala/org/bdgenomics/adam/rdd/ADAMContext.scala
@@ -525,8 +525,8 @@ class ADAMContext(@transient val sc: SparkContext) extends Serializable with Log
     filePath2: String,
     recordGroupOpt: Option[String],
     stringency: ValidationStringency): AlignmentRecordRDD = {
-    val reads1 = loadUnpairedFastq(filePath1, setFirstOfPair = true, stringency = stringency)
-    val reads2 = loadUnpairedFastq(filePath2, setSecondOfPair = true, stringency = stringency)
+    val reads1 = loadUnpairedFastq(filePath1, recordGroupOpt, setFirstOfPair = true, stringency = stringency)
+    val reads2 = loadUnpairedFastq(filePath2, recordGroupOpt, setSecondOfPair = true, stringency = stringency)
 
     stringency match {
       case ValidationStringency.STRICT | ValidationStringency.LENIENT =>

--- a/adam-core/src/main/scala/org/bdgenomics/adam/rdd/ADAMContext.scala
+++ b/adam-core/src/main/scala/org/bdgenomics/adam/rdd/ADAMContext.scala
@@ -254,12 +254,10 @@ class ADAMContext(@transient val sc: SparkContext) extends Serializable with Log
    * AlignmentRecord schema.
    *
    * @param filePath Path to the file on disk.
-   *
    * @return Returns an AlignmentRecordRDD which wraps the RDD of reads,
    *   sequence dictionary representing the contigs these reads are aligned to
    *   if the reads are aligned, and the record group dictionary for the reads
    *   if one is available.
-   *
    * @see loadAlignments
    */
   def loadBam(filePath: String,
@@ -388,10 +386,8 @@ class ADAMContext(@transient val sc: SparkContext) extends Serializable with Log
    * As such, we must force the user to pass in the schema.
    *
    * @tparam T The type of the specific record we are loading.
-   *
    * @param filename Path to load file from.
    * @param schema Schema of records we are loading.
-   *
    * @return Returns a Seq containing the avro records.
    */
   private def loadAvro[T <: SpecificRecordBase](filename: String,
@@ -458,17 +454,14 @@ class ADAMContext(@transient val sc: SparkContext) extends Serializable with Log
    * @param filePath The path of the file to load.
    * @param predicate An optional predicate to push down into the file.
    * @param projection An optional schema designating the fields to project.
-   *
    * @return Returns an AlignmentRecordRDD which wraps the RDD of reads,
    *   sequence dictionary representing the contigs these reads are aligned to
    *   if the reads are aligned, and the record group dictionary for the reads
    *   if one is available.
-   *
    * @note The sequence dictionary is read from an avro file stored at
    *   filePath.seqdict and the record group dictionary is read from an
    *   avro file stored at filePath.rgdict. These files are pure avro,
    *   not Parquet.
-   *
    * @see loadAlignments
    */
   def loadParquetAlignments(
@@ -750,18 +743,18 @@ class ADAMContext(@transient val sc: SparkContext) extends Serializable with Log
 
     if (filePath.endsWith(".bed")) {
       log.info(s"Loading $filePath as BED and converting to features. Projection is ignored.")
-      loadBED(filePath)
+      loadBED(filePath, minPartitions)
     } else if (filePath.endsWith(".gtf") ||
       filePath.endsWith(".gff")) {
       log.info(s"Loading $filePath as GTF/GFF and converting to features. Projection is ignored.")
-      loadGTF(filePath)
+      loadGTF(filePath, minPartitions)
     } else if (filePath.endsWith(".narrowPeak") ||
       filePath.endsWith(".narrowpeak")) {
       log.info(s"Loading $filePath as NarrowPeak and converting to features. Projection is ignored.")
-      loadNarrowPeak(filePath)
+      loadNarrowPeak(filePath, minPartitions)
     } else if (filePath.endsWith(".interval_list")) {
       log.info(s"Loading $filePath as IntervalList and converting to features. Projection is ignored.")
-      loadIntervalList(filePath)
+      loadIntervalList(filePath, minPartitions)
     } else {
       log.info(s"Loading $filePath as Parquet containing Features.")
       loadParquetFeatures(filePath, None, projection)
@@ -846,12 +839,10 @@ class ADAMContext(@transient val sc: SparkContext) extends Serializable with Log
    *  Ignored if not FASTQ.
    * @param recordGroupOpt Optional record group name to set if loading FASTQ.
    * @param stringency Validation stringency used on FASTQ import/merging.
-   *
    * @return Returns an AlignmentRecordRDD which wraps the RDD of reads,
    *   sequence dictionary representing the contigs these reads are aligned to
    *   if the reads are aligned, and the record group dictionary for the reads
    *   if one is available.
-   *
    * @see loadBam
    * @see loadParquetAlignments
    * @see loadInterleavedFastq
@@ -924,7 +915,6 @@ class ADAMContext(@transient val sc: SparkContext) extends Serializable with Log
    *   sequence dictionary representing the contigs these reads are aligned to
    *   if the reads are aligned, and the record group dictionary for the reads
    *   if one is available.
-   *
    * @see loadAlignments
    */
   def loadAlignmentsFromPaths(paths: Seq[Path]): AlignmentRecordRDD = {

--- a/adam-core/src/main/scala/org/bdgenomics/adam/rdd/read/recalibration/CycleCovariate.scala
+++ b/adam-core/src/main/scala/org/bdgenomics/adam/rdd/read/recalibration/CycleCovariate.scala
@@ -23,7 +23,7 @@ import org.bdgenomics.adam.rich.DecadentRead
 class CycleCovariate extends AbstractCovariate[Int] {
   def compute(read: DecadentRead): Seq[Option[Int]] = {
     val (initial, increment) = initialization(read)
-    Range(0, read.residues.length).map(pos => Some(initial + increment * pos))
+    read.residues.indices.map(pos => Some(initial + increment * pos))
   }
 
   // Returns (initialValue, increment)


### PR DESCRIPTION
A couple random things I had laying around:
* most substantive change: allow a `minPartitions` parameter to the various interval-file-loading functions, which wrap `sc.textFile`.
  * I am having issues where 20MM-line bed files get loaded with maximum 2 partitions due to [this (imho inadvisable) `math.min` in Spark](https://github.com/apache/spark/blob/v1.6.0/core/src/main/scala/org/apache/spark/SparkContext.scala#L2099), resulting in executor OOMs.
* Thread a record-group parameter through some places that it was missing.
* Style nits.

Fixes #969 #968 