### PR TITLE
Refactoring `org.bdgenomics.adam.io` package.

### DIFF
--- a/adam-core/src/main/java/org/bdgenomics/adam/io/FastqRecordReader.java
+++ b/adam-core/src/main/java/org/bdgenomics/adam/io/FastqRecordReader.java
@@ -1,0 +1,343 @@
+/**
+ * Licensed to Big Data Genomics (BDG) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The BDG licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.bdgenomics.adam.io;
+
+import java.io.EOFException;
+import java.io.IOException;
+import java.io.InputStream;
+import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.fs.FSDataInputStream;
+import org.apache.hadoop.fs.FileSystem;
+import org.apache.hadoop.fs.Path;
+import org.apache.hadoop.io.Text;
+import org.apache.hadoop.io.compress.CompressionCodec;
+import org.apache.hadoop.io.compress.CompressionCodecFactory;
+import org.apache.hadoop.mapreduce.InputSplit;
+import org.apache.hadoop.mapreduce.RecordReader;
+import org.apache.hadoop.mapreduce.TaskAttemptContext;
+import org.apache.hadoop.mapreduce.lib.input.FileSplit;
+import org.apache.hadoop.util.LineReader;
+
+/**
+ * A record reader for the interleaved FASTQ format.
+ *
+ * Reads over an input file and parses interleaved FASTQ read pairs into
+ * a single Text output. This is then fed into the FastqConverter, which
+ * converts the single Text instance into two AlignmentRecords.
+ */
+abstract class FastqRecordReader extends RecordReader<Void,Text> {
+    /*
+     * fastq format:
+     * <fastq>  :=  <block>+
+     * <block>  :=  @<seqname>\n<seq>\n\+[<seqname>]\n<qual>\n
+     * <seqname>  :=  [A-Za-z0-9_.:-]+
+     * <seq>  :=  [A-Za-z\n\.~]+
+     * <qual> :=  [!-~\n]+
+     *
+     * LP: this format is broken, no?  You can have multi-line sequence and quality strings,
+     * and the quality encoding includes '@' in its valid character range.  So how should one
+     * distinguish between \n@ as a record delimiter and and \n@ as part of a multi-line
+     * quality string?
+     *
+     * For now I'm going to assume single-line sequences.  This works for our sequencing
+     * application.  We'll see if someone complains in other applications.
+     */
+    
+    /**
+     * First valid data index in the stream.
+     */
+    private long start;
+    
+    /**
+     * First index value beyond the slice, i.e. slice is in range [start,end).
+     */
+    protected long end;
+    
+    /**
+     * Current position in file.
+     */
+    protected long pos;
+    
+    /**
+     * Path of the file being parsed.
+     */
+    private Path file;
+    
+    /**
+     * The line reader we are using to read the file.
+     */
+    private LineReader lineReader;
+    
+    /**
+     * The input stream we are using to read the file.
+     */
+    private InputStream inputStream;
+    
+    /**
+     * The text for a single record pair we have parsed out.
+     * Hadoop's RecordReader contract requires us to save this as state.
+     */
+    private Text currentValue;
+    
+    /**
+     * Newline string for matching on.
+     */
+    private static final byte[] newline = "\n".getBytes();
+    
+    /**
+     * Maximum length for a read string.
+     */
+    private static final int MAX_LINE_LENGTH = 10000;
+    
+    /**
+     * Builds a new record reader given a config file and an input split.
+     *
+     * @param conf The Hadoop configuration object. Used for gaining access
+     *   to the underlying file system.
+     * @param split The file split to read.
+     */
+    protected FastqRecordReader(final Configuration conf, final FileSplit split) throws IOException {
+        file = split.getPath();
+        start = split.getStart();
+        end = start + split.getLength();
+        
+        FileSystem fs = file.getFileSystem(conf);
+        FSDataInputStream fileIn = fs.open(file);
+        
+        CompressionCodecFactory codecFactory = new CompressionCodecFactory(conf);
+        CompressionCodec codec = codecFactory.getCodec(file);
+        
+        if (codec == null) { // no codec.  Uncompressed file.
+            positionAtFirstRecord(fileIn);
+            inputStream = fileIn;
+        } else { 
+            // compressed file
+            if (start != 0) {
+                throw new RuntimeException("Start position for compressed file is not 0! (found " + start + ")");
+            }
+            
+            inputStream = codec.createInputStream(fileIn);
+            end = Long.MAX_VALUE; // read until the end of the file
+        }
+        
+        lineReader = new LineReader(inputStream);
+    }
+    
+    /**
+     * Checks to see whether the buffer is positioned at a valid record.
+     *
+     * @param bufferLength The length of the line currently in the buffer.
+     * @param buffer A buffer containing a peek at the first line in the current
+     *   stream.
+     * @return Returns true if the buffer contains the first line of a properly
+     *   formatted FASTQ record.
+     */
+    abstract protected boolean checkBuffer(int bufferLength, Text buffer);
+
+    /**
+     * Position the input stream at the start of the first record.
+     *
+     * @param stream The stream to reposition.
+     */
+    protected void positionAtFirstRecord(FSDataInputStream stream) throws IOException {
+        Text buffer = new Text();
+        
+        if (true) { // (start > 0) // use start>0 to assume that files start with valid data
+            // Advance to the start of the first record that ends with /1
+            // We use a temporary LineReader to read lines until we find the
+            // position of the right one.  We then seek the file to that position.
+            stream.seek(start);
+            LineReader reader = new LineReader(stream);
+            
+            int bytesRead = 0;
+            do {
+                bytesRead = reader.readLine(buffer, (int)Math.min(MAX_LINE_LENGTH, end - start));
+                int bufferLength = buffer.getLength();
+                if (bytesRead > 0 && !checkBuffer(bufferLength, buffer)) {
+                    start += bytesRead;
+                } else {
+                    // line starts with @.  Read two more and verify that it starts with a +
+                    //
+                    // If this isn't the start of a record, we want to backtrack to its end
+                    long backtrackPosition = start + bytesRead;
+                    
+                    bytesRead = reader.readLine(buffer, (int)Math.min(MAX_LINE_LENGTH, end - start));
+                    bytesRead = reader.readLine(buffer, (int)Math.min(MAX_LINE_LENGTH, end - start));
+                    if (bytesRead > 0 && buffer.getLength() > 0 && buffer.getBytes()[0] == '+') {
+                        break; // all good!
+                    } else {
+                        // backtrack to the end of the record we thought was the start.
+                        start = backtrackPosition;
+                        stream.seek(start);
+                        reader = new LineReader(stream);
+                    }
+                }
+            } while (bytesRead > 0);
+            
+            stream.seek(start);
+        }
+        
+        pos = start;
+    }
+    
+    /**
+     * Method is a no-op.
+     *
+     * @param split The input split that we will parse.
+     * @param context The Hadoop task context.
+     */
+    public void initialize(InputSplit split, TaskAttemptContext context) throws IOException, InterruptedException {}
+    
+    /**
+     * FASTQ has no keys, so we return null.
+     *
+     * @return Always returns null.
+     */
+    public Void getCurrentKey() {
+        return null;
+    }
+    
+    /**
+     * Returns the last interleaved FASTQ record.
+     *
+     * @return The text corresponding to the last read pair.
+     */
+    public Text getCurrentValue() {
+        return currentValue;
+    }
+    
+    /**
+     * Seeks ahead in our split to the next key-value pair.
+     *
+     * Triggers the read of an interleaved FASTQ read pair, and populates
+     * internal state.
+     *
+     * @return True if reading the next read pair succeeded.
+     */
+    public boolean nextKeyValue() throws IOException, InterruptedException {
+        currentValue = new Text();
+        
+        return next(currentValue);
+    }
+    
+    /**
+     * Close this RecordReader to future operations.
+     */
+    public void close() throws IOException {
+        inputStream.close();
+    }
+    
+    /**
+     * How much of the input has the RecordReader consumed?
+     *
+     * @return Returns a value on [0.0, 1.0] that notes how many bytes we
+     *   have read so far out of the total bytes to read.
+     */
+    public float getProgress() {
+        if (start == end) {
+            return 1.0f;
+        } else {
+            return Math.min(1.0f, (pos - start) / (float)(end - start));
+        }
+    }
+    
+    /**
+     * Produces a debugging message with the file position.
+     *
+     * @return Returns a string containing {filename}:{index}.
+     */
+    protected String makePositionMessage() {
+        return file.toString() + ":" + pos;
+    }
+    
+    /**
+     * Parses a read from an interleaved FASTQ file.
+     *
+     * Only reads a single record.
+     *
+     * @param readName Text record containing read name. Output parameter.
+     * @param value Text record containing full record. Output parameter.
+     * @return Returns true if read was successful (did not hit EOF).
+     *
+     * @throws RuntimeException Throws exception if FASTQ record doesn't
+     *   have proper formatting (e.g., record doesn't start with @).
+     */
+    protected boolean lowLevelFastqRead(Text readName, Text value) throws IOException {
+        // ID line
+        readName.clear();
+        long skipped = appendLineInto(readName, true);
+        pos += skipped;
+        if (skipped == 0) {
+            return false; // EOF
+        }
+
+        if (readName.getBytes()[0] != '@') {
+            throw new RuntimeException("unexpected fastq record didn't start with '@' at " +
+                                       makePositionMessage() +
+                                       ". Line: " +
+                                       readName + ". \n");
+        }
+        
+        value.append(readName.getBytes(), 0, readName.getLength());
+        
+        // sequence
+        appendLineInto(value, false);
+        
+        // separator line
+        appendLineInto(value, false);
+        
+        // quality
+        appendLineInto(value, false);
+        
+        return true;
+    }
+    
+    /**
+     * Reads from the input split.
+     *
+     * @param value Text record to write input value into.
+     * @return Returns whether this read was successful or not.
+     *
+     * @see lowLevelFastqRead
+     */
+    abstract protected boolean next(Text value) throws IOException;
+        
+    /**
+     * Reads a newline into a text record from the underlying line reader.
+     *
+     * @param dest Text record to read line into.
+     * @param eofOk Whether an EOF is acceptable in this line.
+     * @return Returns the number of bytes read.
+     *
+     * @throws EOFException Throws if eofOk was false and we hit an EOF in
+     *    the current line.
+     */
+    private int appendLineInto(final Text dest, final boolean eofOk) throws EOFException, IOException {
+        Text buf = new Text();
+        int bytesRead = lineReader.readLine(buf, MAX_LINE_LENGTH);
+        
+        if (bytesRead < 0 || (bytesRead == 0 && !eofOk))
+            throw new EOFException();
+        
+        dest.append(buf.getBytes(), 0, buf.getLength());
+        dest.append(newline, 0, 1);
+        pos += bytesRead;
+        
+        return bytesRead;
+    }
+}

