### PR TITLE
Cleanup on `org.bdgenomics.adam.algorithms.smithwaterman` package.

### DIFF
--- a/adam-core/src/main/scala/org/bdgenomics/adam/algorithms/smithwaterman/SmithWatermanConstantGapScoring.scala
+++ b/adam-core/src/main/scala/org/bdgenomics/adam/algorithms/smithwaterman/SmithWatermanConstantGapScoring.scala
@@ -17,28 +17,55 @@
  */
 package org.bdgenomics.adam.algorithms.smithwaterman
 
-object SmithWatermanConstantGapScoring {
+/**
+ * Performs a pairwise alignment of two sequences using constant penalties.
+ *
+ * @see scoreFn
+ *
+ * @param xSequence The first sequence in the pair.
+ * @param ySequence The second sequence in the pair.
+ * @param wMatch The alignment gap penalty for a residue match.
+ * @param wMismatch The alignment gap penalty for a residue mismatch.
+ * @param wInsert The alignment gap penalty for an insertion in the first
+ *   sequence.
+ * @param wDelete The alignment gap penalty for a deletion in the first
+ *   sequence.
+ */
+case class SmithWatermanConstantGapScoring(xSequence: String,
+                                           ySequence: String,
+                                           wMatch: Double,
+                                           wMismatch: Double,
+                                           wInsert: Double,
+                                           wDelete: Double) extends SmithWatermanGapScoringFromFn {
 
-  protected def constantGapFn(wMatch: Double, wDelete: Double, wInsert: Double, wMismatch: Double)(x: Int, y: Int, i: Char, j: Char): Double = {
-    if (i == j) {
+  /**
+   * Scores residues using scoring constants.
+   *
+   * * If a deletion is observed (xResidue is a gap), then the deletion
+   *   penalty is returned.
+   * * If an insertion is observed (yResidue is a gap), then the insertion
+   *   penalty is returned.
+   * * Else, the residues are compared, and either the match or mismatch
+   *   penalty is returned.
+   *
+   * The position indices are ignored, so no affine/open-continue gap model is
+   * incorporated.
+   *
+   * @param xPos Residue position from first sequence.
+   * @param yPos Residue position from second sequence.
+   * @param xResidue Residue from first sequence.
+   * @param yResidue Residue from second sequence.
+   * @return Returns the gap score for this residue pair.
+   */
+  protected def scoreFn(xPos: Int, yPos: Int, xResidue: Char, yResidue: Char): Double = {
+    if (xResidue == yResidue) {
       wMatch
-    } else if (i == '_') {
+    } else if (xResidue == '_') {
       wDelete
-    } else if (j == '_') {
+    } else if (yResidue == '_') {
       wInsert
     } else {
       wMismatch
     }
   }
-
-}
-
-class SmithWatermanConstantGapScoring(
-  xSequence: String,
-  ySequence: String,
-  wMatch: Double,
-  wMismatch: Double,
-  wInsert: Double,
-  wDelete: Double)
-    extends SmithWatermanGapScoringFromFn(xSequence, ySequence, SmithWatermanConstantGapScoring.constantGapFn(wMatch, wInsert, wDelete, wMismatch)) {
 }

--- a/adam-core/src/main/scala/org/bdgenomics/adam/algorithms/smithwaterman/SmithWatermanGapScoringFromFn.scala
+++ b/adam-core/src/main/scala/org/bdgenomics/adam/algorithms/smithwaterman/SmithWatermanGapScoringFromFn.scala
@@ -17,12 +17,30 @@
  */
 package org.bdgenomics.adam.algorithms.smithwaterman
 
-abstract class SmithWatermanGapScoringFromFn(
-  xSequence: String,
-  ySequence: String,
-  scoreFn: (Int, Int, Char, Char) => Double)
-    extends SmithWaterman(xSequence, ySequence) {
+/**
+ * Implements a Smith-Waterman based method where the score matrix is built
+ * using a function that returns a score given the current position and residue
+ * for both sequences.
+ */
+private[smithwaterman] trait SmithWatermanGapScoringFromFn extends SmithWaterman {
 
+  /**
+   * Returns the alignment penalty for a pair of residues in two sequences.
+   *
+   * @param xPos Residue position from first sequence.
+   * @param yPos Residue position from second sequence.
+   * @param xResidue Residue from first sequence.
+   * @param yResidue Residue from second sequence.
+   * @return Returns the gap score for this residue pair.
+   */
+  protected def scoreFn(xPos: Int, yPos: Int, xResidue: Char, yResidue: Char): Double
+
+  /**
+   * Builds Smith-Waterman score matrix by calling scoring function for
+   * all residue pairs.
+   *
+   * @return 2D array of doubles, along with move direction at each point.
+   */
   def buildScoringMatrix(): (Array[Array[Double]], Array[Array[Char]]) = {
 
     val y = ySequence.length
@@ -73,6 +91,5 @@ abstract class SmithWatermanGapScoringFromFn(
 
     (scoreMatrix, moveMatrix)
   }
-
 }
 


### PR DESCRIPTION
* Added documentation for all methods, values, classes, and constructors that were currently missing documentation.
* Made `SmithWatermanGapScoringFromFn` class package private.
* Refactored `SmithWaterman` and `SmithWatermanGapScoringFromFn` to be traits instead of abstract classes, which allowed for refactoring `SmithWatermanConstantGapScoring` to eliminate the singleton object.