### PR TITLE
[ADAM-1004] Remove recursive maven.build.timestamp declaration

### DIFF
--- a/adam-cli/pom.xml
+++ b/adam-cli/pom.xml
@@ -12,7 +12,7 @@
   <packaging>jar</packaging>
   <name>ADAM_2.10: CLI</name>
   <properties>
-    <maven.build.timestamp>${maven.build.timestamp}</maven.build.timestamp>
+    <timestamp>${maven.build.timestamp}</timestamp>
     <maven.build.timestamp.format>yyyy-MM-dd</maven.build.timestamp.format>
   </properties>
   <build>

--- a/adam-cli/src/main/java-templates/org/bdgenomics/adam/cli/About.java
+++ b/adam-cli/src/main/java-templates/org/bdgenomics/adam/cli/About.java
@@ -22,7 +22,7 @@ package org.bdgenomics.adam.cli;
  */
 public final class About {
     private static final String ARTIFACT_ID = "${project.artifactId}";
-    private static final String BUILD_TIMESTAMP = "${maven.build.timestamp}";
+    private static final String BUILD_TIMESTAMP = "${timestamp}";
     private static final String COMMIT = "${git.commit.id}";
     private static final String HADOOP_VERSION = "${hadoop.version}";
     private static final String SCALA_VERSION = "${scala.version}";


### PR DESCRIPTION
Fixes #1004 

This workaround for https://issues.apache.org/jira/browse/MRESOURCES-99 hasn't always worked for me in the past, but it seems to work fine here
```bash
$ ./bin/adam-submit --version
Using ADAM_MAIN=org.bdgenomics.adam.cli.ADAMMain
Using SPARK_SUBMIT=/usr/local/bin/spark-submit

       e         888~-_          e             e    e
      d8b        888   \        d8b           d8b  d8b
     /Y88b       888    |      /Y88b         d888bdY88b
    /  Y88b      888    |     /  Y88b       / Y88Y Y888b
   /____Y88b     888   /     /____Y88b     /   YY   Y888b
  /      Y88b    888_-~     /      Y88b   /          Y888b

ADAM version: 0.19.1-SNAPSHOT
Commit: f8c3133ae75947fde0a29d63f025f81fbcdb58f9 Build: 2016-04-20
Built for: Scala 2.10 and Hadoop 2.6.0
```