### PR TITLE
Remove StructuralVariant and StructuralVariantType, add names field to Variant

### DIFF
--- a/adam-cli/src/main/scala/org/bdgenomics/adam/cli/AlleleCount.scala
+++ b/adam-cli/src/main/scala/org/bdgenomics/adam/cli/AlleleCount.scala
@@ -49,8 +49,8 @@ class AlleleCountArgs extends Args4jBase with ParquetArgs {
 object AlleleCountHelper extends Serializable {
   def chooseAllele(x: (String, java.lang.Long, String, String, GenotypeAllele)) =
     x match {
-      case (chr, position, refAllele, varAllele, GenotypeAllele.Ref) => Some(chr, position, refAllele)
-      case (chr, position, refAllele, varAllele, GenotypeAllele.Alt) => Some(chr, position, varAllele)
+      case (chr, position, refAllele, varAllele, GenotypeAllele.REF) => Some(chr, position, refAllele)
+      case (chr, position, refAllele, varAllele, GenotypeAllele.ALT) => Some(chr, position, varAllele)
       case _ => None
     }
 

--- a/adam-core/src/main/scala/org/bdgenomics/adam/converters/VariantContextConverter.scala
+++ b/adam-core/src/main/scala/org/bdgenomics/adam/converters/VariantContextConverter.scala
@@ -72,10 +72,10 @@ private[adam] object VariantContextConverter {
    * @return The Avro representation for this allele.
    */
   private def convertAllele(vc: HtsjdkVariantContext, allele: Allele): GenotypeAllele = {
-    if (allele.isNoCall) GenotypeAllele.NoCall
-    else if (allele.isReference) GenotypeAllele.Ref
-    else if (allele == NON_REF_ALLELE || !vc.hasAlternateAllele(allele)) GenotypeAllele.OtherAlt
-    else GenotypeAllele.Alt
+    if (allele.isNoCall) GenotypeAllele.NO_CALL
+    else if (allele.isReference) GenotypeAllele.REF
+    else if (allele == NON_REF_ALLELE || !vc.hasAlternateAllele(allele)) GenotypeAllele.OTHER_ALT
+    else GenotypeAllele.ALT
   }
 
   /**
@@ -123,9 +123,9 @@ private[adam] object VariantContextConverter {
     var alleles = g.getAlleles
     if (alleles == null) return Collections.emptyList[Allele]
     else g.getAlleles.map {
-      case GenotypeAllele.NoCall                        => Allele.NO_CALL
-      case GenotypeAllele.Ref | GenotypeAllele.OtherAlt => Allele.create(g.getVariant.getReferenceAllele, true)
-      case GenotypeAllele.Alt                           => Allele.create(g.getVariant.getAlternateAllele)
+      case GenotypeAllele.NO_CALL                        => Allele.NO_CALL
+      case GenotypeAllele.REF | GenotypeAllele.OTHER_ALT => Allele.create(g.getVariant.getReferenceAllele, true)
+      case GenotypeAllele.ALT                            => Allele.create(g.getVariant.getAlternateAllele)
     }
   }
 }
@@ -327,10 +327,9 @@ private[adam] class VariantContextConverter(dict: Option[SequenceDictionary] = N
       .setStart(vc.getStart - 1 /* ADAM is 0-indexed */ )
       .setEnd(vc.getEnd /* ADAM is 0-indexed, so the 1-indexed inclusive end becomes exclusive */ )
       .setReferenceAllele(vc.getReference.getBaseString)
-    if (vc.hasLog10PError) {
-      builder.setVariantErrorProbability(vc.getPhredScaledQual.intValue())
-    }
     alt.foreach(builder.setAlternateAllele(_))
+    if (vc.hasID())
+      builder.setNames(vc.getID().split(VCFConstants.ID_FIELD_SEPARATOR))
     builder.build
   }
 
@@ -392,7 +391,7 @@ private[adam] class VariantContextConverter(dict: Option[SequenceDictionary] = N
           .setVariantCallingAnnotations(annotations)
           .setSampleId(g.getSampleName)
           .setAlleles(g.getAlleles.map(VariantContextConverter.convertAllele(vc, _)))
-          .setIsPhased(g.isPhased)
+          .setPhased(g.isPhased)
 
         if (g.hasGQ) genotype.setGenotypeQuality(g.getGQ)
         if (g.hasDP) genotype.setReadDepth(g.getDP)
@@ -547,7 +546,7 @@ private[adam] class VariantContextConverter(dict: Option[SequenceDictionary] = N
           g.getSampleId, VariantContextConverter.convertAlleles(g)
         )
 
-        Option(g.getIsPhased).foreach(gb.phased(_))
+        Option(g.getPhased).foreach(gb.phased(_))
         Option(g.getGenotypeQuality).foreach(gb.GQ(_))
         Option(g.getReadDepth).foreach(gb.DP(_))
 

--- a/adam-core/src/main/scala/org/bdgenomics/adam/projections/FeatureField.scala
+++ b/adam-core/src/main/scala/org/bdgenomics/adam/projections/FeatureField.scala
@@ -24,5 +24,5 @@ import org.bdgenomics.formats.avro.Feature
  */
 object FeatureField extends FieldEnumeration(Feature.SCHEMA$) {
 
-  val featureId, name, source, featureType, contigName, start, end, strand, phase, frame, score, geneId, transcriptId, exonId, aliases, parentIds, target, gap, derivesFrom, notes, dbxrefs, ontologyTerms, isCircular, attributes = SchemaValue
+  val featureId, name, source, featureType, contigName, start, end, strand, phase, frame, score, geneId, transcriptId, exonId, aliases, parentIds, target, gap, derivesFrom, notes, dbxrefs, ontologyTerms, circular, attributes = SchemaValue
 }

--- a/adam-core/src/main/scala/org/bdgenomics/adam/projections/GenotypeField.scala
+++ b/adam-core/src/main/scala/org/bdgenomics/adam/projections/GenotypeField.scala
@@ -24,5 +24,5 @@ import org.bdgenomics.formats.avro.Genotype
  */
 object GenotypeField extends FieldEnumeration(Genotype.SCHEMA$) {
 
-  val variant, contigName, start, end, variantCallingAnnotations, sampleId, sampleDescription, processingDescription, alleles, referenceReadDepth, alternateReadDepth, readDepth, genotypeQuality, genotypeLikelihoods, splitFromMultiAllelic, isPhased, phaseSetId, phaseQuality = SchemaValue
+  val variant, contigName, start, end, variantCallingAnnotations, sampleId, sampleDescription, processingDescription, alleles, expectedAlleleDosage, referenceReadDepth, alternateReadDepth, readDepth, minReadDepth, genotypeQuality, genotypeLikelihoods, nonReferenceLikelihoods, strandBiasComponents, splitFromMultiAllelic, phased, phaseSetId, phaseQuality = SchemaValue
 }

--- a/adam-core/src/main/scala/org/bdgenomics/adam/projections/VariantField.scala
+++ b/adam-core/src/main/scala/org/bdgenomics/adam/projections/VariantField.scala
@@ -24,5 +24,5 @@ import org.bdgenomics.formats.avro.Variant
  */
 object VariantField extends FieldEnumeration(Variant.SCHEMA$) {
 
-  val contig, start, end, referenceAllele, variantAllele = SchemaValue
+  val contigName, start, end, referenceAllele, alternateAllele, svAllele, somatic, variantErrorProbability = SchemaValue
 }

--- a/adam-core/src/main/scala/org/bdgenomics/adam/projections/VariantField.scala
+++ b/adam-core/src/main/scala/org/bdgenomics/adam/projections/VariantField.scala
@@ -24,5 +24,5 @@ import org.bdgenomics.formats.avro.Variant
  */
 object VariantField extends FieldEnumeration(Variant.SCHEMA$) {
 
-  val contigName, start, end, referenceAllele, alternateAllele, svAllele, somatic, variantErrorProbability = SchemaValue
+  val contigName, start, end, names, referenceAllele, alternateAllele, somatic = SchemaValue
 }

--- a/adam-core/src/main/scala/org/bdgenomics/adam/rdd/features/Features.scala
+++ b/adam-core/src/main/scala/org/bdgenomics/adam/rdd/features/Features.scala
@@ -138,7 +138,7 @@ private[features] object Features {
         case "Target"        => f.setTarget(entry._2)
         case "Gap"           => f.setGap(entry._2)
         case "Derives_from"  => f.setDerivesFrom(entry._2)
-        case "Is_circular"   => f.setIsCircular(entry._2.toBoolean)
+        case "Is_circular"   => f.setCircular(entry._2.toBoolean)
         case "Alias"         => aliases += entry._2
         case "Note"          => notes += entry._2
         case "Parent"        => parentIds += entry._2
@@ -185,7 +185,7 @@ private[features] object Features {
     Option(feature.getTarget).foreach(attrs += Tuple2("Target", _))
     Option(feature.getGap).foreach(attrs += Tuple2("Gap", _))
     Option(feature.getDerivesFrom).foreach(attrs += Tuple2("Derives_from", _))
-    Option(feature.getIsCircular).foreach(addBooleanTuple)
+    Option(feature.getCircular).foreach(addBooleanTuple)
     Option(feature.getGeneId).foreach(attrs += Tuple2("gene_id", _))
     Option(feature.getTranscriptId).foreach(attrs += Tuple2("transcript_id", _))
     Option(feature.getExonId).foreach(attrs += Tuple2("exon_id", _))

--- a/adam-core/src/main/scala/org/bdgenomics/adam/rich/RichGenotype.scala
+++ b/adam-core/src/main/scala/org/bdgenomics/adam/rich/RichGenotype.scala
@@ -40,26 +40,26 @@ class RichGenotype(val genotype: Genotype) {
       distinctListOfAlleles match {
 
         // If all alleles are the reference allele, the genotype is Homozygous Reference (HOM_REF)
-        case List(GenotypeAllele.Ref)      => GenotypeType.HOM_REF
+        case List(GenotypeAllele.REF)       => GenotypeType.HOM_REF
 
         // If all alleles are the primary alternative allele, the genotype is Homozygous Alternative (HOM_ALT)
-        case List(GenotypeAllele.Alt)      => GenotypeType.HOM_ALT
+        case List(GenotypeAllele.ALT)       => GenotypeType.HOM_ALT
 
         // If all alleles are not called, the genotype is not called  (NO_CALL)
-        case List(GenotypeAllele.NoCall)   => GenotypeType.NO_CALL
+        case List(GenotypeAllele.NO_CALL)   => GenotypeType.NO_CALL
 
-        // If all alleles are OtherAlt.
-        // If genotype.getAlleles returns a single OtherAlt, the genotype is Homozygous Alternative (HOM_ALT)
-        // If genotype.getAlleles returns a multiple OtherAlt, the genotype is
-        // A) The OtherAlt alleles are the same OtherAlt alleles: Homozygous Alternative (HOM_ALT)
-        // B) The OtherAlt allales are different OtherAlt alleles: Heterozygous
+        // If all alleles are OTHER_ALT.
+        // If genotype.getAlleles returns a single OTHER_ALT, the genotype is Homozygous Alternative (HOM_ALT)
+        // If genotype.getAlleles returns a multiple OTHER_ALT, the genotype is
+        // A) The OTHER_ALT alleles are the same OTHER_ALT alleles: Homozygous Alternative (HOM_ALT)
+        // B) The OTHER_ALT alleles are different OTHER_ALT alleles: Heterozygous
         // For now return NO_CALL as the genotypes, as was done in the previous getType function
         // See also issue https://github.com/bigdatagenomics/adam/issues/897
-        case List(GenotypeAllele.OtherAlt) => GenotypeType.NO_CALL
+        case List(GenotypeAllele.OTHER_ALT) => GenotypeType.NO_CALL
 
         // only the four above alleles are possible
         // https://github.com/bigdatagenomics/bdg-formats/blob/master/src/main/resources/avro/bdg.avdl#L464
-        case _                             => throw new IllegalStateException("Found single distinct allele other than the four possible alleles: Ref, Alt, NoCall and OtherAlt")
+        case _                              => throw new IllegalStateException("Found single distinct allele other than the four possible alleles: REF, ALT, NO_CALL and OTHER_ALT")
       }
     } // In the case that there are multiple distinct alleles
     // This should be applicable to any genome ploidy.
@@ -69,9 +69,9 @@ class RichGenotype(val genotype: Genotype) {
       // IN HTS-JDK this would be GenotypeType.MIXED , this type is not available in BDG / ADAM
       // https://github.com/bigdatagenomics/bdg-formats/blob/master/src/main/resources/avro/bdg.avdl#L483
       // https://github.com/samtools/htsjdk/blob/master/src/java/htsjdk/variant/variantcontext/Genotype.java#L218
-      if (distinctListOfAlleles contains GenotypeAllele.NoCall) {
+      if (distinctListOfAlleles contains GenotypeAllele.NO_CALL) {
         GenotypeType.NO_CALL
-      } // Otherwise the distinct alleles are a combination of 2 or 3 alleles from the list  (GenotypeAllele.Ref, GenotypeAllele.Alt, GenotypeAllele.OtherAlt)
+      } // Otherwise the distinct alleles are a combination of 2 or 3 alleles from the list (GenotypeAllele.REF, GenotypeAllele.ALT, GenotypeAllele.OTHER_ALT)
       // Therefore the genotype is Heterozygous HET
       else {
         GenotypeType.HET

--- a/adam-core/src/main/scala/org/bdgenomics/adam/serialization/ADAMKryoRegistrator.scala
+++ b/adam-core/src/main/scala/org/bdgenomics/adam/serialization/ADAMKryoRegistrator.scala
@@ -57,6 +57,7 @@ import org.bdgenomics.formats.avro._
 import org.codehaus.jackson.node.{ BooleanNode, NullNode, TextNode }
 import org.seqdoop.hadoop_bam.{ VariantContextWithHeader, VariantContextWritable }
 import scala.collection.immutable
+import scala.collection.mutable.ArrayBuffer
 import scala.reflect.ClassTag
 
 case class InputStreamWithDecoder(size: Int) {
@@ -104,6 +105,7 @@ class ADAMKryoRegistrator extends KryoRegistrator {
 
     kryo.register(classOf[Genotype], new AvroSerializer[Genotype])
     kryo.register(classOf[Array[Genotype]])
+    kryo.register(classOf[ArrayBuffer[Genotype]])
 
     kryo.register(classOf[Variant], new AvroSerializer[Variant])
     kryo.register(classOf[Array[Variant]])
@@ -116,7 +118,6 @@ class ADAMKryoRegistrator extends KryoRegistrator {
 
     kryo.register(classOf[Contig], new AvroSerializer[Contig])
     kryo.register(classOf[RecordGroupMetadata], new AvroSerializer[RecordGroupMetadata])
-    kryo.register(classOf[StructuralVariant], new AvroSerializer[StructuralVariant])
     kryo.register(classOf[VariantCallingAnnotations], new AvroSerializer[VariantCallingAnnotations])
     kryo.register(classOf[TranscriptEffect], new AvroSerializer[TranscriptEffect])
     kryo.register(classOf[VariantAnnotation], new AvroSerializer[VariantAnnotation])

--- a/adam-core/src/test/scala/org/bdgenomics/adam/converters/VariantContextConverterSuite.scala
+++ b/adam-core/src/test/scala/org/bdgenomics/adam/converters/VariantContextConverterSuite.scala
@@ -121,7 +121,7 @@ class VariantContextConverterSuite extends ADAMFunSuite {
     val adamGTs = adamVCs.flatMap(_.genotypes)
     assert(adamGTs.length === 1)
     val adamGT = adamGTs.head
-    assert(adamGT.getAlleles.sameElements(List(GenotypeAllele.Ref, GenotypeAllele.Alt)))
+    assert(adamGT.getAlleles.sameElements(List(GenotypeAllele.REF, GenotypeAllele.ALT)))
     assert(adamGT.getPhaseSetId === 1)
     assert(adamGT.getPhaseQuality === 50)
   }
@@ -182,7 +182,7 @@ class VariantContextConverterSuite extends ADAMFunSuite {
     val genotype = Genotype.newBuilder
       .setVariant(variant)
       .setSampleId("NA12878")
-      .setAlleles(List(GenotypeAllele.Ref, GenotypeAllele.Alt))
+      .setAlleles(List(GenotypeAllele.REF, GenotypeAllele.ALT))
       .setVariantCallingAnnotations(VariantCallingAnnotations.newBuilder()
         .setFisherStrandBiasPValue(3.0f)
         .setRmsMapQ(0.0f)
@@ -233,19 +233,19 @@ class VariantContextConverterSuite extends ADAMFunSuite {
       val adamGT = adamVC.genotypes.head
       assert(adamGT.getSplitFromMultiAllelic)
       assert(adamGT.getReferenceReadDepth === 4)
-      assert(adamGT.getIsPhased)
+      assert(adamGT.getPhased)
     }
 
     val adamGT1 = adamVCs(0).genotypes.head
     val adamGT2 = adamVCs(1).genotypes.head
-    assert(adamGT1.getAlleles.sameElements(List(GenotypeAllele.Alt, GenotypeAllele.OtherAlt)))
+    assert(adamGT1.getAlleles.sameElements(List(GenotypeAllele.ALT, GenotypeAllele.OTHER_ALT)))
     assert(adamGT1.getAlternateReadDepth === 2)
     assert(adamGT1.getGenotypeLikelihoods
       .map(f => f: scala.Float)
       .map(PhredUtils.logProbabilityToPhred)
       .sameElements(List(59, 0, 256)))
 
-    assert(adamGT2.getAlleles.sameElements(List(GenotypeAllele.OtherAlt, GenotypeAllele.Alt)))
+    assert(adamGT2.getAlleles.sameElements(List(GenotypeAllele.OTHER_ALT, GenotypeAllele.ALT)))
     assert(adamGT2.getAlternateReadDepth === 3)
     assert(adamGT2.getGenotypeLikelihoods
       .map(f => f: scala.Float)
@@ -269,7 +269,7 @@ class VariantContextConverterSuite extends ADAMFunSuite {
     assert(adamGTs.length === 1)
     val adamGT = adamGTs.head
     assert(adamGT.getVariant.getAlternateAllele === null)
-    assert(adamGT.getAlleles.sameElements(List(GenotypeAllele.Ref, GenotypeAllele.Ref)))
+    assert(adamGT.getAlleles.sameElements(List(GenotypeAllele.REF, GenotypeAllele.REF)))
     assert(adamGT.getMinReadDepth === 38)
     assert(adamGT.getGenotypeLikelihoods.isEmpty)
     assert(adamGT.getNonReferenceLikelihoods

--- a/adam-core/src/test/scala/org/bdgenomics/adam/converters/VariantContextConverterSuite.scala
+++ b/adam-core/src/test/scala/org/bdgenomics/adam/converters/VariantContextConverterSuite.scala
@@ -17,6 +17,7 @@
  */
 package org.bdgenomics.adam.converters
 
+import com.google.common.collect.ImmutableList
 import htsjdk.samtools.SAMFileReader
 import htsjdk.variant.variantcontext.{ Allele, GenotypeBuilder, GenotypeType, VariantContextBuilder }
 import java.io.File
@@ -32,25 +33,25 @@ class VariantContextConverterSuite extends ADAMFunSuite {
     SequenceDictionary(SAMFileReader.getSequenceDictionary(new File(path)))
   }
 
-  def gatkSNVBuilder: VariantContextBuilder = new VariantContextBuilder()
+  def htsjdkSNVBuilder: VariantContextBuilder = new VariantContextBuilder()
     .alleles(List(Allele.create("A", true), Allele.create("T")))
     .start(1L)
     .stop(1L)
     .chr("1")
 
-  def gatkMultiAllelicSNVBuilder: VariantContextBuilder = new VariantContextBuilder()
+  def htsjdkMultiAllelicSNVBuilder: VariantContextBuilder = new VariantContextBuilder()
     .alleles(List(Allele.create("A", true), Allele.create("T"), Allele.create("G")))
     .start(1L)
     .stop(1L)
     .chr("1")
 
-  def gatkRefSNV: VariantContextBuilder = new VariantContextBuilder()
+  def htsjdkRefSNV: VariantContextBuilder = new VariantContextBuilder()
     .alleles(List(Allele.create("A", true), Allele.create("<NON_REF>", false)))
     .start(1L)
     .stop(1L)
     .chr("1")
 
-  def gatkCNVBuilder: VariantContextBuilder = new VariantContextBuilder()
+  def htsjdkCNVBuilder: VariantContextBuilder = new VariantContextBuilder()
     .alleles(List(Allele.create("A", true), Allele.create("<CN0>", false)))
     .start(10L)
     .stop(20L)
@@ -62,10 +63,10 @@ class VariantContextConverterSuite extends ADAMFunSuite {
     .setReferenceAllele("A")
     .setAlternateAllele("T")
 
-  test("Convert GATK site-only SNV to ADAM") {
+  test("Convert htsjdk site-only SNV to ADAM") {
     val converter = new VariantContextConverter
 
-    val adamVCs = converter.convert(gatkSNVBuilder.make)
+    val adamVCs = converter.convert(htsjdkSNVBuilder.make)
     assert(adamVCs.length === 1)
     val adamVC = adamVCs.head
 
@@ -78,10 +79,10 @@ class VariantContextConverterSuite extends ADAMFunSuite {
     assert(variant.getStart === 0L)
   }
 
-  test("Convert GATK site-only SNV to ADAM with contig conversion") {
+  test("Convert htsjdk site-only SNV to ADAM with contig conversion") {
     val converter = new VariantContextConverter(Some(dictionary))
 
-    val adamVCs = converter.convert(gatkSNVBuilder.make)
+    val adamVCs = converter.convert(htsjdkSNVBuilder.make)
     assert(adamVCs.length === 1)
 
     val adamVC = adamVCs.head
@@ -89,10 +90,10 @@ class VariantContextConverterSuite extends ADAMFunSuite {
     assert(variant.getContigName === "NC_000001.10")
   }
 
-  test("Convert GATK site-only CNV to ADAM") {
+  test("Convert htsjdk site-only CNV to ADAM") {
     val converter = new VariantContextConverter
 
-    val adamVCs = converter.convert(gatkCNVBuilder.make)
+    val adamVCs = converter.convert(htsjdkCNVBuilder.make)
     assert(adamVCs.length === 1)
     val adamVC = adamVCs.head
 
@@ -107,8 +108,8 @@ class VariantContextConverterSuite extends ADAMFunSuite {
     assert(variant.getEnd === 20L)
   }
 
-  test("Convert GATK SNV w/ genotypes w/ phase information to ADAM") {
-    val vcb = gatkSNVBuilder
+  test("Convert htsjdk SNV w/ genotypes w/ phase information to ADAM") {
+    val vcb = htsjdkSNVBuilder
 
     val genotypeAttributes = Map[String, Object]("PQ" -> new Integer(50), "PS" -> new Integer(1))
     val vc = vcb.genotypes(GenotypeBuilder.create("NA12878", vcb.getAlleles(), genotypeAttributes)).make()
@@ -126,8 +127,8 @@ class VariantContextConverterSuite extends ADAMFunSuite {
     assert(adamGT.getPhaseQuality === 50)
   }
 
-  test("Convert GATK SNV with different filters to ADAM") {
-    val vcb = gatkSNVBuilder
+  test("Convert htsjdk SNV with different filters to ADAM") {
+    val vcb = htsjdkSNVBuilder
     vcb.genotypes(GenotypeBuilder.create("NA12878", vcb.getAlleles))
 
     val converter = new VariantContextConverter
@@ -152,32 +153,32 @@ class VariantContextConverterSuite extends ADAMFunSuite {
     }
   }
 
-  test("Convert ADAM site-only SNV to GATK") {
+  test("Convert ADAM site-only SNV to htsjdk") {
     val vc = ADAMVariantContext(adamSNVBuilder().build)
 
     val converter = new VariantContextConverter
 
-    val gatkVC = converter.convert(vc)
-    assert(gatkVC.getContig === "1")
-    assert(gatkVC.getStart === 1)
-    assert(gatkVC.getEnd === 1)
-    assert(gatkVC.getReference === Allele.create("A", true))
-    assert(gatkVC.getAlternateAlleles.sameElements(List(Allele.create("T"))))
-    assert(!gatkVC.hasLog10PError)
-    assert(!gatkVC.hasID)
-    assert(!gatkVC.filtersWereApplied)
+    val htsjdkVC = converter.convert(vc)
+    assert(htsjdkVC.getContig === "1")
+    assert(htsjdkVC.getStart === 1)
+    assert(htsjdkVC.getEnd === 1)
+    assert(htsjdkVC.getReference === Allele.create("A", true))
+    assert(htsjdkVC.getAlternateAlleles.sameElements(List(Allele.create("T"))))
+    assert(!htsjdkVC.hasLog10PError)
+    assert(!htsjdkVC.hasID)
+    assert(!htsjdkVC.filtersWereApplied)
   }
 
-  test("Convert ADAM site-only SNV to GATK with contig conversion") {
+  test("Convert ADAM site-only SNV to htsjdk with contig conversion") {
     val vc = ADAMVariantContext(adamSNVBuilder("NC_000001.10").build)
 
     val converter = new VariantContextConverter(dict = Some(dictionary))
 
-    val gatkVC = converter.convert(vc)
-    assert(gatkVC.getContig === "1")
+    val htsjdkVC = converter.convert(vc)
+    assert(htsjdkVC.getContig === "1")
   }
 
-  test("Convert ADAM SNV w/ genotypes to GATK") {
+  test("Convert ADAM SNV w/ genotypes to htsjdk") {
     val variant = adamSNVBuilder().build
     val genotype = Genotype.newBuilder
       .setVariant(variant)
@@ -192,18 +193,18 @@ class VariantContextConverterSuite extends ADAMFunSuite {
 
     val converter = new VariantContextConverter
 
-    val gatkVC = converter.convert(ADAMVariantContext(variant, Seq(genotype)))
-    assert(gatkVC.getNSamples === 1)
-    assert(gatkVC.hasGenotype("NA12878"))
-    val gatkGT = gatkVC.getGenotype("NA12878")
-    assert(gatkGT.getType === GenotypeType.HET)
-    assert(gatkVC.hasAttribute("FS"))
-    assert(gatkVC.hasAttribute("MQ"))
-    assert(gatkVC.hasAttribute("MQ0"))
+    val htsjdkVC = converter.convert(ADAMVariantContext(variant, Seq(genotype)))
+    assert(htsjdkVC.getNSamples === 1)
+    assert(htsjdkVC.hasGenotype("NA12878"))
+    val htsjdkGT = htsjdkVC.getGenotype("NA12878")
+    assert(htsjdkGT.getType === GenotypeType.HET)
+    assert(htsjdkVC.hasAttribute("FS"))
+    assert(htsjdkVC.hasAttribute("MQ"))
+    assert(htsjdkVC.hasAttribute("MQ0"))
   }
 
-  test("Convert GATK multi-allelic sites-only SNVs to ADAM") {
-    val vc = gatkMultiAllelicSNVBuilder.make
+  test("Convert htsjdk multi-allelic sites-only SNVs to ADAM") {
+    val vc = htsjdkMultiAllelicSNVBuilder.make
     val converter = new VariantContextConverter
 
     val adamVCs = converter.convert(vc)
@@ -216,11 +217,11 @@ class VariantContextConverterSuite extends ADAMFunSuite {
     }
   }
 
-  test("Convert GATK multi-allelic SNVs to ADAM") {
+  test("Convert htsjdk multi-allelic SNVs to ADAM") {
     val gb = new GenotypeBuilder("NA12878", List(Allele.create("T"), Allele.create("G")))
     gb.AD(Array(4, 2, 3)).PL(Array(59, 0, 181, 1, 66, 102))
 
-    val vcb = gatkMultiAllelicSNVBuilder
+    val vcb = htsjdkMultiAllelicSNVBuilder
     vcb.genotypes(gb.make)
 
     val converter = new VariantContextConverter
@@ -257,7 +258,7 @@ class VariantContextConverterSuite extends ADAMFunSuite {
     val gb = new GenotypeBuilder("NA12878", List(Allele.create("A", true), Allele.create("A", true)))
     gb.PL(Array(0, 1, 2)).DP(44).attribute("MIN_DP", 38)
 
-    val vcb = gatkRefSNV
+    val vcb = htsjdkRefSNV
     vcb.genotypes(gb.make)
 
     val converter = new VariantContextConverter
@@ -276,5 +277,83 @@ class VariantContextConverterSuite extends ADAMFunSuite {
       .map(f => f: scala.Float)
       .map(PhredUtils.logProbabilityToPhred)
       .sameElements(List(0, 1, 2)))
+  }
+
+  test("Convert htsjdk variant context with no IDs to ADAM") {
+    val vcb = htsjdkSNVBuilder
+    vcb.noID()
+
+    val converter = new VariantContextConverter
+
+    val adamVCs = converter.convert(vcb.make)
+    assert(adamVCs.length == 1)
+
+    val variant = adamVCs.head.variant
+    assert(variant.getNames.isEmpty)
+  }
+
+  test("Convert htsjdk variant context with one ID to ADAM") {
+    val vcb = htsjdkSNVBuilder
+    vcb.id("rs3131972")
+
+    val converter = new VariantContextConverter
+
+    val adamVCs = converter.convert(vcb.make)
+    assert(adamVCs.length == 1)
+
+    val variant = adamVCs.head.variant
+    assert(variant.getNames.length === 1)
+    assert(variant.getNames.get(0) === "rs3131972")
+  }
+
+  test("Convert htsjdk variant context with multiple IDs to ADAM") {
+    val vcb = htsjdkSNVBuilder
+    vcb.id("rs3131972;rs201888535")
+
+    val converter = new VariantContextConverter
+
+    val adamVCs = converter.convert(vcb.make)
+    assert(adamVCs.length == 1)
+
+    val variant = adamVCs.head.variant
+    assert(variant.getNames.length === 2)
+    assert(variant.getNames.get(0) === "rs3131972")
+    assert(variant.getNames.get(1) === "rs201888535")
+  }
+
+  test("Convert ADAM variant context with no names to htsjdk") {
+    val variant = adamSNVBuilder()
+      .build
+
+    assert(variant.getNames.isEmpty)
+
+    val converter = new VariantContextConverter
+
+    val htsjdkVC = converter.convert(ADAMVariantContext(variant))
+    assert(!htsjdkVC.hasID)
+  }
+
+  test("Convert ADAM variant context with one name to htsjdk") {
+    val variant = adamSNVBuilder()
+      .setNames(ImmutableList.of("rs3131972"))
+      .build
+
+    val converter = new VariantContextConverter
+
+    val htsjdkVC = converter.convert(ADAMVariantContext(variant))
+    assert(htsjdkVC.hasID)
+    assert(htsjdkVC.getID === "rs3131972")
+  }
+
+  test("Convert ADAM variant context with multiple names to htsjdk") {
+    val variant = adamSNVBuilder()
+      .setNames(ImmutableList.of("rs3131972", "rs201888535"))
+      .build
+
+    val converter = new VariantContextConverter
+
+    val htsjdkVC = converter.convert(ADAMVariantContext(variant))
+    assert(htsjdkVC.hasID)
+    assert(htsjdkVC.getID === "rs3131972;rs201888535")
   }
 }

--- a/adam-core/src/test/scala/org/bdgenomics/adam/rdd/features/FeatureRDDSuite.scala
+++ b/adam-core/src/test/scala/org/bdgenomics/adam/rdd/features/FeatureRDDSuite.scala
@@ -44,7 +44,7 @@ class FeatureRDDSuite extends ADAMFunSuite with TypeCheckedTripleEquals {
         a.getTarget === b.getTarget &&
         a.getGap === b.getGap &&
         a.getDerivesFrom === b.getDerivesFrom &&
-        a.getIsCircular === b.getIsCircular &&
+        a.getCircular === b.getCircular &&
         a.getAliases === b.getAliases &&
         a.getNotes === b.getNotes &&
         a.getParentIds === b.getParentIds &&

--- a/adam-core/src/test/scala/org/bdgenomics/adam/rdd/variation/VariantContextRDDSuite.scala
+++ b/adam-core/src/test/scala/org/bdgenomics/adam/rdd/variation/VariantContextRDDSuite.scala
@@ -46,7 +46,7 @@ class VariantContextRDDSuite extends ADAMFunSuite {
 
     val g0 = Genotype.newBuilder().setVariant(v0)
       .setSampleId("NA12878")
-      .setAlleles(List(GenotypeAllele.Ref, GenotypeAllele.Alt))
+      .setAlleles(List(GenotypeAllele.REF, GenotypeAllele.ALT))
       .build
 
     VariantContextRDD(sc.parallelize(List(

--- a/adam-core/src/test/scala/org/bdgenomics/adam/rdd/variation/VariantContextRDDSuite.scala
+++ b/adam-core/src/test/scala/org/bdgenomics/adam/rdd/variation/VariantContextRDDSuite.scala
@@ -17,6 +17,7 @@
  */
 package org.bdgenomics.adam.rdd.variation
 
+import com.google.common.collect.ImmutableList
 import com.google.common.io.Files
 import java.io.File
 import org.bdgenomics.adam.models.{
@@ -42,6 +43,7 @@ class VariantContextRDDSuite extends ADAMFunSuite {
       .setStart(17409572)
       .setReferenceAllele("T")
       .setAlternateAllele("C")
+      .setNames(ImmutableList.of("rs3131972", "rs201888535"))
       .build
 
     val g0 = Genotype.newBuilder().setVariant(v0)
@@ -60,8 +62,19 @@ class VariantContextRDDSuite extends ADAMFunSuite {
     val path = new File(tempDir, "test.vcf")
     variants.saveAsVcf(TestSaveArgs(path.getAbsolutePath), false)
     assert(path.exists)
+
     val vcRdd = sc.loadVcf("%s/test.vcf/part-r-00000".format(tempDir))
     assert(vcRdd.rdd.count === 1)
+
+    val variant = vcRdd.rdd.first.variant
+    assert(variant.getContigName === "chr11")
+    assert(variant.getStart === 17409572)
+    assert(variant.getReferenceAllele === "T")
+    assert(variant.getAlternateAllele === "C")
+    assert(variant.getNames.length === 2)
+    assert(variant.getNames.get(0) === "rs3131972")
+    assert(variant.getNames.get(1) === "rs201888535")
+
     assert(vcRdd.sequences.records.size === 1)
     assert(vcRdd.sequences.records(0).name === "chr11")
   }

--- a/adam-core/src/test/scala/org/bdgenomics/adam/rich/RichGenotypeSuite.scala
+++ b/adam-core/src/test/scala/org/bdgenomics/adam/rich/RichGenotypeSuite.scala
@@ -32,7 +32,7 @@ class RichGenotypeSuite extends FunSuite {
   test("different ploidy") {
     val gb = Genotype.newBuilder.setVariant(v0).setSampleId("NA12878")
     for (ploidy <- 0 until 3) {
-      val g = gb.setAlleles(List.fill(ploidy)(GenotypeAllele.Ref)).build
+      val g = gb.setAlleles(List.fill(ploidy)(GenotypeAllele.REF)).build
       assert(g.ploidy === ploidy)
     }
   }
@@ -40,23 +40,22 @@ class RichGenotypeSuite extends FunSuite {
   test("all types for diploid genotype") {
     val gb = Genotype.newBuilder.setVariant(v0).setSampleId("NA12878")
 
-    val hom_ref = gb.setAlleles(List(GenotypeAllele.Ref, GenotypeAllele.Ref)).build
+    val hom_ref = gb.setAlleles(List(GenotypeAllele.REF, GenotypeAllele.REF)).build
     assert(hom_ref.getType === GenotypeType.HOM_REF)
 
-    val het1 = gb.setAlleles(List(GenotypeAllele.Ref, GenotypeAllele.Alt)).build
+    val het1 = gb.setAlleles(List(GenotypeAllele.REF, GenotypeAllele.ALT)).build
     assert(het1.getType === GenotypeType.HET)
-    val het2 = gb.setAlleles(List(GenotypeAllele.Alt, GenotypeAllele.Ref)).build
+    val het2 = gb.setAlleles(List(GenotypeAllele.ALT, GenotypeAllele.REF)).build
     assert(het2.getType === GenotypeType.HET)
 
-    val hom_alt = gb.setAlleles(List(GenotypeAllele.Alt, GenotypeAllele.Alt)).build
+    val hom_alt = gb.setAlleles(List(GenotypeAllele.ALT, GenotypeAllele.ALT)).build
     assert(hom_alt.getType === GenotypeType.HOM_ALT)
 
     for (a <- GenotypeAllele.values) {
-      val no_call1 = gb.setAlleles(List(GenotypeAllele.NoCall, a)).build
+      val no_call1 = gb.setAlleles(List(GenotypeAllele.NO_CALL, a)).build
       assert(no_call1.getType === GenotypeType.NO_CALL)
-      val no_call2 = gb.setAlleles(List(a, GenotypeAllele.NoCall)).build
+      val no_call2 = gb.setAlleles(List(a, GenotypeAllele.NO_CALL)).build
       assert(no_call2.getType === GenotypeType.NO_CALL)
     }
   }
-
 }

--- a/pom.xml
+++ b/pom.xml
@@ -27,7 +27,7 @@
     <hadoop.version>2.6.0</hadoop.version>
     <hadoop-bam.version>7.6.0</hadoop-bam.version>
     <slf4j.version>1.7.21</slf4j.version>
-    <bdg-formats.version>0.10.0-SNAPSHOT</bdg-formats.version>
+    <bdg-formats.version>0.9.1-SNAPSHOT</bdg-formats.version>
     <bdg-utils.version>0.2.7</bdg-utils.version>
     <htsjdk.version>2.5.0</htsjdk.version>
   </properties>

--- a/pom.xml
+++ b/pom.xml
@@ -27,7 +27,7 @@
     <hadoop.version>2.6.0</hadoop.version>
     <hadoop-bam.version>7.6.0</hadoop-bam.version>
     <slf4j.version>1.7.21</slf4j.version>
-    <bdg-formats.version>0.9.0</bdg-formats.version>
+    <bdg-formats.version>0.10.0-SNAPSHOT</bdg-formats.version>
     <bdg-utils.version>0.2.7</bdg-utils.version>
     <htsjdk.version>2.5.0</htsjdk.version>
   </properties>


### PR DESCRIPTION
Still left to do (in a later pull request) is to populate the `somatic` field from VCF INFO attributes.