### PR TITLE
[ADAM-1212] Add empty assembly object, allows Maven build to create sources and javadoc artifacts

### DIFF
--- a/adam-assembly/src/main/scala/org/bdgenomics/adam/assembly/Assembly.scala
+++ b/adam-assembly/src/main/scala/org/bdgenomics/adam/assembly/Assembly.scala
@@ -1,0 +1,25 @@
+/**
+ * Licensed to Big Data Genomics (BDG) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The BDG licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.bdgenomics.adam.assembly
+
+/**
+ * Empty assembly object, allows Maven build to create sources and javadoc artifacts.
+ */
+object Assembly {
+  // empty
+}

--- a/bin/adam-shell
+++ b/bin/adam-shell
@@ -36,14 +36,14 @@ else
   ASSEMBLY_DIR="$SCRIPT_DIR/adam-assembly/target"
 fi
 
-num_jars="$(ls -1 "$ASSEMBLY_DIR" | grep "^adam_[0-9A-Za-z\.-]*\.jar$" | grep -v javadoc | wc -l)"
+num_jars="$(ls -1 "$ASSEMBLY_DIR" | grep "^adam_[0-9A-Za-z\.-]*\.jar$" | grep -v javadoc | grep -v sources | wc -l)"
 if [ "$num_jars" -eq "0" ]; then
   echo "Failed to find ADAM assembly in $ASSEMBLY_DIR." 1>&2
   echo "You need to build ADAM before running this program." 1>&2
   exit 1
 fi
 
-ASSEMBLY_JARS="$(ls -1 "$ASSEMBLY_DIR" | grep "^adam_[0-9A-Za-z\.-]*\.jar$" | grep -v javadoc || true)"
+ASSEMBLY_JARS="$(ls -1 "$ASSEMBLY_DIR" | grep "^adam_[0-9A-Za-z\.-]*\.jar$" | grep -v javadoc | grep -v sources || true)"
 if [ "$num_jars" -gt "1" ]; then
   echo "Found multiple ADAM cli assembly jars in $ASSEMBLY_DIR:" 1>&2
   echo "$ASSEMBLY_JARS" 1>&2

--- a/bin/adam-submit
+++ b/bin/adam-submit
@@ -60,14 +60,14 @@ else
   ASSEMBLY_DIR="$SCRIPT_DIR/adam-assembly/target"
 fi
 
-num_jars="$(ls -1 "$ASSEMBLY_DIR" | grep "^adam_[0-9A-Za-z\.-]*\.jar$" | grep -v javadoc | wc -l)"
+num_jars="$(ls -1 "$ASSEMBLY_DIR" | grep "^adam_[0-9A-Za-z\.-]*\.jar$" | grep -v javadoc | grep -v sources | wc -l)"
 if [ "$num_jars" -eq "0" ]; then
   echo "Failed to find ADAM cli assembly in $ASSEMBLY_DIR." 1>&2
   echo "You need to build ADAM before running this program." 1>&2
   exit 1
 fi
 
-ASSEMBLY_JARS="$(ls -1 "$ASSEMBLY_DIR" | grep "^adam_[0-9A-Za-z\.-]*\.jar$" | grep -v javadoc || true)"
+ASSEMBLY_JARS="$(ls -1 "$ASSEMBLY_DIR" | grep "^adam_[0-9A-Za-z\.-]*\.jar$" | grep -v javadoc | grep -v sources || true)"
 if [ "$num_jars" -gt "1" ]; then
   echo "Found multiple ADAM cli assembly jars in $ASSEMBLY_DIR:" 1>&2
   echo "$ASSEMBLY_JARS" 1>&2


### PR DESCRIPTION
Progress towards #1212 
