### PR TITLE
Error in the README.md for kmer.scala example, need to get rdd first.

### DIFF
--- a/README.md
+++ b/README.md
@@ -266,6 +266,7 @@ val reads = ac.loadAlignments(
 // Generate, count and sort 21-mers
 val kmers =
   reads
+    .rdd
     .flatMap(_.getSequence.sliding(21).map(k => (k, 1L)))
     .reduceByKey(_ + _)
     .map(_.swap)


### PR DESCRIPTION
When I ran the example from the README for kmer.scala I received errors trying to flatMap:
> error: value flatMap is not a member of org.bdgenomics.adam.rdd.read.AlignmentRecordRDD

By using .rdd:
> reads.rdd.flatMap(_.getSequence.sliding(21).map(k => (k, 1L)))....
It works.

 