### PR TITLE
Make AlignmentRecordConverter public so that it can be used from other projects

### DIFF
--- a/adam-core/src/main/scala/org/bdgenomics/adam/converters/AlignmentRecordConverter.scala
+++ b/adam-core/src/main/scala/org/bdgenomics/adam/converters/AlignmentRecordConverter.scala
@@ -27,7 +27,7 @@ import scala.collection.JavaConversions._
 /**
  * This class contains methods to convert AlignmentRecords to other formats.
  */
-private[adam] class AlignmentRecordConverter extends Serializable {
+class AlignmentRecordConverter extends Serializable {
 
   /**
    * Converts a single record to FASTQ. FASTQ format is:


### PR DESCRIPTION
AlignmentRecordConverter used to be a public class, but was made private in https://github.com/bigdatagenomics/adam/commit/9764b2c. Unfortunately, this causes a problem for GATK, which uses AlignmentRecordConverter to read ADAM formatted files. This PR reinstates public visibility. There are other converters in the same package that are private that could be changed back, but I haven't done that in this PR.