### PR TITLE
Add scoverage aggregator and fail on low coverage.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -652,6 +652,7 @@
             <version>${scoverage.plugin.version}</version>
             <configuration>
               <scalaVersion>2.10.4</scalaVersion>
+              <aggregate>true</aggregate>
             </configuration>
           </plugin>
         </plugins>


### PR DESCRIPTION
Small Scoverage update --> sets aggregate to true, which produces a report under `${ADAM_HOME}/target` at the end of the build containing the aggregated coverage across all submodules.