### PR TITLE
 add maxScore

### DIFF
--- a/adam-core/src/test/scala/org/bdgenomics/adam/rdd/read/MarkDuplicatesSuite.scala
+++ b/adam-core/src/test/scala/org/bdgenomics/adam/rdd/read/MarkDuplicatesSuite.scala
@@ -172,7 +172,7 @@ class MarkDuplicatesSuite extends ADAMFunSuite {
     assert(dups.size == 10 && dups.forall(p => p.getReadName.startsWith("fragment")))
   }
 
-  test("quality scores") {
+  sparkTest("quality scores") {
     // The ascii value 53 is equal to a phred score of 20
     val qual = 53.toChar.toString * 100
     val record = AlignmentRecord.newBuilder().setQual(qual).build()


### PR DESCRIPTION
When we map reads to a ref,we need each read maxScore;Moreover ,a read maybe have many seed and each seed need extension,we need max score of eac extension in seed ,then we can take the high score in each max score in extension and decide the read mapping location in ref.
I add the maxScores function and lazy val maxScore