### PR TITLE
[ADAM-582] Eliminate .get on option in FragmentCoverter.

### DIFF
--- a/adam-core/src/main/scala/org/bdgenomics/adam/converters/FragmentConverter.scala
+++ b/adam-core/src/main/scala/org/bdgenomics/adam/converters/FragmentConverter.scala
@@ -35,11 +35,11 @@ private object FragmentCollector extends Serializable {
    * @return Returns key value pair where the key is the contig metadata and the
    *   value is a Fragment Collector object.
    */
-  def apply(fragment: NucleotideContigFragment): (Contig, FragmentCollector) = {
-    (
-      fragment.getContig,
-      FragmentCollector(Seq((ReferenceRegion(fragment).get, fragment.getFragmentSequence)))
-    )
+  def apply(fragment: NucleotideContigFragment): Option[(Contig, FragmentCollector)] = {
+    ReferenceRegion(fragment).map(rr => {
+      (fragment.getContig,
+        FragmentCollector(Seq((rr, fragment.getFragmentSequence))))
+    })
   }
 }
 
@@ -153,7 +153,7 @@ private[adam] object FragmentConverter extends Serializable {
    * @return Returns an RDD of reads that represent aligned contigs.
    */
   def convertRdd(rdd: RDD[NucleotideContigFragment]): RDD[AlignmentRecord] = {
-    rdd.map(FragmentCollector(_))
+    rdd.flatMap(FragmentCollector(_))
       .reduceByKey(mergeFragments)
       .flatMap(convertFragment)
   }

--- a/adam-core/src/test/scala/org/bdgenomics/adam/converters/FragmentConverterSuite.scala
+++ b/adam-core/src/test/scala/org/bdgenomics/adam/converters/FragmentConverterSuite.scala
@@ -24,11 +24,13 @@ import org.bdgenomics.formats.avro._
 class FragmentConverterSuite extends ADAMFunSuite {
 
   test("build a fragment collector and convert to a read") {
-    val (builtContig, builtFragment) = FragmentCollector(NucleotideContigFragment.newBuilder()
+    val fcOpt = FragmentCollector(NucleotideContigFragment.newBuilder()
       .setContig(Contig.newBuilder().setContigName("ctg").build())
       .setFragmentSequence("ACACACAC")
       .setFragmentStartPosition(0L)
       .build())
+    assert(fcOpt.isDefined)
+    val (builtContig, builtFragment) = fcOpt.get
 
     assert(builtContig.getContigName === "ctg")
     assert(builtFragment.fragments.length === 1)
@@ -44,6 +46,11 @@ class FragmentConverterSuite extends ADAMFunSuite {
     assert(convertedRead.getContigName === "ctg")
     assert(convertedRead.getStart === 0L)
     assert(convertedRead.getEnd === 8L)
+  }
+
+  test("if a fragment isn't associated with a contig, don't get a fragment collector") {
+    val fcOpt = FragmentCollector(NucleotideContigFragment.newBuilder().build())
+    assert(fcOpt.isEmpty)
   }
 
   sparkTest("convert an rdd of discontinuous fragments, all from the same contig") {


### PR DESCRIPTION
Resolves #582. In the FragmentConverter, we had code that called .get on an optional ReferenceRegion. If a NucleotideContigFragment didn't have a contig associated with it, then we would call .get on the empty option, which would throw an error. This commit changes that code to call map on the Option[ReferenceRegion], and then changes the usage of that method so that it is called in a flatMap. Additionally, I've added a test to cover this case.