### PR TITLE
replacing uses of deprecated class SAMFileReader

### DIFF
--- a/adam-cli/src/main/scala/org/bdgenomics/adam/cli/DictionaryCommand.scala
+++ b/adam-cli/src/main/scala/org/bdgenomics/adam/cli/DictionaryCommand.scala
@@ -17,10 +17,11 @@
  */
 package org.bdgenomics.adam.cli
 
-import java.io.{ FileOutputStream, File }
+import java.io.{ File, FileOutputStream }
+
+import htsjdk.variant.utils.SAMSequenceDictionaryExtractor
 import org.apache.commons.io.IOUtils
 import org.bdgenomics.adam.models.SequenceDictionary
-import htsjdk.samtools.SAMFileReader
 
 trait DictionaryCommand {
   private def getDictionaryFile(name: String): Option[File] = {
@@ -33,7 +34,7 @@ trait DictionaryCommand {
     Some(file)
   }
 
-  private def getDictionary(file: File) = Some(SequenceDictionary(SAMFileReader.getSequenceDictionary(file)))
+  private def getDictionary(file: File) = Some(SequenceDictionary(SAMSequenceDictionaryExtractor.extractDictionary(file)))
 
   def loadSequenceDictionary(file: File): Option[SequenceDictionary] = {
     if (file != null) {

--- a/adam-core/src/main/scala/org/bdgenomics/adam/models/RecordGroupDictionary.scala
+++ b/adam-core/src/main/scala/org/bdgenomics/adam/models/RecordGroupDictionary.scala
@@ -17,9 +17,11 @@
  */
 package org.bdgenomics.adam.models
 
-import htsjdk.samtools.{ SAMFileHeader, SAMFileReader, SAMReadGroupRecord }
 import java.util.Date
+
+import htsjdk.samtools.{ SAMFileHeader, SAMReadGroupRecord, SamReader }
 import org.bdgenomics.formats.avro.{ RecordGroupMetadata, Sample }
+
 import scala.collection.JavaConversions._
 
 object RecordGroupDictionary {
@@ -42,7 +44,7 @@ object RecordGroupDictionary {
    * @param samReader SAM file header with attached read groups.
    * @return Returns a new record group dictionary with the read groups attached to the file header.
    */
-  def fromSAMReader(samReader: SAMFileReader): RecordGroupDictionary = {
+  def fromSAMReader(samReader: SamReader): RecordGroupDictionary = {
     fromSAMHeader(samReader.getFileHeader)
   }
 

--- a/adam-core/src/main/scala/org/bdgenomics/adam/rdd/read/AnySAMOutFormatter.scala
+++ b/adam-core/src/main/scala/org/bdgenomics/adam/rdd/read/AnySAMOutFormatter.scala
@@ -17,19 +17,13 @@
  */
 package org.bdgenomics.adam.rdd.read
 
-import htsjdk.samtools.{
-  SAMFileReader,
-  SAMRecord,
-  SAMRecordIterator
-}
 import java.io.InputStream
+
+import htsjdk.samtools._
 import org.bdgenomics.adam.converters.SAMRecordConverter
-import org.bdgenomics.adam.models.{
-  RecordGroupDictionary,
-  SequenceDictionary
-}
 import org.bdgenomics.adam.rdd.OutFormatter
 import org.bdgenomics.formats.avro.AlignmentRecord
+
 import scala.annotation.tailrec
 import scala.collection.mutable.ListBuffer
 
@@ -47,7 +41,7 @@ class AnySAMOutFormatter extends OutFormatter[AlignmentRecord] {
     val converter = new SAMRecordConverter
 
     // make reader
-    val reader = new SAMFileReader(is)
+    val reader = SamReaderFactory.makeDefault().open(SamInputResource.of(is))
 
     // make iterator from said reader
     val iter = reader.iterator()

--- a/adam-core/src/test/scala/org/bdgenomics/adam/converters/VariantContextConverterSuite.scala
+++ b/adam-core/src/test/scala/org/bdgenomics/adam/converters/VariantContextConverterSuite.scala
@@ -20,16 +20,19 @@ package org.bdgenomics.adam.converters
 import htsjdk.samtools.SAMFileReader
 import htsjdk.variant.variantcontext.{ Allele, GenotypeBuilder, GenotypeType, VariantContextBuilder }
 import java.io.File
-import org.bdgenomics.adam.models.{ VariantContext => ADAMVariantContext, SequenceDictionary }
+
+import htsjdk.variant.utils.SAMSequenceDictionaryExtractor
+import org.bdgenomics.adam.models.{ SequenceDictionary, VariantContext => ADAMVariantContext }
 import org.bdgenomics.adam.util.{ ADAMFunSuite, PhredUtils }
 import org.bdgenomics.formats.avro._
 import org.scalatest.FunSuite
+
 import scala.collection.JavaConversions._
 
 class VariantContextConverterSuite extends ADAMFunSuite {
   val dictionary = {
     val path = testFile("dict_with_accession.dict")
-    SequenceDictionary(SAMFileReader.getSequenceDictionary(new File(path)))
+    SequenceDictionary(SAMSequenceDictionaryExtractor.extractDictionary(new File(path)))
   }
 
   def gatkSNVBuilder: VariantContextBuilder = new VariantContextBuilder()

--- a/adam-core/src/test/scala/org/bdgenomics/adam/models/SequenceDictionarySuite.scala
+++ b/adam-core/src/test/scala/org/bdgenomics/adam/models/SequenceDictionarySuite.scala
@@ -17,10 +17,13 @@
  */
 package org.bdgenomics.adam.models
 
-import htsjdk.samtools.{ SAMFileReader, SAMSequenceRecord, SAMSequenceDictionary }
+import htsjdk.samtools.{ SAMFileReader, SAMSequenceDictionary, SAMSequenceRecord }
 import htsjdk.variant.vcf.VCFFileReader
 import java.io.File
+
+import htsjdk.variant.utils.SAMSequenceDictionaryExtractor
 import org.bdgenomics.adam.util.ADAMFunSuite
+
 import scala.collection.JavaConversions._
 
 class SequenceDictionarySuite extends ADAMFunSuite {
@@ -41,7 +44,7 @@ class SequenceDictionarySuite extends ADAMFunSuite {
 
   test("Convert from SAM sequence dictionary file (with extra fields)") {
     val path = testFile("dict_with_accession.dict")
-    val ssd = SAMFileReader.getSequenceDictionary(new File(path))
+    val ssd = SAMSequenceDictionaryExtractor.extractDictionary(new File(path))
 
     val chr1 = ssd.getSequence("1") // Validate that extra fields are parsed
     assert(chr1 != null)
@@ -55,7 +58,7 @@ class SequenceDictionarySuite extends ADAMFunSuite {
 
   test("merge into existing dictionary") {
     val path = testFile("dict_with_accession.dict")
-    val ssd = SAMFileReader.getSequenceDictionary(new File(path))
+    val ssd = SAMSequenceDictionaryExtractor.extractDictionary(new File(path))
 
     val asd = SequenceDictionary(ssd)
     assert(asd.containsRefName("1"))
@@ -68,7 +71,7 @@ class SequenceDictionarySuite extends ADAMFunSuite {
 
   test("Convert from SAM sequence dictionary and back") {
     val path = testFile("dict_with_accession.dict")
-    val ssd = SAMFileReader.getSequenceDictionary(new File(path))
+    val ssd = SAMSequenceDictionaryExtractor.extractDictionary(new File(path))
     val asd = SequenceDictionary(ssd)
     ssd.assertSameDictionary(SequenceDictionary.toSAMSequenceDictionary(asd))
   }


### PR DESCRIPTION
Replacing all references to `SAMFileReader`, this is a long deprecated htsjdk class that's been replaced by `SamReader`.  