### PR TITLE
exclude javadoc jar in adam-shell

### DIFF
--- a/adam-core/src/main/scala/org/bdgenomics/adam/models/RecordGroupDictionary.scala
+++ b/adam-core/src/main/scala/org/bdgenomics/adam/models/RecordGroupDictionary.scala
@@ -62,7 +62,7 @@ object RecordGroupDictionary {
  */
 case class RecordGroupDictionary(recordGroups: Seq[RecordGroup]) {
   lazy val recordGroupMap = recordGroups.map(v => (v.recordGroupName, v))
-    .sortBy(kv => kv._1)
+    .sortBy(_._1)
     .zipWithIndex
     .map(kv => {
       val ((name, group), index) = kv
@@ -121,19 +121,18 @@ object RecordGroup {
     new RecordGroup(
       samRGR.getSample,
       samRGR.getReadGroupId,
-      Option(samRGR.getSequencingCenter).map(_.toString),
-      Option(samRGR.getDescription).map(_.toString),
+      Option(samRGR.getSequencingCenter),
+      Option(samRGR.getDescription),
       Option(samRGR.getRunDate).map(_.getTime),
-      Option(samRGR.getFlowOrder).map(_.toString),
-      Option(samRGR.getKeySequence).map(_.toString),
-      Option(samRGR.getLibrary).map(_.toString),
+      Option(samRGR.getFlowOrder),
+      Option(samRGR.getKeySequence),
+      Option(samRGR.getLibrary),
       Option({
         // must explicitly reference as a java.lang.integer to avoid implicit conversion
-        val i: java.lang.Integer = samRGR.getPredictedMedianInsertSize
-        i
+        samRGR.getPredictedMedianInsertSize: java.lang.Integer
       }).map(_.toInt),
-      Option(samRGR.getPlatform).map(_.toString),
-      Option(samRGR.getPlatformUnit).map(_.toString)
+      Option(samRGR.getPlatform),
+      Option(samRGR.getPlatformUnit)
     )
   }
 

--- a/bin/adam-shell
+++ b/bin/adam-shell
@@ -34,13 +34,14 @@ else
   ASSEMBLY_DIR="$SCRIPT_DIR/adam-cli/target"
 fi
 
-num_jars="$(ls -1 "$ASSEMBLY_DIR" | grep "^adam-cli_[0-9A-Za-z\.-]*\.jar$" | wc -l)"
+num_jars="$(ls -1 "$ASSEMBLY_DIR" | grep "^adam-cli_[0-9A-Za-z\.-]*\.jar$" | grep -v javadoc | wc -l)"
 if [ "$num_jars" -eq "0" ]; then
   echo "Failed to find ADAM cli assembly in $ASSEMBLY_DIR." 1>&2
   echo "You need to build ADAM before running this program." 1>&2
   exit 1
 fi
-ASSEMBLY_JARS="$(ls -1 "$ASSEMBLY_DIR" | grep "^adam-cli_[0-9A-Za-z\.-]*\.jar$" || true)"
+
+ASSEMBLY_JARS="$(ls -1 "$ASSEMBLY_DIR" | grep "^adam-cli_[0-9A-Za-z\.-]*\.jar$" | grep -v javadoc || true)"
 if [ "$num_jars" -gt "1" ]; then
   echo "Found multiple ADAM cli assembly jars in $ASSEMBLY_DIR:" 1>&2
   echo "$ASSEMBLY_JARS" 1>&2

--- a/bin/adam-submit
+++ b/bin/adam-submit
@@ -66,6 +66,7 @@ if [ "$num_jars" -eq "0" ]; then
   echo "You need to build ADAM before running this program." 1>&2
   exit 1
 fi
+
 ASSEMBLY_JARS="$(ls -1 "$ASSEMBLY_DIR" | grep "^adam-cli_[0-9A-Za-z\.-]*\.jar$" | grep -v javadoc || true)"
 if [ "$num_jars" -gt "1" ]; then
   echo "Found multiple ADAM cli assembly jars in $ASSEMBLY_DIR:" 1>&2


### PR DESCRIPTION
follow-on to 4955aee8ff759f8e619c18a3f5c2352e9265da28