### PR TITLE
Logging to be done by ADAM utils code rather than Spark

### DIFF
--- a/adam-cli/pom.xml
+++ b/adam-cli/pom.xml
@@ -151,6 +151,10 @@
     </dependency>
     <dependency>
       <groupId>org.bdgenomics.utils</groupId>
+      <artifactId>utils-misc_2.10</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.bdgenomics.utils</groupId>
       <artifactId>utils-io_2.10</artifactId>
     </dependency>
     <dependency>

--- a/adam-cli/src/main/scala/org/bdgenomics/adam/cli/ADAM2Fasta.scala
+++ b/adam-cli/src/main/scala/org/bdgenomics/adam/cli/ADAM2Fasta.scala
@@ -17,13 +17,14 @@
  */
 package org.bdgenomics.adam.cli
 
-import org.apache.spark.{ Logging, SparkContext }
+import org.apache.spark.SparkContext
 import org.apache.spark.rdd.RDD
 import org.bdgenomics.adam.projections.NucleotideContigFragmentField._
 import org.bdgenomics.adam.projections.Projection
 import org.bdgenomics.adam.rdd.ADAMContext._
 import org.bdgenomics.formats.avro.NucleotideContigFragment
 import org.bdgenomics.utils.cli._
+import org.bdgenomics.utils.misc.Logging
 import org.kohsuke.args4j.{ Argument, Option => Args4JOption }
 
 class ADAM2FastaArgs extends ParquetLoadSaveArgs {

--- a/adam-cli/src/main/scala/org/bdgenomics/adam/cli/ADAM2Vcf.scala
+++ b/adam-cli/src/main/scala/org/bdgenomics/adam/cli/ADAM2Vcf.scala
@@ -19,12 +19,13 @@ package org.bdgenomics.adam.cli
 
 import java.io.File
 import org.apache.spark.rdd.RDD
-import org.apache.spark.{ Logging, SparkContext }
+import org.apache.spark.SparkContext
 import org.apache.hadoop.mapreduce.Job
 import org.bdgenomics.adam.models.SequenceDictionary
 import org.bdgenomics.adam.rdd.ADAMContext._
 import org.bdgenomics.formats.avro.Genotype
 import org.bdgenomics.utils.cli._
+import org.bdgenomics.utils.misc.Logging
 import org.kohsuke.args4j.{ Option => Args4jOption, Argument }
 import scala.Option
 

--- a/adam-cli/src/main/scala/org/bdgenomics/adam/cli/ADAMMain.scala
+++ b/adam-cli/src/main/scala/org/bdgenomics/adam/cli/ADAMMain.scala
@@ -21,7 +21,7 @@ import java.util.logging.Level._
 import javax.inject.Inject
 import com.google.inject.AbstractModule
 import net.codingwell.scalaguice.ScalaModule
-import org.apache.spark.Logging
+import org.bdgenomics.utils.misc.Logging
 import org.bdgenomics.adam.util.ParquetLogger
 import org.bdgenomics.utils.cli._
 

--- a/adam-cli/src/main/scala/org/bdgenomics/adam/cli/AlleleCount.scala
+++ b/adam-cli/src/main/scala/org/bdgenomics/adam/cli/AlleleCount.scala
@@ -19,11 +19,12 @@
 package org.bdgenomics.adam.cli
 
 import org.apache.hadoop.mapreduce.Job
-import org.apache.spark.{ Logging, SparkContext }
+import org.apache.spark.SparkContext
 import org.apache.spark.rdd.RDD
 import org.bdgenomics.adam.rdd.ADAMContext._
 import org.bdgenomics.formats.avro.{ Genotype, GenotypeAllele }
 import org.bdgenomics.utils.cli._
+import org.bdgenomics.utils.misc.Logging
 import org.kohsuke.args4j.Argument
 
 object AlleleCount extends BDGCommandCompanion {

--- a/adam-cli/src/main/scala/org/bdgenomics/adam/cli/CountContigKmers.scala
+++ b/adam-cli/src/main/scala/org/bdgenomics/adam/cli/CountContigKmers.scala
@@ -19,12 +19,13 @@ package org.bdgenomics.adam.cli
 
 import java.util.logging.Level
 import org.apache.hadoop.mapreduce.Job
-import org.apache.spark.{ SparkContext, Logging }
+import org.apache.spark.SparkContext
 import org.apache.spark.rdd.RDD
 import org.bdgenomics.adam.rdd.ADAMContext._
 import org.bdgenomics.adam.util.ParquetLogger
 import org.bdgenomics.formats.avro.NucleotideContigFragment
 import org.bdgenomics.utils.cli._
+import org.bdgenomics.utils.misc.Logging
 import org.kohsuke.args4j.{ Argument, Option => Args4jOption }
 
 object CountContigKmers extends BDGCommandCompanion {

--- a/adam-cli/src/main/scala/org/bdgenomics/adam/cli/CountReadKmers.scala
+++ b/adam-cli/src/main/scala/org/bdgenomics/adam/cli/CountReadKmers.scala
@@ -19,13 +19,14 @@ package org.bdgenomics.adam.cli
 
 import java.util.logging.Level
 import org.apache.hadoop.mapreduce.Job
-import org.apache.spark.{ SparkContext, Logging }
+import org.apache.spark.SparkContext
 import org.apache.spark.rdd.RDD
 import org.bdgenomics.adam.projections.{ AlignmentRecordField, Projection }
 import org.bdgenomics.adam.rdd.ADAMContext._
 import org.bdgenomics.adam.util.ParquetLogger
 import org.bdgenomics.formats.avro.AlignmentRecord
 import org.bdgenomics.utils.cli._
+import org.bdgenomics.utils.misc.Logging
 import org.kohsuke.args4j.{ Argument, Option => Args4jOption }
 
 object CountReadKmers extends BDGCommandCompanion {

--- a/adam-cli/src/main/scala/org/bdgenomics/adam/cli/Fasta2ADAM.scala
+++ b/adam-cli/src/main/scala/org/bdgenomics/adam/cli/Fasta2ADAM.scala
@@ -17,9 +17,10 @@
  */
 package org.bdgenomics.adam.cli
 
-import org.apache.spark.{ Logging, SparkContext }
+import org.apache.spark.SparkContext
 import org.bdgenomics.adam.rdd.ADAMContext._
 import org.bdgenomics.utils.cli._
+import org.bdgenomics.utils.misc.Logging
 import org.kohsuke.args4j.{ Argument, Option => Args4jOption }
 
 object Fasta2ADAM extends BDGCommandCompanion {

--- a/adam-cli/src/main/scala/org/bdgenomics/adam/cli/Flatten.scala
+++ b/adam-cli/src/main/scala/org/bdgenomics/adam/cli/Flatten.scala
@@ -20,10 +20,11 @@ package org.bdgenomics.adam.cli
 import org.apache.avro.Schema
 import org.apache.avro.generic.IndexedRecord
 import org.apache.spark.rdd.MetricsContext._
-import org.apache.spark.{ Logging, SparkContext }
+import org.apache.spark.SparkContext
 import org.bdgenomics.adam.rdd.ADAMContext._
 import org.bdgenomics.adam.util.Flattener
 import org.bdgenomics.utils.cli._
+import org.bdgenomics.utils.misc.Logging
 import org.bdgenomics.utils.instrumentation.Metrics
 import org.bdgenomics.utils.misc.HadoopUtil
 import org.kohsuke.args4j.Argument

--- a/adam-cli/src/main/scala/org/bdgenomics/adam/cli/Fragments2Reads.scala
+++ b/adam-cli/src/main/scala/org/bdgenomics/adam/cli/Fragments2Reads.scala
@@ -17,11 +17,12 @@
  */
 package org.bdgenomics.adam.cli
 
-import org.apache.spark.{ Logging, SparkContext }
+import org.apache.spark.SparkContext
 import org.bdgenomics.adam.models.{ RecordGroupDictionary, SequenceDictionary }
 import org.bdgenomics.adam.rdd.ADAMContext._
 import org.bdgenomics.adam.rdd.ADAMSaveAnyArgs
 import org.bdgenomics.utils.cli._
+import org.bdgenomics.utils.misc.Logging
 import org.kohsuke.args4j.{ Argument, Option => Args4jOption }
 
 object Fragments2Reads extends BDGCommandCompanion {

--- a/adam-cli/src/main/scala/org/bdgenomics/adam/cli/Reads2Fragments.scala
+++ b/adam-cli/src/main/scala/org/bdgenomics/adam/cli/Reads2Fragments.scala
@@ -17,10 +17,11 @@
  */
 package org.bdgenomics.adam.cli
 
-import org.apache.spark.{ Logging, SparkContext }
+import org.apache.spark.SparkContext
 import org.bdgenomics.adam.rdd.ADAMContext._
 import org.bdgenomics.adam.rdd.ADAMSaveAnyArgs
 import org.bdgenomics.utils.cli._
+import org.bdgenomics.utils.misc.Logging
 import org.kohsuke.args4j.{ Argument, Option => Args4jOption }
 
 object Reads2Fragments extends BDGCommandCompanion {

--- a/adam-cli/src/main/scala/org/bdgenomics/adam/cli/Transform.scala
+++ b/adam-cli/src/main/scala/org/bdgenomics/adam/cli/Transform.scala
@@ -19,7 +19,7 @@ package org.bdgenomics.adam.cli
 
 import htsjdk.samtools.ValidationStringency
 import org.apache.parquet.filter2.dsl.Dsl._
-import org.apache.spark.{ Logging, SparkContext }
+import org.apache.spark.SparkContext
 import org.apache.spark.rdd.RDD
 import org.apache.spark.storage.StorageLevel
 import org.bdgenomics.adam.algorithms.consensus._
@@ -36,6 +36,7 @@ import org.bdgenomics.adam.rdd.read.{ AlignmentRecordRDD, MDTagging }
 import org.bdgenomics.adam.rich.RichVariant
 import org.bdgenomics.formats.avro.AlignmentRecord
 import org.bdgenomics.utils.cli._
+import org.bdgenomics.utils.misc.Logging
 import org.kohsuke.args4j.{ Argument, Option => Args4jOption }
 
 object Transform extends BDGCommandCompanion {

--- a/adam-cli/src/main/scala/org/bdgenomics/adam/cli/Vcf2ADAM.scala
+++ b/adam-cli/src/main/scala/org/bdgenomics/adam/cli/Vcf2ADAM.scala
@@ -18,11 +18,12 @@
 package org.bdgenomics.adam.cli
 
 import org.apache.hadoop.mapreduce.Job
-import org.apache.spark.{ Logging, SparkContext }
+import org.apache.spark.SparkContext
 import org.apache.spark.rdd.RDD
 import org.bdgenomics.adam.models.{ SequenceDictionary, VariantContext }
 import org.bdgenomics.adam.rdd.ADAMContext._
 import org.bdgenomics.utils.cli._
+import org.bdgenomics.utils.misc.Logging
 import org.kohsuke.args4j.{ Option => Args4jOption, Argument }
 import java.io.File
 

--- a/adam-cli/src/main/scala/org/bdgenomics/adam/cli/VcfAnnotation2ADAM.scala
+++ b/adam-cli/src/main/scala/org/bdgenomics/adam/cli/VcfAnnotation2ADAM.scala
@@ -19,13 +19,14 @@ package org.bdgenomics.adam.cli
 
 import org.apache.hadoop.mapreduce.Job
 import org.apache.spark.SparkContext._
-import org.apache.spark.{ Logging, SparkContext }
+import org.apache.spark.SparkContext
 import org.apache.spark.rdd.RDD
 import org.bdgenomics.adam.converters.VariantAnnotationConverter
 import org.bdgenomics.adam.rdd.ADAMContext._
 import org.bdgenomics.adam.rich.RichVariant
 import org.bdgenomics.formats.avro._
 import org.bdgenomics.utils.cli._
+import org.bdgenomics.utils.misc.Logging
 import org.kohsuke.args4j.{ Argument, Option => Args4jOption }
 
 object VcfAnnotation2ADAM extends BDGCommandCompanion {

--- a/adam-cli/src/test/scala/org/bdgenomics/adam/cli/ParquetLister.scala
+++ b/adam-cli/src/test/scala/org/bdgenomics/adam/cli/ParquetLister.scala
@@ -23,7 +23,7 @@ import org.apache.avro.Schema
 import org.apache.avro.generic.IndexedRecord
 import org.apache.hadoop.conf.Configuration
 import org.apache.hadoop.fs.Path
-import org.apache.spark.Logging
+import org.bdgenomics.utils.misc.Logging
 import org.apache.parquet.avro.AvroReadSupport
 import org.apache.parquet.hadoop.ParquetReader
 

--- a/adam-core/src/main/scala/org/bdgenomics/adam/converters/FastqRecordConverter.scala
+++ b/adam-core/src/main/scala/org/bdgenomics/adam/converters/FastqRecordConverter.scala
@@ -19,7 +19,7 @@ package org.bdgenomics.adam.converters
 
 import htsjdk.samtools.ValidationStringency
 import org.apache.hadoop.io.Text
-import org.apache.spark.Logging
+import org.bdgenomics.utils.misc.Logging
 import org.bdgenomics.adam.rdd.ADAMContext._
 import org.bdgenomics.formats.avro.{
   AlignmentRecord,

--- a/adam-core/src/main/scala/org/bdgenomics/adam/converters/SAMRecordConverter.scala
+++ b/adam-core/src/main/scala/org/bdgenomics/adam/converters/SAMRecordConverter.scala
@@ -23,7 +23,7 @@ import htsjdk.samtools.{
   SAMRecord,
   SAMUtils
 }
-import org.apache.spark.Logging
+import org.bdgenomics.utils.misc.Logging
 import org.bdgenomics.adam.models.{
   Attribute,
   RecordGroupDictionary,

--- a/adam-core/src/main/scala/org/bdgenomics/adam/converters/VariantContextConverter.scala
+++ b/adam-core/src/main/scala/org/bdgenomics/adam/converters/VariantContextConverter.scala
@@ -25,7 +25,7 @@ import htsjdk.variant.variantcontext.{
   VariantContextBuilder
 }
 import java.util.Collections
-import org.apache.spark.Logging
+import org.bdgenomics.utils.misc.Logging
 import org.bdgenomics.adam.models.{
   SequenceDictionary,
   VariantContext => ADAMVariantContext

--- a/adam-core/src/main/scala/org/bdgenomics/adam/models/IndelTable.scala
+++ b/adam-core/src/main/scala/org/bdgenomics/adam/models/IndelTable.scala
@@ -17,11 +17,12 @@
  */
 package org.bdgenomics.adam.models
 
-import org.apache.spark.{ Logging, SparkContext }
+import org.apache.spark.SparkContext
 import org.apache.spark.SparkContext._
 import org.apache.spark.rdd.RDD
 import org.bdgenomics.adam.rdd.ADAMContext._
 import org.bdgenomics.formats.avro.Variant
+import org.bdgenomics.utils.misc.Logging
 
 class IndelTable(private val table: Map[String, Iterable[Consensus]]) extends Serializable with Logging {
   log.info("Indel table has %s contigs and %s entries".format(

--- a/adam-core/src/main/scala/org/bdgenomics/adam/models/ReferencePositionPair.scala
+++ b/adam-core/src/main/scala/org/bdgenomics/adam/models/ReferencePositionPair.scala
@@ -20,7 +20,7 @@ package org.bdgenomics.adam.models
 import com.esotericsoftware.kryo.{ Kryo, Serializer }
 import com.esotericsoftware.kryo.io.{ Input, Output }
 import Ordering.Option
-import org.apache.spark.Logging
+import org.bdgenomics.utils.misc.Logging
 import org.bdgenomics.adam.instrumentation.Timers.CreateReferencePositionPair
 import org.bdgenomics.adam.models.ReferenceRegion._
 import org.bdgenomics.adam.rich.RichAlignmentRecord

--- a/adam-core/src/main/scala/org/bdgenomics/adam/models/SingleReadBucket.scala
+++ b/adam-core/src/main/scala/org/bdgenomics/adam/models/SingleReadBucket.scala
@@ -19,7 +19,7 @@ package org.bdgenomics.adam.models
 
 import com.esotericsoftware.kryo.{ Kryo, Serializer }
 import com.esotericsoftware.kryo.io.{ Output, Input }
-import org.apache.spark.Logging
+import org.bdgenomics.utils.misc.Logging
 import org.apache.spark.rdd.RDD
 import org.bdgenomics.adam.rdd.ADAMContext._
 import org.bdgenomics.adam.serialization.AvroSerializer

--- a/adam-core/src/main/scala/org/bdgenomics/adam/models/SnpTable.scala
+++ b/adam-core/src/main/scala/org/bdgenomics/adam/models/SnpTable.scala
@@ -19,7 +19,7 @@ package org.bdgenomics.adam.models
 
 import org.bdgenomics.adam.rich.RichVariant
 import org.bdgenomics.adam.rich.DecadentRead._
-import org.apache.spark.Logging
+import org.bdgenomics.utils.misc.Logging
 import org.apache.spark.rdd.RDD
 import scala.collection.immutable._
 import scala.collection.mutable

--- a/adam-core/src/main/scala/org/bdgenomics/adam/rdd/ADAMContext.scala
+++ b/adam-core/src/main/scala/org/bdgenomics/adam/rdd/ADAMContext.scala
@@ -33,7 +33,7 @@ import org.apache.parquet.hadoop.ParquetInputFormat
 import org.apache.parquet.hadoop.util.ContextUtil
 import org.apache.spark.rdd.MetricsContext._
 import org.apache.spark.rdd.RDD
-import org.apache.spark.{ Logging, SparkContext }
+import org.apache.spark.SparkContext
 import org.bdgenomics.adam.converters._
 import org.bdgenomics.adam.instrumentation.Timers._
 import org.bdgenomics.adam.io._
@@ -55,6 +55,7 @@ import org.bdgenomics.formats.avro._
 import org.bdgenomics.utils.instrumentation.Metrics
 import org.bdgenomics.utils.io.LocalFileByteAccess
 import org.bdgenomics.utils.misc.HadoopUtil
+import org.bdgenomics.utils.misc.Logging
 import org.seqdoop.hadoop_bam._
 import org.seqdoop.hadoop_bam.util.SAMHeaderReader
 import scala.collection.JavaConversions._

--- a/adam-core/src/main/scala/org/bdgenomics/adam/rdd/ADAMRDDFunctions.scala
+++ b/adam-core/src/main/scala/org/bdgenomics/adam/rdd/ADAMRDDFunctions.scala
@@ -22,7 +22,7 @@ import java.util.logging.Level
 import org.apache.avro.Schema
 import org.apache.avro.generic.IndexedRecord
 import org.apache.hadoop.mapreduce.{ OutputFormat => NewOutputFormat }
-import org.apache.spark.{ SparkContext, Logging }
+import org.apache.spark.SparkContext
 import org.apache.spark.rdd.MetricsContext._
 import org.apache.spark.rdd.{ InstrumentedOutputFormat, RDD }
 import org.bdgenomics.adam.instrumentation.Timers._
@@ -30,6 +30,7 @@ import org.bdgenomics.adam.models._
 import org.bdgenomics.adam.util.ParquetLogger
 import org.bdgenomics.utils.cli.SaveArgs
 import org.bdgenomics.utils.misc.HadoopUtil
+import org.bdgenomics.utils.misc.Logging
 import org.apache.parquet.avro.AvroParquetOutputFormat
 import org.apache.parquet.hadoop.ParquetOutputFormat
 import org.apache.parquet.hadoop.metadata.CompressionCodecName

--- a/adam-core/src/main/scala/org/bdgenomics/adam/rdd/GenomicPartitioners.scala
+++ b/adam-core/src/main/scala/org/bdgenomics/adam/rdd/GenomicPartitioners.scala
@@ -18,7 +18,8 @@
 package org.bdgenomics.adam.rdd
 
 import org.bdgenomics.adam.models.{ ReferenceRegion, ReferencePosition, SequenceDictionary }
-import org.apache.spark.{ Logging, Partitioner }
+import org.bdgenomics.utils.misc.Logging
+import org.apache.spark.Partitioner
 import scala.math._
 
 /**

--- a/adam-core/src/main/scala/org/bdgenomics/adam/rdd/contig/NucleotideContigFragmentRDDFunctions.scala
+++ b/adam-core/src/main/scala/org/bdgenomics/adam/rdd/contig/NucleotideContigFragmentRDDFunctions.scala
@@ -20,7 +20,7 @@ package org.bdgenomics.adam.rdd.contig
 import com.google.common.base.Splitter
 import java.util.logging.Level
 import org.apache.avro.specific.SpecificRecord
-import org.apache.spark.Logging
+import org.bdgenomics.utils.misc.Logging
 import org.apache.spark.SparkContext._
 import org.apache.spark.rdd.RDD
 import org.bdgenomics.adam.converters.FragmentConverter

--- a/adam-core/src/main/scala/org/bdgenomics/adam/rdd/features/FeatureRDDFunctions.scala
+++ b/adam-core/src/main/scala/org/bdgenomics/adam/rdd/features/FeatureRDDFunctions.scala
@@ -17,7 +17,7 @@
  */
 package org.bdgenomics.adam.rdd.features
 
-import org.apache.spark.Logging
+import org.bdgenomics.utils.misc.Logging
 import org.apache.spark.rdd.RDD
 import org.apache.spark.SparkContext._
 import org.bdgenomics.adam.models._

--- a/adam-core/src/main/scala/org/bdgenomics/adam/rdd/fragment/FragmentRDDFunctions.scala
+++ b/adam-core/src/main/scala/org/bdgenomics/adam/rdd/fragment/FragmentRDDFunctions.scala
@@ -21,7 +21,7 @@ import org.apache.spark.rdd.RDD
 import org.bdgenomics.adam.converters.AlignmentRecordConverter
 import org.bdgenomics.adam.models.SequenceRecord
 import org.bdgenomics.adam.rdd.ADAMSequenceDictionaryRDDAggregator
-import org.apache.spark.Logging
+import org.bdgenomics.utils.misc.Logging
 import org.bdgenomics.formats.avro._
 import scala.collection.JavaConversions._
 

--- a/adam-core/src/main/scala/org/bdgenomics/adam/rdd/read/AlignmentRecordRDDFunctions.scala
+++ b/adam-core/src/main/scala/org/bdgenomics/adam/rdd/read/AlignmentRecordRDDFunctions.scala
@@ -26,7 +26,7 @@ import org.apache.avro.file.DataFileWriter
 import org.apache.avro.specific.{ SpecificDatumWriter, SpecificRecordBase }
 import org.apache.hadoop.fs.{ FileSystem, Path }
 import org.apache.hadoop.io.LongWritable
-import org.apache.spark.{ Logging, SparkContext }
+import org.apache.spark.SparkContext
 import org.apache.spark.broadcast.Broadcast
 import org.apache.spark.rdd.MetricsContext._
 import org.apache.spark.rdd.RDD
@@ -42,6 +42,7 @@ import org.bdgenomics.adam.rdd.{ ADAMRDDFunctions, ADAMSaveAnyArgs, ADAMSequence
 import org.bdgenomics.adam.rich.RichAlignmentRecord
 import org.bdgenomics.adam.util.MapTools
 import org.bdgenomics.formats.avro._
+import org.bdgenomics.utils.misc.Logging
 import org.seqdoop.hadoop_bam.SAMRecordWritable
 import scala.annotation.tailrec
 import scala.language.implicitConversions

--- a/adam-core/src/main/scala/org/bdgenomics/adam/rdd/read/MDTagging.scala
+++ b/adam-core/src/main/scala/org/bdgenomics/adam/rdd/read/MDTagging.scala
@@ -19,7 +19,7 @@ package org.bdgenomics.adam.rdd.read
 
 import org.bdgenomics.adam.rdd.ADAMContext._
 import htsjdk.samtools.{ TextCigarCodec, ValidationStringency }
-import org.apache.spark.Logging
+import org.bdgenomics.utils.misc.Logging
 // NOTE(ryan): this is necessary for Spark <= 1.2.1.
 import org.apache.spark.SparkContext._
 import org.apache.spark.rdd.RDD

--- a/adam-core/src/main/scala/org/bdgenomics/adam/rdd/read/MarkDuplicates.scala
+++ b/adam-core/src/main/scala/org/bdgenomics/adam/rdd/read/MarkDuplicates.scala
@@ -17,7 +17,7 @@
  */
 package org.bdgenomics.adam.rdd.read
 
-import org.apache.spark.Logging
+import org.bdgenomics.utils.misc.Logging
 import org.apache.spark.rdd.RDD
 import org.bdgenomics.adam.instrumentation.Timers._
 import org.bdgenomics.adam.models.{

--- a/adam-core/src/main/scala/org/bdgenomics/adam/rdd/read/realignment/IndelRealignmentTarget.scala
+++ b/adam-core/src/main/scala/org/bdgenomics/adam/rdd/read/realignment/IndelRealignmentTarget.scala
@@ -20,7 +20,7 @@ package org.bdgenomics.adam.rdd.read.realignment
 import com.esotericsoftware.kryo.io.{ Input, Output }
 import com.esotericsoftware.kryo.{ Kryo, Serializer }
 import htsjdk.samtools.CigarOperator
-import org.apache.spark.Logging
+import org.bdgenomics.utils.misc.Logging
 import org.bdgenomics.adam.models.ReferenceRegion
 import org.bdgenomics.adam.rdd.ADAMContext._
 import org.bdgenomics.adam.rich.RichAlignmentRecord

--- a/adam-core/src/main/scala/org/bdgenomics/adam/rdd/read/realignment/RealignIndels.scala
+++ b/adam-core/src/main/scala/org/bdgenomics/adam/rdd/read/realignment/RealignIndels.scala
@@ -18,7 +18,7 @@
 package org.bdgenomics.adam.rdd.read.realignment
 
 import htsjdk.samtools.{ Cigar, CigarElement, CigarOperator }
-import org.apache.spark.Logging
+import org.bdgenomics.utils.misc.Logging
 import org.apache.spark.rdd.MetricsContext._
 import org.apache.spark.rdd.RDD
 import org.bdgenomics.adam.algorithms.consensus.{ ConsensusGenerator, ConsensusGeneratorFromReads }

--- a/adam-core/src/main/scala/org/bdgenomics/adam/rdd/read/realignment/RealignmentTargetFinder.scala
+++ b/adam-core/src/main/scala/org/bdgenomics/adam/rdd/read/realignment/RealignmentTargetFinder.scala
@@ -17,7 +17,7 @@
  */
 package org.bdgenomics.adam.rdd.read.realignment
 
-import org.apache.spark.Logging
+import org.bdgenomics.utils.misc.Logging
 import org.apache.spark.rdd.RDD
 import org.bdgenomics.adam.rich.RichAlignmentRecord
 import org.bdgenomics.adam.instrumentation.Timers._

--- a/adam-core/src/main/scala/org/bdgenomics/adam/rdd/read/recalibration/BaseQualityRecalibration.scala
+++ b/adam-core/src/main/scala/org/bdgenomics/adam/rdd/read/recalibration/BaseQualityRecalibration.scala
@@ -20,7 +20,7 @@ package org.bdgenomics.adam.rdd.read.recalibration
 import htsjdk.samtools.ValidationStringency
 import java.io._
 import org.apache.spark.SparkContext._
-import org.apache.spark.Logging
+import org.bdgenomics.utils.misc.Logging
 import org.apache.spark.broadcast.Broadcast
 import org.apache.spark.rdd.RDD
 import org.bdgenomics.adam.models.SnpTable

--- a/adam-core/src/main/scala/org/bdgenomics/adam/rdd/variation/VariationRDDFunctions.scala
+++ b/adam-core/src/main/scala/org/bdgenomics/adam/rdd/variation/VariationRDDFunctions.scala
@@ -18,7 +18,7 @@
 package org.bdgenomics.adam.rdd.variation
 
 import org.apache.hadoop.io.LongWritable
-import org.apache.spark.Logging
+import org.bdgenomics.utils.misc.Logging
 import org.apache.spark.rdd.RDD
 import org.bdgenomics.adam.converters.VariantContextConverter
 import org.bdgenomics.adam.models.{ ReferencePosition, ReferenceRegion, SequenceDictionary, SequenceRecord, VariantContext }

--- a/adam-core/src/main/scala/org/bdgenomics/adam/rich/DecadentRead.scala
+++ b/adam-core/src/main/scala/org/bdgenomics/adam/rich/DecadentRead.scala
@@ -18,7 +18,7 @@
 package org.bdgenomics.adam.rich
 
 import htsjdk.samtools.ValidationStringency
-import org.apache.spark.Logging
+import org.bdgenomics.utils.misc.Logging
 import org.apache.spark.rdd.RDD
 import org.bdgenomics.adam.models.ReferencePosition
 import org.bdgenomics.adam.rdd.ADAMContext._

--- a/pom.xml
+++ b/pom.xml
@@ -21,7 +21,7 @@
     <avro.version>1.7.7</avro.version>
     <!-- informative only, used in about template substitution -->
     <scala.version>2.10</scala.version>
-    <spark.version>1.5.2</spark.version>
+    <spark.version>1.6.1</spark.version>
     <parquet.version>1.8.1</parquet.version>
     <!-- Edit the following line to configure the Hadoop (HDFS) version. -->
     <hadoop.version>2.6.0</hadoop.version>
@@ -364,6 +364,17 @@
         <type>test-jar</type>
         <scope>test</scope>
         <exclusions>
+          <exclusion>
+            <groupId>org.apache.spark</groupId>
+            <artifactId>*</artifactId>
+          </exclusion>
+        </exclusions>
+      </dependency>
+      <dependency>
+        <groupId>org.bdgenomics.utils</groupId>
+        <artifactId>utils-misc_2.10</artifactId>
+        <version>${utils.version}</version>
+         <exclusions>
           <exclusion>
             <groupId>org.apache.spark</groupId>
             <artifactId>*</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -26,7 +26,7 @@
     <!-- Edit the following line to configure the Hadoop (HDFS) version. -->
     <hadoop.version>2.6.0</hadoop.version>
     <scoverage.version>1.1.1</scoverage.version>
-    <utils.version>0.2.4</utils.version>
+    <utils.version>0.2.6</utils.version>
     <htsjdk.version>1.139</htsjdk.version>
   </properties>
 


### PR DESCRIPTION
This PR has a dependency on bdg-utils PR at:
https://github.com/bigdatagenomics/utils/pull/72
and will fail tests without it.

Note: also bumps Spark version 1.6.1

This PR solves the version compatibility logging problems caused by recent versions of Spark making `org.apache.spark.Logging` private to Spark