### PR TITLE
[ADAM-768] ReferenceRegion from variant/genotypes

### DIFF
--- a/adam-core/src/main/scala/org/bdgenomics/adam/models/ReferenceRegion.scala
+++ b/adam-core/src/main/scala/org/bdgenomics/adam/models/ReferenceRegion.scala
@@ -92,6 +92,26 @@ object ReferenceRegion {
       None
   }
 
+  /**
+   * Builds a reference region for a called genotype.
+   *
+   * @param genotype Called genotype to extract region from.
+   * @return The site where this genotype lives.
+   */
+  def apply(genotype: Genotype): ReferenceRegion = {
+    ReferenceRegion(genotype.getVariant)
+  }
+
+  /**
+   * Builds a reference region for a variant site.
+   *
+   * @param variant Variant to extract region from.
+   * @return The site where this variant covers.
+   */
+  def apply(variant: Variant): ReferenceRegion = {
+    ReferenceRegion(variant.getContigName, variant.getStart, variant.getEnd)
+  }
+
   def apply(record: AlignmentRecord): ReferenceRegion = {
     ReferenceRegion(record.getContigName, record.getStart, record.getEnd)
   }

--- a/adam-core/src/test/scala/org/bdgenomics/adam/models/ReferenceRegionSuite.scala
+++ b/adam-core/src/test/scala/org/bdgenomics/adam/models/ReferenceRegionSuite.scala
@@ -18,7 +18,7 @@
 package org.bdgenomics.adam.models
 
 import org.scalatest._
-import org.bdgenomics.formats.avro.{ AlignmentRecord, Contig, Strand }
+import org.bdgenomics.formats.avro._
 
 class ReferenceRegionSuite extends FunSuite {
 
@@ -241,5 +241,23 @@ class ReferenceRegionSuite extends FunSuite {
     assert(ReferenceRegion("chr1", 100, 201).width === 101)
     assert(ReferenceRegion("chr2", 200, 401, Strand.FORWARD).width === 201)
     assert(ReferenceRegion("chr3", 399, 1000, Strand.REVERSE).width === 601)
+  }
+
+  test("make a reference region for a variant or genotype") {
+    val v = Variant.newBuilder()
+      .setContigName("chr")
+      .setStart(1L)
+      .setEnd(3L)
+      .build()
+    val g = Genotype.newBuilder()
+      .setVariant(v)
+      .build()
+    val rrV = ReferenceRegion(v)
+    val rrG = ReferenceRegion(g)
+
+    assert(rrV.referenceName === "chr")
+    assert(rrV.start === 1L)
+    assert(rrV.end === 3L)
+    assert(rrV === rrG)
   }
 }


### PR DESCRIPTION
Resolves #768. Adds apply methods to ReferenceRegion for Avro variant and genotype records.