--- a/adam-core/src/main/java/org/bdgenomics/adam/io/InterleavedFastqInputFormat.java
+++ b/adam-core/src/main/java/org/bdgenomics/adam/io/InterleavedFastqInputFormat.java
@@ -15,27 +15,17 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package org.bdgenomics.adam.io;
 
+import java.io.EOFException;
+import java.io.IOException;
 import org.apache.hadoop.conf.Configuration;
-import org.apache.hadoop.fs.FSDataInputStream;
-import org.apache.hadoop.fs.FileSystem;
-import org.apache.hadoop.fs.Path;
 import org.apache.hadoop.io.Text;
-import org.apache.hadoop.io.compress.CompressionCodec;
-import org.apache.hadoop.io.compress.CompressionCodecFactory;
 import org.apache.hadoop.mapreduce.InputSplit;
-import org.apache.hadoop.mapreduce.JobContext;
 import org.apache.hadoop.mapreduce.RecordReader;
 import org.apache.hadoop.mapreduce.TaskAttemptContext;
 import org.apache.hadoop.mapreduce.lib.input.FileInputFormat;
 import org.apache.hadoop.mapreduce.lib.input.FileSplit;
-import org.apache.hadoop.util.LineReader;
-
-import java.io.EOFException;
-import java.io.IOException;
-import java.io.InputStream;
 
 /**
  * This class is a Hadoop reader for "interleaved fastq" -- that is,
@@ -50,219 +40,54 @@ import java.io.InputStream;
  *
  * This reader is based on the FastqInputFormat that's part of Hadoop-BAM,
  * found at https://github.com/HadoopGenomics/Hadoop-BAM/blob/master/src/main/java/org/seqdoop/hadoop_bam/FastqInputFormat.java
- *
- * @author Jeremy Elson (jelson@microsoft.com)
  */
 public class InterleavedFastqInputFormat extends FileInputFormat<Void,Text> {
-    
-    public static class InterleavedFastqRecordReader extends RecordReader<Void,Text> {
-        /*
-         * fastq format:
-         * <fastq>  :=  <block>+
-         * <block>  :=  @<seqname>\n<seq>\n\+[<seqname>]\n<qual>\n
-         * <seqname>  :=  [A-Za-z0-9_.:-]+
-         * <seq>  :=  [A-Za-z\n\.~]+
-         * <qual> :=  [!-~\n]+
+
+    /**
+     * A record reader for the interleaved FASTQ format.
+     *
+     * Reads over an input file and parses interleaved FASTQ read pairs into
+     * a single Text output. This is then fed into the FastqConverter, which
+     * converts the single Text instance into two AlignmentRecords.
+     */
+    private static class InterleavedFastqRecordReader extends FastqRecordReader {
+
+        InterleavedFastqRecordReader(final Configuration conf,
+                                     final FileSplit split) throws IOException {
+            super(conf, split);
+        }
+
+        /**
+         * Checks to see whether the buffer is positioned at a valid record.
          *
-         * LP: this format is broken, no?  You can have multi-line sequence and quality strings,
-         * and the quality encoding includes '@' in its valid character range.  So how should one
-         * distinguish between \n@ as a record delimiter and and \n@ as part of a multi-line
-         * quality string?
+         * We are properly positioned if the buffer contains a read name (starts
+         * with '@'), and this read name has a first-of-pair suffix (ends with
+         * '/1').
          *
-         * For now I'm going to assume single-line sequences.  This works for our sequencing
-         * application.  We'll see if someone complains in other applications.
+         * @param bufferLength The length of the line currently in the buffer.
+         * @param buffer A buffer containing a peek at the first line in the current
+         *   stream.
+         * @return Returns true if the buffer contains the first line of a properly
+         *   formatted pair of FASTQ records.
          */
-        
-        // start:  first valid data index
-        private long start;
-        // end:  first index value beyond the slice, i.e. slice is in range [start,end)
-        private long end;
-        // pos: current position in file
-        private long pos;
-        // file:  the file being read
-        private Path file;
-        
-        private LineReader lineReader;
-        private InputStream inputStream;
-        private Text currentValue;
-        private byte[] newline = "\n".getBytes();
-
-        // How long can a read get?
-        private static final int MAX_LINE_LENGTH = 10000;
-
-        public InterleavedFastqRecordReader(Configuration conf, FileSplit split) throws IOException {
-            file = split.getPath();
-            start = split.getStart();
-            end = start + split.getLength();
-
-            FileSystem fs = file.getFileSystem(conf);
-            FSDataInputStream fileIn = fs.open(file);
-
-            CompressionCodecFactory codecFactory = new CompressionCodecFactory(conf);
-            CompressionCodec        codec        = codecFactory.getCodec(file);
-
-            if (codec == null) { // no codec.  Uncompressed file.
-                positionAtFirstRecord(fileIn);
-                inputStream = fileIn;
-            } else { 
-                // compressed file
-                if (start != 0) {
-                    throw new RuntimeException("Start position for compressed file is not 0! (found " + start + ")");
-                }
-
-                inputStream = codec.createInputStream(fileIn);
-                end = Long.MAX_VALUE; // read until the end of the file
-            }
-
-            lineReader = new LineReader(inputStream);
+        protected boolean checkBuffer(int bufferLength, Text buffer) {
+            return (bufferLength >= 2 &&
+                    buffer.getBytes()[0] == '@' &&
+                    buffer.getBytes()[bufferLength - 2] == '/' &&
+                    buffer.getBytes()[bufferLength - 1] == '1');
         }
 
         /**
-         * Position the input stream at the start of the first record.
+         * Reads a read pair from the input split.
+         *
+         * @param value Text record to write input value into.
+         * @return Returns whether this read was successful or not.
+         *
+         * @throws RuntimeException Throws exception if we hit an EOF in the
+         *   middle of a read, or if we have a read that is incorrectly
+         *   formatted (missing readname delimiters).
          */
-        private void positionAtFirstRecord(FSDataInputStream stream) throws IOException {
-            Text buffer = new Text();
-
-            if (true) { // (start > 0) // use start>0 to assume that files start with valid data
-                // Advance to the start of the first record that ends with /1
-                // We use a temporary LineReader to read lines until we find the
-                // position of the right one.  We then seek the file to that position.
-                stream.seek(start);
-                LineReader reader = new LineReader(stream);
-
-                int bytesRead = 0;
-                do {
-                    bytesRead = reader.readLine(buffer, (int)Math.min(MAX_LINE_LENGTH, end - start));
-                    int bufferLength = buffer.getLength();
-                    if (bytesRead > 0 && (bufferLength <= 0 ||
-                                          buffer.getBytes()[0] != '@' ||
-                                          (bufferLength >= 2 && buffer.getBytes()[bufferLength - 2] != '/') ||
-                                          (bufferLength >= 1 && buffer.getBytes()[bufferLength - 1] != '1'))) {
-                        start += bytesRead;
-                    } else {
-                        // line starts with @.  Read two more and verify that it starts with a +
-                        //
-                        // If this isn't the start of a record, we want to backtrack to its end
-                        long backtrackPosition = start + bytesRead;
-
-                        bytesRead = reader.readLine(buffer, (int)Math.min(MAX_LINE_LENGTH, end - start));
-                        bytesRead = reader.readLine(buffer, (int)Math.min(MAX_LINE_LENGTH, end - start));
-                        if (bytesRead > 0 && buffer.getLength() > 0 && buffer.getBytes()[0] == '+') {
-                            break; // all good!
-                        } else {
-                            // backtrack to the end of the record we thought was the start.
-                            start = backtrackPosition;
-                            stream.seek(start);
-                            reader = new LineReader(stream);
-                        }
-                    }
-                } while (bytesRead > 0);
-
-                stream.seek(start);
-            }
-
-            pos = start;
-        }
-
-        /**
-         * Added to use mapreduce API.
-         */
-        public void initialize(InputSplit split, TaskAttemptContext context) throws IOException, InterruptedException {}
-
-        /**
-         * Added to use mapreduce API.
-         */
-        public Void getCurrentKey() {
-            return null;
-        }
-
-        /**
-         * Added to use mapreduce API.
-         */
-        public Text getCurrentValue() {
-            return currentValue;
-        }
-
-        /**
-         * Added to use mapreduce API.
-         */
-        public boolean nextKeyValue() throws IOException, InterruptedException {
-            currentValue = new Text();
-
-            return next(currentValue);
-        }
-
-        /**
-         * Close this RecordReader to future operations.
-         */
-        public void close() throws IOException {
-            inputStream.close();
-        }
-
-        /**
-         * Create an object of the appropriate type to be used as a key.
-         */
-        public Text createKey() {
-            return new Text();
-        }
-
-        /**
-         * Create an object of the appropriate type to be used as a value.
-         */
-        public Text createValue() {
-            return new Text();
-        }
-
-        /**
-         * Returns the current position in the input.
-         */
-        public long getPos() { 
-            return pos; 
-        }
-
-        /**
-         * How much of the input has the RecordReader consumed i.e.
-         */
-        public float getProgress() {
-            if (start == end)
-                return 1.0f;
-            else
-                return Math.min(1.0f, (pos - start) / (float)(end - start));
-        }
-
-        public String makePositionMessage() {
-            return file.toString() + ":" + pos;
-        }
-
-        protected boolean lowLevelFastqRead(Text readName, Text value) throws IOException {
-            // ID line
-            readName.clear();
-            long skipped = appendLineInto(readName, true);
-            pos += skipped;
-            if (skipped == 0)
-                return false; // EOF
-            if (readName.getBytes()[0] != '@')
-                throw new RuntimeException("unexpected fastq record didn't start with '@' at " + makePositionMessage() + ". Line: " + readName + ". \n");
-
-            value.append(readName.getBytes(), 0, readName.getLength());
-
-            // sequence
-            appendLineInto(value, false);
-
-            // separator line
-            appendLineInto(value, false);
-
-            // quality
-            appendLineInto(value, false);
-
-            return true;
-        }
-
-
-        /**
-         * Reads the next key/value pair from the input for processing.
-         */
-        public boolean next(Text value) throws IOException {
+        protected boolean next(Text value) throws IOException {
             if (pos >= end)
                 return false; // past end of slice
             try {
@@ -277,8 +102,6 @@ public class InterleavedFastqInputFormat extends FileInputFormat<Void,Text> {
                 if (!gotData)
                     return false;
 
-
-
                 // second read of the pair
                 gotData = lowLevelFastqRead(readName2, value);
 
@@ -290,23 +113,15 @@ public class InterleavedFastqInputFormat extends FileInputFormat<Void,Text> {
                 throw new RuntimeException("unexpected end of file in fastq record at " + makePositionMessage());
             }
         }
-
-
-        private int appendLineInto(Text dest, boolean eofOk) throws EOFException, IOException {
-            Text buf = new Text();
-            int bytesRead = lineReader.readLine(buf, MAX_LINE_LENGTH);
-
-            if (bytesRead < 0 || (bytesRead == 0 && !eofOk))
-                throw new EOFException();
-
-            dest.append(buf.getBytes(), 0, buf.getLength());
-            dest.append(newline, 0, 1);
-            pos += bytesRead;
-
-            return bytesRead;
-        }
     }
 
+    /**
+     * Creates the new record reader that underlies this input format.
+     *
+     * @param genericSplit The split that the record reader should read.
+     * @param context The Hadoop task context.
+     * @return Returns the interleaved FASTQ record reader.
+     */
     public RecordReader<Void, Text> createRecordReader(
             InputSplit genericSplit,
             TaskAttemptContext context) throws IOException, InterruptedException {

--- a/adam-core/src/main/java/org/bdgenomics/adam/io/SingleFastqInputFormat.java
+++ b/adam-core/src/main/java/org/bdgenomics/adam/io/SingleFastqInputFormat.java
@@ -15,243 +15,68 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package org.bdgenomics.adam.io;
 
+import java.io.EOFException;
+import java.io.IOException;
 import org.apache.hadoop.conf.Configuration;
-import org.apache.hadoop.fs.FSDataInputStream;
-import org.apache.hadoop.fs.FileSystem;
-import org.apache.hadoop.fs.Path;
 import org.apache.hadoop.io.Text;
-import org.apache.hadoop.io.compress.CompressionCodec;
-import org.apache.hadoop.io.compress.CompressionCodecFactory;
 import org.apache.hadoop.mapreduce.InputSplit;
-import org.apache.hadoop.mapreduce.JobContext;
 import org.apache.hadoop.mapreduce.RecordReader;
 import org.apache.hadoop.mapreduce.TaskAttemptContext;
 import org.apache.hadoop.mapreduce.lib.input.FileInputFormat;
 import org.apache.hadoop.mapreduce.lib.input.FileSplit;
-import org.apache.hadoop.util.LineReader;
-
-import java.io.EOFException;
-import java.io.IOException;
-import java.io.InputStream;
 
 /**
  * This class is a Hadoop reader for single read fastq.
  *
  * This reader is based on the FastqInputFormat that's part of Hadoop-BAM,
  * found at https://github.com/HadoopGenomics/Hadoop-BAM/blob/master/src/main/java/org/seqdoop/hadoop_bam/FastqInputFormat.java
- *
- * @author Frank Austin Nothaft (fnothaft@berkeley.edu)
  */
 public class SingleFastqInputFormat extends FileInputFormat<Void,Text> {
     
-    public static class SingleFastqRecordReader extends RecordReader<Void,Text> {
-        /*
-         * fastq format:
-         * <fastq>  :=  <block>+
-         * <block>  :=  @<seqname>\n<seq>\n\+[<seqname>]\n<qual>\n
-         * <seqname>  :=  [A-Za-z0-9_.:-]+
-         * <seq>  :=  [A-Za-z\n\.~]+
-         * <qual> :=  [!-~\n]+
+    /**
+     * A record reader for the standard FASTQ format.
+     *
+     * Reads over an input file and parses FASTQ read pairs into Text. This is
+     * then fed into the FastqConverter, which converts the Text instance into
+     * an AlignmentRecord.
+     */
+    private static class SingleFastqRecordReader extends FastqRecordReader {
+
+        SingleFastqRecordReader(final Configuration conf,
+                                final FileSplit split) throws IOException {
+            super(conf, split);
+        }
+
+        /**
+         * Checks to see whether the buffer is positioned at a valid record.
          *
-         * LP: this format is broken, no?  You can have multi-line sequence and quality strings,
-         * and the quality encoding includes '@' in its valid character range.  So how should one
-         * distinguish between \n@ as a record delimiter and and \n@ as part of a multi-line
-         * quality string?
+         * We are properly positioned if the buffer contains a read name (starts
+         * with '@'). We do not check for a read name suffix.
          *
-         * For now I'm going to assume single-line sequences.  This works for our sequencing
-         * application.  We'll see if someone complains in other applications.
+         * @param bufferLength The length of the line currently in the buffer.
+         * @param buffer A buffer containing a peek at the first line in the current
+         *   stream.
+         * @return Returns true if the buffer contains the first line of a properly
+         *   formatted pair of FASTQ records.
          */
-        
-        // start:  first valid data index
-        private long start;
-        // end:  first index value beyond the slice, i.e. slice is in range [start,end)
-        private long end;
-        // pos: current position in file
-        private long pos;
-        // file:  the file being read
-        private Path file;
-        
-        private LineReader lineReader;
-        private InputStream inputStream;
-        private Text currentValue;
-        private byte[] newline = "\n".getBytes();
-
-        // How long can a read get?
-        private static final int MAX_LINE_LENGTH = 10000;
-
-        public SingleFastqRecordReader(Configuration conf, FileSplit split) throws IOException {
-            file = split.getPath();
-            start = split.getStart();
-            end = start + split.getLength();
-
-            FileSystem fs = file.getFileSystem(conf);
-            FSDataInputStream fileIn = fs.open(file);
-
-            CompressionCodecFactory codecFactory = new CompressionCodecFactory(conf);
-            CompressionCodec        codec        = codecFactory.getCodec(file);
-
-            if (codec == null) { // no codec.  Uncompressed file.
-                positionAtFirstRecord(fileIn);
-                inputStream = fileIn;
-            } else { 
-                // compressed file
-                if (start != 0) {
-                    throw new RuntimeException("Start position for compressed file is not 0! (found " + start + ")");
-                }
-
-                inputStream = codec.createInputStream(fileIn);
-                end = Long.MAX_VALUE; // read until the end of the file
-            }
-
-            lineReader = new LineReader(inputStream);
+        protected boolean checkBuffer(int bufferLength, Text buffer) {
+            return (bufferLength >= 0 &&
+                    buffer.getBytes()[0] == '@');
         }
 
         /**
-         * Position the input stream at the start of the first record.
+         * Reads the next read from the input split.
+         *
+         * @param value Text record to write input value into.
+         * @return Returns whether this read was successful or not.
+         *
+         * @throws RuntimeException Throws exception if we hit an EOF in the
+         *   middle of a read, or if we have a read that is incorrectly
+         *   formatted (missing readname delimiters).
          */
-        private void positionAtFirstRecord(FSDataInputStream stream) throws IOException {
-            Text buffer = new Text();
-
-            if (true) { // (start > 0) // use start>0 to assume that files start with valid data
-                // Advance to the start of the first record
-                // We use a temporary LineReader to read lines until we find the
-                // position of the right one.  We then seek the file to that position.
-                stream.seek(start);
-                LineReader reader = new LineReader(stream);
-
-                int bytesRead = 0;
-                do {
-                    bytesRead = reader.readLine(buffer, (int)Math.min(MAX_LINE_LENGTH, end - start));
-                    int bufferLength = buffer.getLength();
-                    if (bytesRead > 0 && (bufferLength <= 0 ||
-                                          buffer.getBytes()[0] != '@')) {
-                        start += bytesRead;
-                    } else {
-                        // line starts with @.  Read two more and verify that it starts with a +
-                        //
-                        // If this isn't the start of a record, we want to backtrack to its end
-                        long backtrackPosition = start + bytesRead;
-
-                        bytesRead = reader.readLine(buffer, (int)Math.min(MAX_LINE_LENGTH, end - start));
-                        bytesRead = reader.readLine(buffer, (int)Math.min(MAX_LINE_LENGTH, end - start));
-                        if (bytesRead > 0 && buffer.getLength() > 0 && buffer.getBytes()[0] == '+') {
-                            break; // all good!
-                        } else {
-                            // backtrack to the end of the record we thought was the start.
-                            start = backtrackPosition;
-                            stream.seek(start);
-                            reader = new LineReader(stream);
-                        }
-                    }
-                } while (bytesRead > 0);
-
-                stream.seek(start);
-            }
-
-            pos = start;
-        }
-
-        /**
-         * Added to use mapreduce API.
-         */
-        public void initialize(InputSplit split, TaskAttemptContext context) throws IOException, InterruptedException {}
-
-        /**
-         * Added to use mapreduce API.
-         */
-        public Void getCurrentKey() {
-            return null;
-        }
-
-        /**
-         * Added to use mapreduce API.
-         */
-        public Text getCurrentValue() {
-            return currentValue;
-        }
-
-        /**
-         * Added to use mapreduce API.
-         */
-        public boolean nextKeyValue() throws IOException, InterruptedException {
-            currentValue = new Text();
-
-            return next(currentValue);
-        }
-
-        /**
-         * Close this RecordReader to future operations.
-         */
-        public void close() throws IOException {
-            inputStream.close();
-        }
-
-        /**
-         * Create an object of the appropriate type to be used as a key.
-         */
-        public Text createKey() {
-            return new Text();
-        }
-
-        /**
-         * Create an object of the appropriate type to be used as a value.
-         */
-        public Text createValue() {
-            return new Text();
-        }
-
-        /**
-         * Returns the current position in the input.
-         */
-        public long getPos() { 
-            return pos; 
-        }
-
-        /**
-         * How much of the input has the RecordReader consumed i.e.
-         */
-        public float getProgress() {
-            if (start == end)
-                return 1.0f;
-            else
-                return Math.min(1.0f, (pos - start) / (float)(end - start));
-        }
-
-        public String makePositionMessage() {
-            return file.toString() + ":" + pos;
-        }
-
-        protected boolean lowLevelFastqRead(Text readName, Text value) throws IOException {
-            // ID line
-            readName.clear();
-            long skipped = appendLineInto(readName, true);
-            if (skipped == 0)
-                return false; // EOF
-            if (readName.getBytes()[0] != '@')
-                throw new RuntimeException("unexpected fastq record didn't start with '@' at " + makePositionMessage() + ". Line: " + readName + ". \n");
-
-            value.append(readName.getBytes(), 0, readName.getLength());
-
-            // sequence
-            appendLineInto(value, false);
-
-            // separator line
-            appendLineInto(value, false);
-
-            // quality
-            appendLineInto(value, false);
-
-            return true;
-        }
-
-
-        /**
-         * Reads the next key/value pair from the input for processing.
-         */
-        public boolean next(Text value) throws IOException {
+        protected boolean next(Text value) throws IOException {
             if (pos >= end)
                 return false; // past end of slice
             try {
@@ -267,23 +92,15 @@ public class SingleFastqInputFormat extends FileInputFormat<Void,Text> {
                 throw new RuntimeException("unexpected end of file in fastq record at " + makePositionMessage());
             }
         }
-
-
-        private int appendLineInto(Text dest, boolean eofOk) throws EOFException, IOException {
-            Text buf = new Text();
-            int bytesRead = lineReader.readLine(buf, MAX_LINE_LENGTH);
-
-            if (bytesRead < 0 || (bytesRead == 0 && !eofOk))
-                throw new EOFException();
-
-            dest.append(buf.getBytes(), 0, buf.getLength());
-            dest.append(newline, 0, 1);
-            pos += bytesRead;
-
-            return bytesRead;
-        }
     }
 
+    /**
+     * Creates the new record reader that underlies this input format.
+     *
+     * @param genericSplit The split that the record reader should read.
+     * @param context The Hadoop task context.
+     * @return Returns the interleaved FASTQ record reader.
+     */
     public RecordReader<Void, Text> createRecordReader(
             InputSplit genericSplit,
             TaskAttemptContext context) throws IOException, InterruptedException {


### PR DESCRIPTION
* Added documentation to all classes, methods, and fields that were missing descriptions.
* Factored duplicated code from `SingleFastqRecordReader` and `InterleavedFastqRecordReader` out into a new abstract base class `FastqRecordReader`.
* Tightened up access modifiers where possible. Sadly, the two input formats cannot be made more private, since Java has a more restricted form of package-private than scala, and the input formats are used from inside of `org.bdgenomics.adam.rdd`.
* Removed `@author` tags.