### PR TITLE
Use .adam/_{seq,rg}dict.avro paths for Avro-formatted dictionaries

### DIFF
--- a/adam-core/src/main/scala/org/bdgenomics/adam/rdd/ADAMContext.scala
+++ b/adam-core/src/main/scala/org/bdgenomics/adam/rdd/ADAMContext.scala
@@ -459,8 +459,8 @@ class ADAMContext(@transient val sc: SparkContext) extends Serializable with Log
    *   if the reads are aligned, and the record group dictionary for the reads
    *   if one is available.
    * @note The sequence dictionary is read from an avro file stored at
-   *   filePath.seqdict and the record group dictionary is read from an
-   *   avro file stored at filePath.rgdict. These files are pure avro,
+   *   filePath/_seqdict.avro and the record group dictionary is read from an
+   *   avro file stored at filePath/_rgdict.avro. These files are pure avro,
    *   not Parquet.
    * @see loadAlignments
    */
@@ -471,9 +471,9 @@ class ADAMContext(@transient val sc: SparkContext) extends Serializable with Log
 
     // load from disk
     val rdd = loadParquet[AlignmentRecord](filePath, predicate, projection)
-    val avroSd = loadAvro[Contig]("%s.seqdict".format(filePath),
+    val avroSd = loadAvro[Contig]("%s/_seqdict.avro".format(filePath),
       Contig.SCHEMA$)
-    val avroRgd = loadAvro[RecordGroupMetadata]("%s.rgdict".format(filePath),
+    val avroRgd = loadAvro[RecordGroupMetadata]("%s/_rgdict.avro".format(filePath),
       RecordGroupMetadata.SCHEMA$)
 
     // convert avro to sequence dictionary


### PR DESCRIPTION
Fixes #945 

This results in a Parquet folder structure of
```
$ ls -ls /var/folders/3y/61r1w_cs4hbdr_34nrdrbhww0000gn/T/3911097172870281306/reads12.adam
total 176
 8 -rw-r--r--   1 user  staff      8 Mar 24 17:38 ._SUCCESS.crc
 8 -rw-r--r--   1 user  staff     92 Mar 24 17:38 ._common_metadata.crc
 8 -rw-r--r--   1 user  staff    120 Mar 24 17:38 ._metadata.crc
 8 -rw-r--r--   1 user  staff     20 Mar 24 17:38 ._rgdict.avro.crc
 8 -rw-r--r--   1 user  staff     20 Mar 24 17:38 ._seqdict.avro.crc
 8 -rw-r--r--   1 user  staff    204 Mar 24 17:38 .part-r-00000.gz.parquet.crc
 0 -rw-r--r--   1 user  staff      0 Mar 24 17:38 _SUCCESS
24 -rw-r--r--   1 user  staff  10494 Mar 24 17:38 _common_metadata
32 -rw-r--r--   1 user  staff  14304 Mar 24 17:38 _metadata
 8 -rw-r--r--   1 user  staff   1247 Mar 24 17:38 _rgdict.avro
 8 -rw-r--r--   1 user  staff   1450 Mar 24 17:38 _seqdict.avro
56 -rw-r--r--   1 user  staff  24716 Mar 24 17:38 part-r-00000.gz.parquet
```
Another option would be ```.adam/.{seq,rg}dict.avro```.

Other file names are mistaken by Parquet to be Parquet-formatted files and a RuntimeException is thrown, e.g.
```
RuntimeException: file:/var/folders/3y/61r1w_cs4hbdr_34nrdrbhww0000gn/T/
7766788398861766842/reads12.adam/seqdict.avro is not a Parquet file. expected
magic number at tail [80, 65, 82, 49] but found [-104, -80, 71, -108]
```