### PR TITLE
[ADAM-510] Refactoring RDD function names

### DIFF
--- a/adam-apis/src/main/scala/org/bdgenomics/adam/apis/java/JavaADAMContext.scala
+++ b/adam-apis/src/main/scala/org/bdgenomics/adam/apis/java/JavaADAMContext.scala
@@ -60,7 +60,7 @@ class JavaADAMContext(val ac: ADAMContext) extends Serializable {
    * @param filePath Path to load the file from.
    * @return Returns a read RDD.
    */
-  def adamRecordLoad(filePath: java.lang.String): JavaAlignmentRecordRDD = {
+  def loadAlignments(filePath: java.lang.String): JavaAlignmentRecordRDD = {
     val aRdd = ac.loadAlignments(filePath)
     new JavaAlignmentRecordRDD(aRdd.rdd.toJavaRDD(),
       aRdd.sequences,

--- a/adam-apis/src/main/scala/org/bdgenomics/adam/apis/java/JavaAlignmentRecordRDD.scala
+++ b/adam-apis/src/main/scala/org/bdgenomics/adam/apis/java/JavaAlignmentRecordRDD.scala
@@ -46,7 +46,7 @@ class JavaAlignmentRecordRDD(val jrdd: JavaRDD[AlignmentRecord],
    * @param compressCodec Name of the compression codec to use.
    * @param disableDictionaryEncoding Whether or not to disable bit-packing.
    */
-  def adamSave(
+  def saveAsParquet(
     filePath: java.lang.String,
     blockSize: java.lang.Integer,
     pageSize: java.lang.Integer,
@@ -67,7 +67,7 @@ class JavaAlignmentRecordRDD(val jrdd: JavaRDD[AlignmentRecord],
    *
    * @param filePath Path to save the file at.
    */
-  def adamSave(
+  def saveAsParquet(
     filePath: java.lang.String) {
     jrdd.rdd.saveAsParquet(
       new JavaSaveArgs(filePath),
@@ -79,18 +79,16 @@ class JavaAlignmentRecordRDD(val jrdd: JavaRDD[AlignmentRecord],
    * Saves this RDD to disk as a SAM/BAM file.
    *
    * @param filePath Path to save the file at.
-   * @param sd A dictionary describing the contigs this file is aligned against.
-   * @param rgd A dictionary describing the read groups in this file.
    * @param asSam If true, saves as SAM. If false, saves as BAM.
    * @param asSingleFile If true, saves output as a single file.
    * @param isSorted If the output is sorted, this will modify the header.
    */
-  def adamSAMSave(
+  def saveAsSam(
     filePath: java.lang.String,
     asSam: java.lang.Boolean,
     asSingleFile: java.lang.Boolean,
     isSorted: java.lang.Boolean) {
-    jrdd.rdd.adamSAMSave(filePath,
+    jrdd.rdd.saveAsSam(filePath,
       sd,
       rgd,
       asSam = asSam,

--- a/adam-apis/src/test/java/org/bdgenomics/adam/apis/java/JavaADAMConduit.java
+++ b/adam-apis/src/test/java/org/bdgenomics/adam/apis/java/JavaADAMConduit.java
@@ -39,10 +39,10 @@ public class JavaADAMConduit {
         // make temp directory and save file
         Path tempDir = Files.createTempDirectory("javaAC");
         String fileName = tempDir.toString() + "/testRdd.adam";
-        recordRdd.adamSave(fileName);
+        recordRdd.saveAsParquet(fileName);
 
         // create a new adam context and load the file
         JavaADAMContext jac = new JavaADAMContext(rdd.context());
-        return jac.adamRecordLoad(fileName);
+        return jac.loadAlignments(fileName);
     }
 }

--- a/adam-apis/src/test/scala/org/bdgenomics/adam/apis/java/JavaADAMContextSuite.scala
+++ b/adam-apis/src/test/scala/org/bdgenomics/adam/apis/java/JavaADAMContextSuite.scala
@@ -29,7 +29,7 @@ class JavaADAMContextSuite extends ADAMFunSuite {
   sparkTest("can read a small .SAM file") {
     val path = copyResource("small.sam")
     val ctx = new JavaADAMContext(sc)
-    val reads = ctx.adamRecordLoad(path)
+    val reads = ctx.loadAlignments(path)
     assert(reads.jrdd.count() === 20)
   }
 

--- a/adam-cli/src/main/scala/org/bdgenomics/adam/cli/ADAM2Fastq.scala
+++ b/adam-cli/src/main/scala/org/bdgenomics/adam/cli/ADAM2Fastq.scala
@@ -76,7 +76,7 @@ class ADAM2Fastq(val args: ADAM2FastqArgs) extends BDGSparkCommand[ADAM2FastqArg
       reads = reads.repartition(args.repartition)
     }
 
-    reads.adamSaveAsFastq(
+    reads.saveAsFastq(
       args.outputPath,
       Option(args.outputPath2),
       outputOriginalBaseQualities = args.outputOriginalBaseQualities,

--- a/adam-cli/src/main/scala/org/bdgenomics/adam/cli/CountContigKmers.scala
+++ b/adam-cli/src/main/scala/org/bdgenomics/adam/cli/CountContigKmers.scala
@@ -56,7 +56,7 @@ class CountContigKmers(protected val args: CountContigKmersArgs) extends BDGSpar
     ParquetLogger.hadoopLoggerLevel(Level.SEVERE)
 
     // read from disk
-    var fragments: RDD[NucleotideContigFragment] = sc.loadSequence(args.inputPath)
+    var fragments: RDD[NucleotideContigFragment] = sc.loadSequences(args.inputPath)
 
     // count kmers
     val countedKmers = fragments.countKmers(args.kmerLength)

--- a/adam-cli/src/main/scala/org/bdgenomics/adam/cli/CountReadKmers.scala
+++ b/adam-cli/src/main/scala/org/bdgenomics/adam/cli/CountReadKmers.scala
@@ -70,7 +70,7 @@ class CountReadKmers(protected val args: CountReadKmersArgs) extends BDGSparkCom
     }
 
     // count kmers
-    val countedKmers = adamRecords.adamCountKmers(args.kmerLength)
+    val countedKmers = adamRecords.countKmers(args.kmerLength)
 
     // cache counted kmers
     countedKmers.cache()

--- a/adam-cli/src/main/scala/org/bdgenomics/adam/cli/Fasta2ADAM.scala
+++ b/adam-cli/src/main/scala/org/bdgenomics/adam/cli/Fasta2ADAM.scala
@@ -55,7 +55,7 @@ class Fasta2ADAM(protected val args: Fasta2ADAMArgs) extends BDGSparkCommand[Fas
 
     if (args.verbose) {
       println("FASTA contains:")
-      println(adamFasta.adamGetSequenceDictionary())
+      println(adamFasta.getSequenceDictionary())
     }
 
     log.info("Writing records to disk.")
@@ -65,7 +65,7 @@ class Fasta2ADAM(protected val args: Fasta2ADAMArgs) extends BDGSparkCommand[Fas
       adamFasta
     }
 
-    finalFasta.adamParquetSave(args)
+    finalFasta.saveAsParquet(args)
   }
 }
 

--- a/adam-cli/src/main/scala/org/bdgenomics/adam/cli/Features2ADAM.scala
+++ b/adam-cli/src/main/scala/org/bdgenomics/adam/cli/Features2ADAM.scala
@@ -48,6 +48,6 @@ class Features2ADAM(val args: Features2ADAMArgs)
   val companion = Features2ADAM
 
   def run(sc: SparkContext) {
-    sc.loadFeatures(args.featuresFile, None, args.numPartitions).adamParquetSave(args)
+    sc.loadFeatures(args.featuresFile, None, args.numPartitions).saveAsParquet(args)
   }
 }

--- a/adam-cli/src/main/scala/org/bdgenomics/adam/cli/FlagStat.scala
+++ b/adam-cli/src/main/scala/org/bdgenomics/adam/cli/FlagStat.scala
@@ -76,7 +76,7 @@ class FlagStat(protected val args: FlagStatArgs) extends BDGSparkCommand[FlagSta
         stringency = stringency
       )
 
-    val (failedVendorQuality, passedVendorQuality) = adamFile.adamFlagStat()
+    val (failedVendorQuality, passedVendorQuality) = adamFile.flagStat()
 
     def percent(fraction: Long, total: Long) = if (total == 0) 0.0 else 100.00 * fraction.toFloat / total
 

--- a/adam-cli/src/main/scala/org/bdgenomics/adam/cli/Flatten.scala
+++ b/adam-cli/src/main/scala/org/bdgenomics/adam/cli/Flatten.scala
@@ -69,7 +69,7 @@ class Flatten(val args: FlattenArgs) extends BDGSparkCommand[FlattenArgs] with L
     val flatSchemaBc = sc.broadcast(flatSchema) // broadcast since Avro schema not serializable
 
     records.map(r => Flattener.flattenRecord(flatSchemaBc.value, r._2))
-      .adamParquetSave(
+      .saveAsParquet(
         args.outputPath,
         args.blockSize,
         args.pageSize,

--- a/adam-cli/src/main/scala/org/bdgenomics/adam/cli/Fragments2Reads.scala
+++ b/adam-cli/src/main/scala/org/bdgenomics/adam/cli/Fragments2Reads.scala
@@ -50,7 +50,7 @@ class Fragments2Reads(protected val args: Fragments2ReadsArgs) extends BDGSparkC
   def run(sc: SparkContext) {
     sc.loadFragments(args.inputPath)
       .toReads
-      .adamSave(args,
+      .save(args,
         SequenceDictionary.empty,
         RecordGroupDictionary.empty)
   }

--- a/adam-cli/src/main/scala/org/bdgenomics/adam/cli/ListDict.scala
+++ b/adam-cli/src/main/scala/org/bdgenomics/adam/cli/ListDict.scala
@@ -43,7 +43,7 @@ class ListDict(protected val args: ListDictArgs) extends BDGSparkCommand[ListDic
   val companion: BDGCommandCompanion = ListDict
 
   def run(sc: SparkContext): Unit = {
-    val dict = sc.adamDictionaryLoad[AlignmentRecord](args.inputPath)
+    val dict = sc.loadDictionary[AlignmentRecord](args.inputPath)
 
     dict.records.foreach {
       rec: SequenceRecord =>

--- a/adam-cli/src/main/scala/org/bdgenomics/adam/cli/PrintTags.scala
+++ b/adam-cli/src/main/scala/org/bdgenomics/adam/cli/PrintTags.scala
@@ -69,11 +69,11 @@ class PrintTags(protected val args: PrintTagsArgs) extends BDGSparkCommand[Print
       filtered.take(count).map(_.getAttributes).foreach(println)
     }
 
-    val tagCounts = filtered.adamCharacterizeTags().collect()
+    val tagCounts = filtered.characterizeTags().collect()
     for ((tag, count) <- tagCounts) {
       println("%3s\t%d".format(tag, count))
       if (toCount.contains(tag)) {
-        val countMap = filtered.adamCharacterizeTagValues(tag)
+        val countMap = filtered.characterizeTagValues(tag)
         for ((value, valueCount) <- countMap) {
           println("\t%10d\t%s".format(valueCount, value.toString))
         }

--- a/adam-cli/src/main/scala/org/bdgenomics/adam/cli/Reads2Fragments.scala
+++ b/adam-cli/src/main/scala/org/bdgenomics/adam/cli/Reads2Fragments.scala
@@ -47,6 +47,6 @@ class Reads2Fragments(protected val args: Reads2FragmentsArgs) extends BDGSparkC
   val companion = Reads2Fragments
 
   def run(sc: SparkContext) {
-    sc.loadAlignments(args.inputPath).rdd.toFragments.adamParquetSave(args)
+    sc.loadAlignments(args.inputPath).rdd.toFragments.saveAsParquet(args)
   }
 }

--- a/adam-cli/src/main/scala/org/bdgenomics/adam/cli/Transform.scala
+++ b/adam-cli/src/main/scala/org/bdgenomics/adam/cli/Transform.scala
@@ -137,7 +137,7 @@ class Transform(protected val args: TransformArgs) extends BDGSparkCommand[Trans
 
     if (args.markDuplicates) {
       log.info("Marking duplicates")
-      adamRecords = adamRecords.adamMarkDuplicates(rgd)
+      adamRecords = adamRecords.markDuplicates(rgd)
     }
 
     if (args.locallyRealign) {
@@ -153,7 +153,7 @@ class Transform(protected val args: TransformArgs) extends BDGSparkCommand[Trans
           new ConsensusGeneratorFromKnowns(_, sc).asInstanceOf[ConsensusGenerator]
         )
 
-      adamRecords = oldRdd.adamRealignIndels(
+      adamRecords = oldRdd.realignIndels(
         consensusGenerator,
         isSorted = false,
         args.maxIndelSize,
@@ -177,7 +177,7 @@ class Transform(protected val args: TransformArgs) extends BDGSparkCommand[Trans
       }
 
       val knownSnps: SnpTable = createKnownSnpsTable(sc)
-      adamRecords = oldRdd.adamBQSR(
+      adamRecords = oldRdd.recalibateBaseQualities(
         sc.broadcast(knownSnps),
         Option(args.observationsPath),
         stringency
@@ -206,7 +206,7 @@ class Transform(protected val args: TransformArgs) extends BDGSparkCommand[Trans
       }
 
       log.info("Sorting reads")
-      adamRecords = oldRdd.adamSortReadsByReferencePosition()
+      adamRecords = oldRdd.sortReadsByReferencePosition()
 
       if (args.cache) {
         oldRdd.unpersist()
@@ -341,7 +341,7 @@ class Transform(protected val args: TransformArgs) extends BDGSparkCommand[Trans
       mergedSd
     }
 
-    outputRdd.adamSave(args, sdFinal, mergedRgd, args.sortReads)
+    outputRdd.save(args, sdFinal, mergedRgd, args.sortReads)
   }
 
   private def createKnownSnpsTable(sc: SparkContext): SnpTable = CreateKnownSnpsTable.time {

--- a/adam-cli/src/main/scala/org/bdgenomics/adam/cli/Vcf2ADAM.scala
+++ b/adam-cli/src/main/scala/org/bdgenomics/adam/cli/Vcf2ADAM.scala
@@ -76,11 +76,11 @@ class Vcf2ADAM(val args: Vcf2ADAMArgs) extends BDGSparkCommand[Vcf2ADAMArgs] wit
     if (args.onlyVariants) {
       adamVariants
         .map(v => v.variant.variant)
-        .adamParquetSave(args)
+        .saveAsParquet(args)
     } else {
       adamVariants
         .flatMap(p => p.genotypes)
-        .adamParquetSave(args)
+        .saveAsParquet(args)
     }
   }
 }

--- a/adam-cli/src/main/scala/org/bdgenomics/adam/cli/VcfAnnotation2ADAM.scala
+++ b/adam-cli/src/main/scala/org/bdgenomics/adam/cli/VcfAnnotation2ADAM.scala
@@ -59,9 +59,9 @@ class VcfAnnotation2ADAM(val args: VcfAnnotation2ADAMArgs) extends BDGSparkComma
       val keyedAnnotations = existingAnnotations.keyBy(anno => new RichVariant(anno.getVariant))
       val joinedAnnotations = keyedAnnotations.join(annotations.keyBy(anno => new RichVariant(anno.getVariant)))
       val mergedAnnotations = joinedAnnotations.map(kv => VariantAnnotationConverter.mergeAnnotations(kv._2._1, kv._2._2))
-      mergedAnnotations.adamParquetSave(args)
+      mergedAnnotations.saveAsParquet(args)
     } else {
-      annotations.adamParquetSave(args)
+      annotations.saveAsParquet(args)
     }
   }
 }

--- a/adam-cli/src/main/scala/org/bdgenomics/adam/cli/View.scala
+++ b/adam-cli/src/main/scala/org/bdgenomics/adam/cli/View.scala
@@ -164,13 +164,13 @@ class View(val args: ViewArgs) extends BDGSparkCommand[ViewArgs] {
 
     val reads = applyFilters(sc.loadAlignments(args.inputPath))
 
-    if (args.outputPath != null)
-      reads.adamAlignedRecordSave(args, SequenceDictionary.empty, RecordGroupDictionary.empty)
-    else {
+    if (args.outputPath != null) {
+      reads.save(args, SequenceDictionary.empty, RecordGroupDictionary.empty)
+    } else {
       if (args.printCount) {
         println(reads.count())
       } else {
-        println(reads.adamSAMString(SequenceDictionary.empty, RecordGroupDictionary.empty))
+        println(reads.saveAsSamString(SequenceDictionary.empty, RecordGroupDictionary.empty))
       }
     }
   }

--- a/adam-cli/src/test/scala/org/bdgenomics/adam/cli/ADAM2FastqSuite.scala
+++ b/adam-cli/src/test/scala/org/bdgenomics/adam/cli/ADAM2FastqSuite.scala
@@ -61,7 +61,7 @@ class Adam2FastqSuite extends ADAMFunSuite {
         .rdd
         .filter(r => r.getReadMapped != null && r.getReadMapped)
 
-    reads.adamSaveAsFastq(outputFastqR1File, Some(outputFastqR2File), sort = true)
+    reads.saveAsFastq(outputFastqR1File, Some(outputFastqR2File), sort = true)
 
     val goldR1Reads =
       scala.io.Source.fromFile(new File(fastq1Path)).getLines().toSeq

--- a/adam-core/src/main/scala/org/bdgenomics/adam/rdd/ADAMRDDFunctions.scala
+++ b/adam-core/src/main/scala/org/bdgenomics/adam/rdd/ADAMRDDFunctions.scala
@@ -42,8 +42,8 @@ trait ADAMSaveAnyArgs extends SaveArgs {
 
 class ADAMRDDFunctions[T <% IndexedRecord: Manifest](rdd: RDD[T]) extends Serializable with Logging {
 
-  def adamParquetSave(args: SaveArgs): Unit = {
-    adamParquetSave(
+  def saveAsParquet(args: SaveArgs): Unit = {
+    saveAsParquet(
       args.outputPath,
       args.blockSize,
       args.pageSize,
@@ -52,7 +52,7 @@ class ADAMRDDFunctions[T <% IndexedRecord: Manifest](rdd: RDD[T]) extends Serial
     )
   }
 
-  def adamParquetSave(
+  def saveAsParquet(
     filePath: String,
     blockSize: Int = 128 * 1024 * 1024,
     pageSize: Int = 1 * 1024 * 1024,
@@ -99,7 +99,7 @@ abstract class ADAMSequenceDictionaryRDDAggregator[T](rdd: RDD[T]) extends Seria
    * @param elem Element from which to extract sequence records.
    * @return A seq of sequence records.
    */
-  def getSequenceRecordsFromElement(elem: T): Set[SequenceRecord]
+  def getSequenceRecords(elem: T): Set[SequenceRecord]
 
   /**
    * Aggregates together a sequence dictionary from the different individual reference sequences
@@ -107,9 +107,9 @@ abstract class ADAMSequenceDictionaryRDDAggregator[T](rdd: RDD[T]) extends Seria
    *
    * @return A sequence dictionary describing the reference contigs in this dataset.
    */
-  def adamGetSequenceDictionary(performLexSort: Boolean = false): SequenceDictionary = {
+  def getSequenceDictionary(performLexSort: Boolean = false): SequenceDictionary = {
     def mergeRecords(l: List[SequenceRecord], rec: T): List[SequenceRecord] = {
-      val recs = getSequenceRecordsFromElement(rec)
+      val recs = getSequenceRecords(rec)
 
       recs.foldLeft(l)((li: List[SequenceRecord], r: SequenceRecord) => {
         if (!li.contains(r)) {
@@ -153,7 +153,7 @@ abstract class ADAMSequenceDictionaryRDDAggregator[T](rdd: RDD[T]) extends Seria
 class ADAMSpecificRecordSequenceDictionaryRDDAggregator[T <% IndexedRecord: Manifest](rdd: RDD[T])
     extends ADAMSequenceDictionaryRDDAggregator[T](rdd) {
 
-  def getSequenceRecordsFromElement(elem: T): Set[SequenceRecord] = {
+  def getSequenceRecords(elem: T): Set[SequenceRecord] = {
     Set(SequenceRecord.fromSpecificRecord(elem))
   }
 }

--- a/adam-core/src/main/scala/org/bdgenomics/adam/rdd/contig/NucleotideContigFragmentRDDFunctions.scala
+++ b/adam-core/src/main/scala/org/bdgenomics/adam/rdd/contig/NucleotideContigFragmentRDDFunctions.scala
@@ -111,7 +111,7 @@ class NucleotideContigFragmentRDDFunctions(rdd: RDD[NucleotideContigFragment]) e
    * @param region Reference region over which to get sequence.
    * @return String of bases corresponding to reference sequence.
    */
-  def adamGetReferenceString(region: ReferenceRegion): String = {
+  def getReferenceString(region: ReferenceRegion): String = {
     def getString(fragment: (ReferenceRegion, NucleotideContigFragment)): (ReferenceRegion, String) = {
       val trimStart = max(0, region.start - fragment._1.start).toInt
       val trimEnd = max(0, fragment._1.end - region.end).toInt
@@ -162,7 +162,7 @@ class NucleotideContigFragmentRDDFunctions(rdd: RDD[NucleotideContigFragment]) e
     }
   }
 
-  def getSequenceRecordsFromElement(elem: NucleotideContigFragment): Set[SequenceRecord] = {
+  def getSequenceRecords(elem: NucleotideContigFragment): Set[SequenceRecord] = {
     // variant context contains a single locus
     Set(SequenceRecord.fromADAMContigFragment(elem))
   }
@@ -179,7 +179,7 @@ class NucleotideContigFragmentRDDFunctions(rdd: RDD[NucleotideContigFragment]) e
   def flankAdjacentFragments(
     flankLength: Int,
     optSd: Option[SequenceDictionary] = None): RDD[NucleotideContigFragment] = {
-    FlankReferenceFragments(rdd, optSd.getOrElse(adamGetSequenceDictionary(performLexSort = false)), flankLength)
+    FlankReferenceFragments(rdd, optSd.getOrElse(getSequenceDictionary(performLexSort = false)), flankLength)
   }
 
   /**

--- a/adam-core/src/main/scala/org/bdgenomics/adam/rdd/features/FeatureRDDFunctions.scala
+++ b/adam-core/src/main/scala/org/bdgenomics/adam/rdd/features/FeatureRDDFunctions.scala
@@ -32,7 +32,7 @@ class FeatureRDDFunctions(featureRDD: RDD[Feature]) extends Serializable with Lo
     case Strand.Independent => true
   }
 
-  def asGenes(): RDD[Gene] = {
+  def toGenes(): RDD[Gene] = {
 
     /*
     Creating a set of gene models works in four steps:

--- a/adam-core/src/main/scala/org/bdgenomics/adam/rdd/read/MarkDuplicates.scala
+++ b/adam-core/src/main/scala/org/bdgenomics/adam/rdd/read/MarkDuplicates.scala
@@ -97,7 +97,7 @@ private[rdd] object MarkDuplicates extends Serializable with Logging {
       p._1.read2refPos
     }
 
-    rdd.adamSingleReadBuckets()
+    rdd.groupReadsByFragment()
       .keyBy(ReferencePositionPair(_))
       .groupBy(leftPositionAndLibrary(_, rgd))
       .flatMap(kv => PerformDuplicateMarking.time {

--- a/adam-core/src/main/scala/org/bdgenomics/adam/rdd/variation/VariationRDDFunctions.scala
+++ b/adam-core/src/main/scala/org/bdgenomics/adam/rdd/variation/VariationRDDFunctions.scala
@@ -35,7 +35,7 @@ class VariantContextRDDFunctions(rdd: RDD[VariantContext]) extends ADAMSequenceD
    * @param elem Element from which to extract sequence records.
    * @return A seq of sequence records.
    */
-  def getSequenceRecordsFromElement(elem: VariantContext): Set[SequenceRecord] = {
+  def getSequenceRecords(elem: VariantContext): Set[SequenceRecord] = {
     elem.genotypes.map(gt => SequenceRecord.fromSpecificRecord(gt.getVariant)).toSet
   }
 

--- a/adam-core/src/test/scala/org/bdgenomics/adam/converters/FastaConverterSuite.scala
+++ b/adam-core/src/test/scala/org/bdgenomics/adam/converters/FastaConverterSuite.scala
@@ -210,7 +210,7 @@ class FastaConverterSuite extends ADAMFunSuite {
 
   sparkTest("convert reference fasta file") {
     //Loading "human_g1k_v37_chr1_59kb.fasta"
-    val referenceSequences = sc.loadSequence(chr1File, fragmentLength = 10).collect()
+    val referenceSequences = sc.loadSequences(chr1File, fragmentLength = 10).collect()
     assert(referenceSequences.forall(_.getContig.getContigName.toString == "1"))
     assert(referenceSequences.slice(0, referenceSequences.length - 2).forall(_.getFragmentSequence.length == 10))
 

--- a/adam-core/src/test/scala/org/bdgenomics/adam/models/GeneSuite.scala
+++ b/adam-core/src/test/scala/org/bdgenomics/adam/models/GeneSuite.scala
@@ -32,7 +32,7 @@ class GeneSuite extends ADAMFunSuite {
     val path = testFile("features/Homo_sapiens.GRCh37.75.trun100.gtf")
     val features: RDD[Feature] = sc.loadFeatures(path)
 
-    val genes: RDD[Gene] = features.asGenes()
+    val genes: RDD[Gene] = features.toGenes()
     assert(genes.count() === 4)
 
     val transcripts = genes.flatMap(_.transcripts)
@@ -46,7 +46,7 @@ class GeneSuite extends ADAMFunSuite {
     val path = testFile("features/gencode.v19.annotation.chr20.250k.gtf")
     val features: RDD[Feature] = sc.loadFeatures(path)
 
-    val genes: RDD[Gene] = features.asGenes()
+    val genes: RDD[Gene] = features.toGenes()
     assert(genes.count() === 8)
 
     val transcripts = genes.flatMap(_.transcripts)
@@ -98,7 +98,7 @@ class GeneSuite extends ADAMFunSuite {
     }
 
     val features: RDD[Feature] = sc.loadFeatures(path)
-    val genes: RDD[Gene] = features.asGenes()
+    val genes: RDD[Gene] = features.toGenes()
     val transcripts: Seq[Transcript] = genes.flatMap(g => g.transcripts).take(100)
 
     transcripts.foreach { transcript =>

--- a/adam-core/src/test/scala/org/bdgenomics/adam/rdd/GenomicPositionPartitionerSuite.scala
+++ b/adam-core/src/test/scala/org/bdgenomics/adam/rdd/GenomicPositionPartitionerSuite.scala
@@ -97,7 +97,7 @@ class GenomicPositionPartitionerSuite extends ADAMFunSuite {
     val filename = resourcePath("reads12.sam")
     val parts = 1
 
-    val dict = sc.adamDictionaryLoad[AlignmentRecord](filename)
+    val dict = sc.loadDictionary[AlignmentRecord](filename)
     val parter = GenomicPositionPartitioner(parts, dict)
 
     val p = {

--- a/adam-core/src/test/scala/org/bdgenomics/adam/rdd/contig/NucleotideContigFragmentRDDFunctionsSuite.scala
+++ b/adam-core/src/test/scala/org/bdgenomics/adam/rdd/contig/NucleotideContigFragmentRDDFunctionsSuite.scala
@@ -50,7 +50,7 @@ class NucleotideContigFragmentRDDFunctionsSuite extends ADAMFunSuite {
 
     val rdd = sc.parallelize(List(ctg0, ctg1))
 
-    val dict = rdd.adamGetSequenceDictionary()
+    val dict = rdd.getSequenceDictionary()
 
     assert(dict.containsRefName("chr0"))
     val chr0 = dict("chr0").get
@@ -79,7 +79,7 @@ class NucleotideContigFragmentRDDFunctionsSuite extends ADAMFunSuite {
 
     val rdd = sc.parallelize(List(fragment))
 
-    assert(rdd.adamGetReferenceString(region) === "ACTGTAC")
+    assert(rdd.getReferenceString(region) === "ACTGTAC")
   }
 
   sparkTest("recover trimmed reference string from a single contig fragment") {
@@ -100,7 +100,7 @@ class NucleotideContigFragmentRDDFunctionsSuite extends ADAMFunSuite {
 
     val rdd = sc.parallelize(List(fragment))
 
-    assert(rdd.adamGetReferenceString(region) === "CTGTA")
+    assert(rdd.getReferenceString(region) === "CTGTA")
   }
 
   sparkTest("recover reference string from multiple contig fragments") {
@@ -144,8 +144,8 @@ class NucleotideContigFragmentRDDFunctionsSuite extends ADAMFunSuite {
 
     val rdd = sc.parallelize(List(fragment0, fragment1, fragment2))
 
-    assert(rdd.adamGetReferenceString(region0) === "ACTGTAC")
-    assert(rdd.adamGetReferenceString(region1) === "GTACTCTCATG")
+    assert(rdd.getReferenceString(region0) === "ACTGTAC")
+    assert(rdd.getReferenceString(region1) === "GTACTCTCATG")
   }
 
   sparkTest("recover trimmed reference string from multiple contig fragments") {
@@ -189,8 +189,8 @@ class NucleotideContigFragmentRDDFunctionsSuite extends ADAMFunSuite {
 
     val rdd = sc.parallelize(List(fragment0, fragment1, fragment2))
 
-    assert(rdd.adamGetReferenceString(region0) === "CTGTA")
-    assert(rdd.adamGetReferenceString(region1) === "CTCTCA")
+    assert(rdd.getReferenceString(region0) === "CTGTA")
+    assert(rdd.getReferenceString(region1) === "CTCTCA")
   }
 
   sparkTest("testing nondeterminism from reduce when recovering referencestring") {
@@ -212,7 +212,7 @@ class NucleotideContigFragmentRDDFunctionsSuite extends ADAMFunSuite {
     var passed = true
     val rdd = sc.parallelize(fragments.toList)
     try {
-      val result = rdd.adamGetReferenceString(new ReferenceRegion("chr1", 0L, 1000L))
+      val result = rdd.getReferenceString(new ReferenceRegion("chr1", 0L, 1000L))
     } catch {
       case e: AssertionError => passed = false
     }

--- a/adam-core/src/test/scala/org/bdgenomics/adam/rdd/read/MarkDuplicatesSuite.scala
+++ b/adam-core/src/test/scala/org/bdgenomics/adam/rdd/read/MarkDuplicatesSuite.scala
@@ -93,7 +93,7 @@ class MarkDuplicatesSuite extends ADAMFunSuite {
   }
 
   private def markDuplicates(reads: AlignmentRecord*) = {
-    sc.parallelize(reads).adamMarkDuplicates(rgd).collect()
+    sc.parallelize(reads).markDuplicates(rgd).collect()
   }
 
   sparkTest("single read") {

--- a/adam-core/src/test/scala/org/bdgenomics/adam/rdd/read/realignment/RealignIndelsSuite.scala
+++ b/adam-core/src/test/scala/org/bdgenomics/adam/rdd/read/realignment/RealignIndelsSuite.scala
@@ -40,8 +40,8 @@ class RealignIndelsSuite extends ADAMFunSuite {
 
   def artificial_realigned_reads: RDD[AlignmentRecord] = {
     artificial_reads
-      .adamRealignIndels()
-      .adamSortReadsByReferencePosition()
+      .realignIndels()
+      .sortReadsByReferencePosition()
   }
 
   def gatk_artificial_realigned_reads: RDD[AlignmentRecord] = {


### PR DESCRIPTION
Fixes #910 

Summary of initial changes:
```
class ADAMContext:

adamBamDictionaryLoad  --> loadBamDictionary
adamBamDictionaryLoad --> loadBamDictionary
adamBamLoadReadGroups --> loadBamReadGroups
loadParquet
adamDictionaryLoad --> loadDictionary
loadBam
loadIndexedBam
loadAvro
loadParquetAlignments
loadInterleavedFastq
loadFastq
loadPairedFastq
loadUnpairedFastq
loadVcf
loadParquetGenotypes
loadParquetVariants
loadFasta
loadInterleavedFastqAsFragments
loadGTF --> loadGtf
loadBED --> loadBed
loadNarrowPeak
loadIntervalList
loadParquetFeatures
loadParquetContigFragments
loadParquetFragments
loadVcfAnnotations
loadParquetVariantAnnotations
loadVariantAnnotations
loadFeatures
loadGenes
loadReferenceFile
loadSequence --> loadSequences
loadGenotypes
loadVariants
loadAlignments
loadFragments
loadAlignmentsFromPaths
findFiles

class ADAMRDDFunctions:

adamParquetSave --> saveAsParquet
adamParquetSave --> saveAsParquet

class ADAMSequenceDictionaryRDDAggregator:

getSequenceRecordsFromElement --> getSequenceRecords
adamGetSequenceDictionary --> getSequenceDictionary

class ADAMSpecificRecordSequenceDictionaryRDDAggregator:

getSequenceRecordsFromElement --> getSequenceRecords

object PairingRDD:

rddToPairingRDD

class NucleotideContigFragmentRDDFunctions:

toReads
saveAsFasta
mergeFragments
adamGetReferenceString --> getReferenceString
getSequenceRecordsFromElement --> getSequenceRecords
flankAdjacentFragments
countKmers

class FeatureRDDFunctions:

asGenes --> toGenes
filterByOverlappingRegion

class FragmentRDDFunctions:

toReads
getSequenceRecordsFromElement --> getSequenceRecords

class AlignmentRecordRDDFunctions:

filterByOverlappingRegion
saveAsParquet
adamAlignedRecordSave --> remove method
adamSave --> save
adamSAMString --> saveAsSamString
adamSAMSave --> saveAsSam
getSequenceRecordsFromElement --> getSequenceRecords
adamConvertToSAM --> convertToSam
adamCountKmers --> countKmers
adamSortReadsByReferencePosition --> sortReadsByReferencePosition
adamMarkDuplicates --> markDuplicates
adamBQSR --> bqsr
adamRealignIndels --> realignIndels
adamFlagStat --> flagStat
adamSingleReadBuckets --> groupReads
adamCharacterizeTags --> characterizeTags
adamCharacterizeTagValues --> characterizeTagValues
adamFilterRecordsWithTag --> filterRecordsWithTag
adamSaveAsPairedFastq --> saveAsPairedFastq
adamSaveAsFastq --> saveAsFastq
adamRePairReads --> reassembleReadPairs
toFragments

class VariantContextRDDFunctions:

getSequenceRecordsFromElement --> getSequenceRecords
joinDatabaseVariantAnnotation
getCallsetSamples
saveAsVcf

class GenotypeRDDFunctions:

toVariantContext
filterByOverlappingRegion
```

Will take a closer look at scaladoc strings and other parts of the codebase in future commits.