### PR TITLE
Update Hadoop-BAM to version 7.7.0

### DIFF
--- a/adam-core/src/test/scala/org/bdgenomics/adam/rdd/read/AlignmentRecordRDDSuite.scala
+++ b/adam-core/src/test/scala/org/bdgenomics/adam/rdd/read/AlignmentRecordRDDSuite.scala
@@ -315,7 +315,7 @@ class AlignmentRecordRDDSuite extends ADAMFunSuite {
     val rRdd = sc.loadAlignments(inputPath)
     rRdd.rdd.cache()
     rRdd.saveAsSam("%s/%s".format(tempFile.toAbsolutePath.toString, filename),
-      asSam = true,
+      asSam = asSam,
       asSingleFile = true)
     val rdd2 = sc.loadAlignments("%s/%s".format(tempFile.toAbsolutePath.toString, filename))
     rdd2.rdd.cache()

--- a/pom.xml
+++ b/pom.xml
@@ -25,7 +25,7 @@
     <parquet.version>1.8.1</parquet.version>
     <!-- Edit the following line to configure the Hadoop (HDFS) version. -->
     <hadoop.version>2.6.0</hadoop.version>
-    <hadoop-bam.version>7.6.0</hadoop-bam.version>
+    <hadoop-bam.version>7.7.0</hadoop-bam.version>
     <slf4j.version>1.7.21</slf4j.version>
     <bdg-formats.version>0.9.0</bdg-formats.version>
     <bdg-utils.version>0.2.8</bdg-utils.version>


### PR DESCRIPTION
Fixes #1158 

Currently fails one unit test
```bash
$ mvn test
...
- write single bam file back *** FAILED ***
  htsjdk.samtools.SAMFormatException: Does not seem like a BAM file
  at org.seqdoop.hadoop_bam.BAMSplitGuesser.<init>(BAMSplitGuesser.java:88)
  at org.seqdoop.hadoop_bam.BAMInputFormat.addProbabilisticSplits(BAMInputFormat.java:234)
  at org.seqdoop.hadoop_bam.BAMInputFormat.getSplits(BAMInputFormat.java:161)
  at org.seqdoop.hadoop_bam.AnySAMInputFormat.getSplits(AnySAMInputFormat.java:252)
  at org.apache.spark.rdd.NewHadoopRDD.getPartitions(NewHadoopRDD.scala:120)
```