### PR TITLE
[ADAM-1087] Migrate away from FileSystem.get

### DIFF
--- a/adam-core/src/main/scala/org/bdgenomics/adam/rdd/ADAMRDDFunctions.scala
+++ b/adam-core/src/main/scala/org/bdgenomics/adam/rdd/ADAMRDDFunctions.scala
@@ -73,10 +73,11 @@ private[rdd] abstract class ADAMRDDFunctions[T <% IndexedRecord: Manifest] exten
                                                   avro: Seq[U])(implicit tUag: ClassTag[U]) {
 
     // get our current file system
-    val fs = FileSystem.get(sc.hadoopConfiguration)
+    val path = new Path(filename)
+    val fs = path.getFileSystem(sc.hadoopConfiguration)
 
     // get an output stream
-    val os = fs.create(new Path(filename))
+    val os = fs.create(path)
       .asInstanceOf[OutputStream]
 
     // set up avro for writing

--- a/adam-core/src/main/scala/org/bdgenomics/adam/util/ParquetFileTraversable.scala
+++ b/adam-core/src/main/scala/org/bdgenomics/adam/util/ParquetFileTraversable.scala
@@ -26,7 +26,7 @@ import org.bdgenomics.utils.misc.HadoopUtil
 class ParquetFileTraversable[T <: IndexedRecord](sc: SparkContext, file: Path) extends Traversable[T] {
   def this(sc: SparkContext, file: String) = this(sc, new Path(file))
 
-  private val fs = FileSystem.get(sc.hadoopConfiguration)
+  private val fs = file.getFileSystem(sc.hadoopConfiguration)
 
   val paths: List[Path] = {
     if (!fs.exists(file)) {


### PR DESCRIPTION
FileSystem.get returns the configured default file system. This can cause issues when loading a file off a non-default FileSystem, e.g., an NFS or S3. This PR changes to use Path.getFileSystem. Resolves #1087.