### PR TITLE
[ADAM-952] Expose sorting by reference index.

### DIFF
--- a/adam-cli/src/test/scala/org/bdgenomics/adam/cli/TransformSuite.scala
+++ b/adam-cli/src/test/scala/org/bdgenomics/adam/cli/TransformSuite.scala
@@ -34,7 +34,7 @@ class TransformSuite extends ADAMFunSuite {
     val inputPath = copyResource("unordered.sam")
     val actualPath = tmpFile("ordered.sam")
     val expectedPath = copyResource("ordered.sam")
-    Transform(Array("-single", "-sort_reads", inputPath, actualPath)).run(sc)
+    Transform(Array("-single", "-sort_reads", "-sort_lexicographically", inputPath, actualPath)).run(sc)
     checkFiles(expectedPath, actualPath)
   }
 
@@ -54,7 +54,7 @@ class TransformSuite extends ADAMFunSuite {
     val actualPath = tmpFile("ordered.sam")
     val expectedPath = copyResource("ordered.sam")
     Transform(Array(inputPath, intermediateAdamPath)).run(sc)
-    Transform(Array("-single", "-sort_reads", intermediateAdamPath, actualPath)).run(sc)
+    Transform(Array("-single", "-sort_reads", "-sort_lexicographically", intermediateAdamPath, actualPath)).run(sc)
     checkFiles(expectedPath, actualPath)
   }
 }

--- a/adam-cli/src/test/scala/org/bdgenomics/adam/cli/ViewSuite.scala
+++ b/adam-cli/src/test/scala/org/bdgenomics/adam/cli/ViewSuite.scala
@@ -18,8 +18,9 @@
 package org.bdgenomics.adam.cli
 
 import org.apache.spark.rdd.RDD
-import org.bdgenomics.adam.util.ADAMFunSuite
+import org.bdgenomics.adam.models.SequenceDictionary
 import org.bdgenomics.adam.rdd.ADAMContext._
+import org.bdgenomics.adam.util.ADAMFunSuite
 import org.bdgenomics.formats.avro.AlignmentRecord
 import org.bdgenomics.utils.cli.Args4j
 
@@ -46,7 +47,7 @@ class ViewSuite extends ADAMFunSuite {
     val rdd = aRdd.rdd
     val rgd = aRdd.recordGroups
 
-    reads = transform.apply(rdd, rgd).collect()
+    reads = transform.apply(rdd, SequenceDictionary.empty, rgd).collect()
     readsCount = reads.size.toInt
   }
 

--- a/adam-core/src/main/scala/org/bdgenomics/adam/instrumentation/Timers.scala
+++ b/adam-core/src/main/scala/org/bdgenomics/adam/instrumentation/Timers.scala
@@ -69,6 +69,7 @@ object Timers extends Metrics {
 
   // Sort Reads
   val SortReads = timer("Sort Reads")
+  val SortByIndex = timer("Sort Reads By Index")
 
   // File Saving
   val SAMSave = timer("SAM Save")


### PR DESCRIPTION
Resolves #952. Adds function `sortByReferenceIndexAndPosition` on RDDs of `AlignmentRecord`. This sorts reads by their position on a contig, where contigs are ordered by contig index. This conforms to the SAM/BAM sort order.