### PR TITLE
HBase backend for Genotypes

### DIFF
--- a/adam-cli/src/main/scala/org/bdgenomics/adam/cli/ADAM2Vcf.scala
+++ b/adam-cli/src/main/scala/org/bdgenomics/adam/cli/ADAM2Vcf.scala
@@ -23,6 +23,7 @@ import org.apache.spark.SparkContext
 import org.apache.hadoop.mapreduce.Job
 import org.bdgenomics.adam.models.SequenceDictionary
 import org.bdgenomics.adam.rdd.ADAMContext._
+import org.bdgenomics.adam.rdd.variation.GenotypeRDD
 import org.bdgenomics.formats.avro.Genotype
 import org.bdgenomics.utils.cli._
 import org.bdgenomics.utils.misc.Logging

--- a/adam-cli/src/main/scala/org/bdgenomics/adam/cli/ADAMMain.scala
+++ b/adam-cli/src/main/scala/org/bdgenomics/adam/cli/ADAMMain.scala
@@ -53,7 +53,8 @@ object ADAMMain {
           WigFix2Bed,
           Fragments2Reads,
           Reads2Fragments,
-          Reads2Coverage
+          Reads2Coverage,
+          Vcf2HBase
         )
       ),
       CommandGroup(

--- a/adam-cli/src/main/scala/org/bdgenomics/adam/cli/Vcf2HBase.scala
+++ b/adam-cli/src/main/scala/org/bdgenomics/adam/cli/Vcf2HBase.scala
@@ -1,0 +1,82 @@
+/**
+ * Licensed to Big Data Genomics (BDG) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The BDG licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.bdgenomics.adam.cli
+
+import org.apache.spark.SparkContext
+
+import org.bdgenomics.adam.hbase.HBaseFunctions
+import org.bdgenomics.adam.instrumentation.Timers._
+import org.bdgenomics.adam.models.{ RecordGroupDictionary, SequenceDictionary, SnpTable }
+import org.bdgenomics.adam.projections.{ AlignmentRecordField, Filter }
+import org.bdgenomics.adam.rdd.ADAMContext._
+import org.bdgenomics.adam.rdd.ADAMSaveAnyArgs
+import org.bdgenomics.adam.rdd.read.{ AlignedReadRDD, AlignmentRecordRDD, MDTagging }
+import org.bdgenomics.adam.rich.RichVariant
+import org.bdgenomics.formats.avro.AlignmentRecord
+import org.bdgenomics.utils.cli._
+import org.bdgenomics.utils.misc.Logging
+import org.kohsuke.args4j.{ Argument, Option => Args4jOption }
+
+object Vcf2HBase extends BDGCommandCompanion {
+  val commandName = "Vcf2HBase"
+  val commandDescription = "Write a VCF file to HBase"
+
+  def apply(cmdLine: Array[String]) = {
+    new Vcf2HBase(Args4j[Vcf2HBaseArgs](cmdLine))
+  }
+}
+
+class Vcf2HBaseArgs extends Args4jBase {
+
+  @Argument(required = true, metaVar = "VCF", usage = "The VCF file to convert", index = 0)
+  var vcfPath: String = _
+
+  @Args4jOption(required = true, name = "-hbase_table", usage = "HBase table name in which to load VCF file")
+  var hbaseTable: String = null
+
+  @Args4jOption(required = true, name = "-seq_dict_id", usage = "User defined name to apply to the sequence dictionary create from this VCF, or name of existing sequence dictionary to be used")
+  var seqDictId: String = null
+
+  @Args4jOption(required = false, name = "-use_existing_seqdict", usage = "Use an existing sequence dictionary, don't write a new one")
+  var useExistingSeqDict: Boolean = false
+
+  @Args4jOption(required = false, name = "-repartition_num", usage = "Reparition into N partitions prior to writing to HBase")
+  var repartitionNum: Int = 0
+
+  @Args4jOption(required = true, name = "-staging_folder", usage = "location for temporary files during bulk load")
+  var stagingFolder: String = null
+
+}
+
+class Vcf2HBase(protected val args: Vcf2HBaseArgs) extends BDGSparkCommand[Vcf2HBaseArgs] with Logging {
+  val companion = Transform
+
+  def run(sc: SparkContext) {
+
+    val vcRdd = sc.loadVcf(args.vcfPath)
+
+    HBaseFunctions.saveVariantContextRDDToHBaseBulk(sc,
+      vcRdd,
+      args.hbaseTable,
+      sequenceDictionaryId = args.seqDictId,
+      numPartitions = args.repartitionNum,
+      stagingFolder = args.stagingFolder)
+
+  }
+
+}

--- a/adam-core/pom.xml
+++ b/adam-core/pom.xml
@@ -137,6 +137,10 @@
       <artifactId>spark-core_${scala.version.prefix}</artifactId>
     </dependency>
     <dependency>
+      <groupId>org.apache.spark</groupId>
+      <artifactId>spark-streaming_2.10</artifactId>
+    </dependency>
+    <dependency>
       <groupId>it.unimi.dsi</groupId>
       <artifactId>fastutil</artifactId>
     </dependency>
@@ -185,5 +189,37 @@
       <groupId>com.google.guava</groupId>
       <artifactId>guava</artifactId>
     </dependency>
+
+    <dependency>
+      <groupId>org.apache.hbase</groupId>
+      <artifactId>hbase-hadoop2-compat</artifactId>
+
+    </dependency>
+
+    <dependency>
+      <groupId>org.apache.hbase</groupId>
+      <artifactId>hbase-server</artifactId>
+
+    </dependency>
+
+    <dependency>
+      <groupId>org.apache.hbase</groupId>
+      <artifactId>hbase-it</artifactId>
+
+    </dependency>
+
+    <dependency>
+      <groupId>org.apache.hbase</groupId>
+      <artifactId>hbase-client</artifactId>
+
+    </dependency>
+
+    <dependency>
+      <groupId>org.apache.hbase</groupId>
+      <artifactId>hbase-spark</artifactId>
+
+    </dependency>
+
+
   </dependencies>
 </project>

--- a/adam-core/src/main/scala/org/bdgenomics/adam/hbase/HBaseFunctions.scala
+++ b/adam-core/src/main/scala/org/bdgenomics/adam/hbase/HBaseFunctions.scala
@@ -1,0 +1,525 @@
+/**
+ * Licensed to Big Data Genomics (BDG) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The BDG licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.bdgenomics.adam.hbase
+
+import java.util
+import org.apache.hadoop.hbase.io.ImmutableBytesWritable
+import org.apache.hadoop.hbase.io.encoding.DataBlockEncoding
+import org.apache.spark.SparkContext
+import org.apache.spark.rdd.RDD
+import org.apache.hadoop.hbase.client._
+import org.apache.hadoop.hbase._
+import org.apache.hadoop.hbase.spark._
+import org.bdgenomics.adam.rdd.variation.{ GenotypeRDD, VariantContextRDD }
+import org.bdgenomics.adam.rich.RichVariant
+import org.bdgenomics.formats.avro._
+import org.apache.hadoop.hbase.spark.HBaseRDDFunctions._
+import org.apache.hadoop.hbase.util.Bytes
+import org.apache.hadoop.hbase.{ HBaseConfiguration, TableName }
+import org.apache.avro.specific.SpecificDatumWriter
+import org.apache.avro.io._
+import java.io.ByteArrayOutputStream
+import org.apache.hadoop.hbase.io.compress.Compression.Algorithm
+import org.apache.avro.specific.SpecificDatumReader
+import org.apache.hadoop.hbase.mapreduce.LoadIncrementalHFiles
+import org.apache.hadoop.fs.{ FSDataInputStream, FileSystem, Path }
+import org.bdgenomics.adam.models.{ ReferenceRegion, ReferencePosition, SequenceDictionary, VariantContext }
+import scala.io.Source
+
+import scala.collection.mutable.ListBuffer
+import sys.process._
+
+import scala.collection.JavaConverters._
+
+/**
+ * Created by jp on 7/23/16.
+ */
+
+object HBaseFunctions {
+
+  def saveSequenceDictionaryToHBase(hbaseTableName: String,
+                                    sequences: SequenceDictionary,
+                                    sequenceDictionaryId: String): Unit = {
+
+    val conf = HBaseConfiguration.create()
+    val connection = ConnectionFactory.createConnection(conf)
+    val table: Table = connection.getTable(TableName.valueOf(hbaseTableName))
+    val contigs = sequences.toAvro
+
+    val baos: java.io.ByteArrayOutputStream = new ByteArrayOutputStream()
+    val encoder = EncoderFactory.get().binaryEncoder(baos, null)
+
+    contigs.foreach((x) => {
+      val contigDatumWriter: DatumWriter[Contig] =
+        new SpecificDatumWriter[Contig](scala.reflect.classTag[Contig].runtimeClass.asInstanceOf[Class[Contig]])
+      contigDatumWriter.write(x, encoder)
+    })
+
+    encoder.flush()
+    baos.flush()
+
+    val put: Put = new Put(Bytes.toBytes(sequenceDictionaryId))
+    put.addColumn(Bytes.toBytes("meta"), Bytes.toBytes("contigdata"), baos.toByteArray)
+    table.put(put)
+  }
+
+  def loadSequenceDictionaryFromHBase(hbaseTableName: String,
+                                      sequenceDictionaryId: String): SequenceDictionary = {
+
+    val conf = HBaseConfiguration.create()
+    val connection = ConnectionFactory.createConnection(conf)
+    val table = connection.getTable(TableName.valueOf(hbaseTableName))
+
+    val myGet = new Get(Bytes.toBytes(sequenceDictionaryId))
+    val result = table.get(myGet)
+    val dataBytes = result.getValue(Bytes.toBytes("meta"), Bytes.toBytes("contigdata"))
+
+    val contigDatumReader: DatumReader[Contig] =
+      new SpecificDatumReader[Contig](scala.reflect.classTag[Contig]
+        .runtimeClass
+        .asInstanceOf[Class[Contig]])
+
+    val decoder = DecoderFactory.get().binaryDecoder(dataBytes, null)
+    var resultList = new ListBuffer[Contig]
+    while (!decoder.isEnd) {
+      resultList += contigDatumReader.read(null, decoder)
+    }
+
+    SequenceDictionary.fromAvro(resultList)
+
+  }
+
+  def saveSampleMetadataToHBase(hbaseTableName: String,
+                                samples: Seq[Sample]): Unit = {
+
+    val conf = HBaseConfiguration.create()
+    val connection = ConnectionFactory.createConnection(conf)
+    val table = connection.getTable(TableName.valueOf(hbaseTableName))
+
+    samples.foreach((x) => {
+      val baos: java.io.ByteArrayOutputStream = new ByteArrayOutputStream()
+      val encoder = EncoderFactory.get().binaryEncoder(baos, null)
+
+      val sampleDatumWriter: DatumWriter[Sample] =
+        new SpecificDatumWriter[Sample](scala.reflect.classTag[Sample].runtimeClass.asInstanceOf[Class[Sample]])
+      sampleDatumWriter.write(x, encoder)
+      encoder.flush()
+      baos.flush()
+
+      val curr_sampleid = x.getSampleId
+
+      val put = new Put(Bytes.toBytes(curr_sampleid))
+      put.addColumn(Bytes.toBytes("meta"), Bytes.toBytes("sampledata"), baos.toByteArray)
+      table.put(put)
+
+    })
+  }
+
+  def loadSampleMetadataFromHBase(hbaseTableName: String,
+                                  sampleIds: List[String]): Seq[Sample] = {
+
+    val conf = HBaseConfiguration.create()
+    val connection = ConnectionFactory.createConnection(conf)
+    val table = connection.getTable(TableName.valueOf(hbaseTableName))
+
+    var resultList = new ListBuffer[Sample]
+
+    sampleIds.foreach((sampleId) => {
+      val myGet = new Get(Bytes.toBytes(sampleId))
+      val result = table.get(myGet)
+      val dataBytes = result.getValue(Bytes.toBytes("meta"), Bytes.toBytes("sampledata"))
+
+      val sampleDatumReader: DatumReader[Sample] =
+        new SpecificDatumReader[Sample](scala.reflect.classTag[Sample]
+          .runtimeClass
+          .asInstanceOf[Class[Sample]])
+
+      val decoder = DecoderFactory.get().binaryDecoder(dataBytes, null)
+
+      while (!decoder.isEnd) {
+        resultList += sampleDatumReader.read(null, decoder)
+      }
+
+    })
+
+    resultList
+
+  }
+
+  def loadRDDofGenotypeFromHBase(sc: SparkContext,
+                                 hbaseTableName: String,
+                                 sampleIds: List[String],
+                                 queryRegion: ReferenceRegion = null,
+                                 numPartitions: Int = 0): RDD[Genotype] = {
+
+    val scan = new Scan()
+    scan.setCaching(100)
+    scan.setMaxVersions(1)
+
+    if (queryRegion != null) {
+      val start = queryRegion.referenceName + "_" + String.format("%10s", queryRegion.start.toString).replace(' ', '0')
+      val stop = queryRegion.referenceName + "_" + String.format("%10s", queryRegion.end.toString).replace(' ', '0')
+      scan.setStartRow(Bytes.toBytes(start))
+      scan.setStopRow(Bytes.toBytes(stop))
+    }
+
+    val conf = HBaseConfiguration.create()
+    val hbaseContext = new HBaseContext(sc, conf)
+
+    sampleIds.foreach(sampleId => {
+      scan.addColumn(Bytes.toBytes("g"), Bytes.toBytes(sampleId))
+    })
+
+    val resultHBaseRDD = hbaseContext.hbaseRDD(TableName.valueOf(hbaseTableName), scan)
+
+    val resultHBaseRDDrepar = if (numPartitions > 0) resultHBaseRDD.repartition(numPartitions)
+    else resultHBaseRDD
+
+    val result: RDD[Genotype] = resultHBaseRDDrepar.mapPartitions((iterator) => {
+
+      val genotypeDatumReader: DatumReader[Genotype] = new SpecificDatumReader[Genotype](scala.reflect.classTag[Genotype]
+        .runtimeClass
+        .asInstanceOf[Class[Genotype]])
+
+      iterator.flatMap((curr) => {
+        var resultList = new ListBuffer[Genotype]
+        sampleIds.foreach((sample) => {
+          val myVal: util.List[Cell] = curr._2.getColumnCells(Bytes.toBytes("g"), Bytes.toBytes(sample))
+          val decoder = DecoderFactory.get().binaryDecoder(CellUtil.cloneValue(myVal.get(0)), null)
+          while (!decoder.isEnd) {
+            resultList += genotypeDatumReader.read(null, decoder)
+          }
+        })
+        resultList
+      })
+
+    })
+    result
+  }
+
+  def loadRDDofVariantContextFromHBase(sc: SparkContext,
+                                       hbaseTableName: String,
+                                       inputsampleIds: List[String] = null,
+                                       sampleListFile: String = null,
+                                       queryRegion: ReferenceRegion = null,
+                                       numPartitions: Int = 0): RDD[VariantContext] = {
+
+    val scan = new Scan()
+    scan.setCaching(100)
+    scan.setMaxVersions(1)
+
+    if (queryRegion != null) {
+      val start = queryRegion.referenceName + "_" + String.format("%10s", queryRegion.start.toString).replace(' ', '0')
+      val stop = queryRegion.referenceName + "_" + String.format("%10s", queryRegion.end.toString).replace(' ', '0')
+      scan.setStartRow(Bytes.toBytes(start))
+      scan.setStopRow(Bytes.toBytes(stop))
+    }
+
+    val conf = HBaseConfiguration.create()
+    val hbaseContext = new HBaseContext(sc, conf)
+
+    var sampleIds: List[String] = inputsampleIds
+    if (sampleListFile != null) {
+      sampleIds = Source.fromFile(sampleListFile).getLines.toList
+    }
+
+    sampleIds.foreach(sampleId => {
+      scan.addColumn(Bytes.toBytes("g"), Bytes.toBytes(sampleId))
+    })
+
+    val resultHBaseRDD = hbaseContext.hbaseRDD(TableName.valueOf(hbaseTableName), scan)
+
+    val resultHBaseRDDrepar = if (numPartitions > 0) resultHBaseRDD.repartition(numPartitions)
+    else resultHBaseRDD
+
+    val result: RDD[VariantContext] = resultHBaseRDDrepar.mapPartitions((iterator) => {
+
+      val genotypeDatumReader: DatumReader[Genotype] = new SpecificDatumReader[Genotype](scala.reflect.classTag[Genotype]
+        .runtimeClass
+        .asInstanceOf[Class[Genotype]])
+
+      iterator.map((curr) => {
+        var resultList = new ListBuffer[Genotype]
+        sampleIds.foreach((sample) => {
+          val myVal = curr._2.getColumnCells(Bytes.toBytes("g"), Bytes.toBytes(sample))
+          val decoder = DecoderFactory.get().binaryDecoder(CellUtil.cloneValue(myVal.get(0)), null)
+          while (!decoder.isEnd) {
+            resultList += genotypeDatumReader.read(null, decoder)
+          }
+        })
+
+        resultList
+        val x = resultList.toList
+
+        val firstGenotype: Genotype = x.head
+        val currVar: RichVariant = RichVariant.genotypeToRichVariant(firstGenotype)
+        val currRefPos = ReferencePosition(currVar.variant.getContigName, currVar.variant.getStart)
+
+        val currVariantContext: VariantContext = new VariantContext(currRefPos, currVar, x)
+        currVariantContext
+      })
+
+    })
+
+    result
+
+  }
+
+  def createHBaseGenotypeTable(hbaseTableName: String, splitsFileName: String): Unit = {
+    val conf = HBaseConfiguration.create()
+
+    val connection = ConnectionFactory.createConnection(conf)
+
+    val admin = connection.getAdmin
+
+    val tableDescriptor = new HTableDescriptor(TableName.valueOf(hbaseTableName))
+    tableDescriptor.addFamily(new HColumnDescriptor("g".getBytes()).setCompressionType(Algorithm.GZ)
+      .setDataBlockEncoding(DataBlockEncoding.FAST_DIFF)
+      .setMaxVersions(1))
+
+    val splits: Array[Array[Byte]] = Source.fromFile(splitsFileName).getLines.toArray
+      .map(x => x.split(" "))
+      .map(g => Bytes.toBytes(g(0) + "_"
+        + String.format("%10s", g(1).toString).replace(' ', '0')))
+
+    admin.createTable(tableDescriptor, splits)
+
+    val hbaseTableName_meta = hbaseTableName + "_meta"
+
+    val tableDescriptor_meta = new HTableDescriptor(TableName.valueOf(hbaseTableName_meta))
+    tableDescriptor_meta.addFamily(new HColumnDescriptor("meta".getBytes())
+      .setCompressionType(Algorithm.GZ)
+      .setDataBlockEncoding(DataBlockEncoding.FAST_DIFF)
+      .setMaxVersions(1))
+    admin.createTable(tableDescriptor_meta)
+  }
+
+  def saveVariantContextRDDToHBase(sc: SparkContext,
+                                   vcRdd: VariantContextRDD,
+                                   hbaseTableName: String,
+                                   sequenceDictionaryId: String = null,
+                                   saveSequenceDictionary: Boolean = true): Unit = {
+
+    val conf = HBaseConfiguration.create()
+
+    val hbaseContext = new HBaseContext(sc, conf)
+
+    saveSampleMetadataToHBase(hbaseTableName + "_meta", vcRdd.samples)
+
+    if (saveSequenceDictionary) saveSequenceDictionaryToHBase(hbaseTableName + "_meta", vcRdd.sequences, sequenceDictionaryId)
+
+    val data: RDD[VariantContext] = vcRdd.rdd
+
+    val genodata = vcRdd.rdd.mapPartitions((iterator) => {
+      val genotypebaos: java.io.ByteArrayOutputStream = new ByteArrayOutputStream()
+      val genotypeEncoder = EncoderFactory.get().binaryEncoder(genotypebaos, null)
+
+      val genotypeDatumWriter: DatumWriter[Genotype] = new SpecificDatumWriter[Genotype](
+        scala.reflect.classTag[Genotype]
+          .runtimeClass
+          .asInstanceOf[Class[Genotype]])
+
+      val genotypesForHbase: Iterator[(Array[Byte], List[(String, Array[Byte])])] = iterator.map((putRecord) => {
+        val myRowKey = Bytes.toBytes(putRecord.variant.variant.getContigName + "_" + String.format("%10s", putRecord.variant.variant.getStart.toString).replace(' ', '0') + "_" +
+          putRecord.variant.variant.getReferenceAllele + "_" + putRecord.variant.variant.getAlternateAllele + "_" + putRecord.variant.variant.getEnd)
+
+        val genotypes: List[(String, Array[Byte])] = putRecord.genotypes.map((geno) => {
+          genotypebaos.reset()
+          genotypeDatumWriter.write(geno, genotypeEncoder)
+          genotypeEncoder.flush()
+          genotypebaos.flush()
+          (geno.getSampleId, genotypebaos.toByteArray)
+        }).toList
+
+        (myRowKey, genotypes)
+
+      })
+
+      genotypesForHbase
+
+    })
+
+    genodata.hbaseBulkPut(hbaseContext,
+      TableName.valueOf(hbaseTableName),
+      (putRecord) => {
+        val put = new Put(putRecord._1)
+
+        putRecord._2.foreach((x) => {
+          val sampleId: String = x._1
+          val genoBytes: Array[Byte] = x._2
+          put.addColumn(Bytes.toBytes("g"), Bytes.toBytes(sampleId), genoBytes)
+        })
+        put
+      })
+  }
+
+  def saveVariantContextRDDToHBaseBulk(sc: SparkContext,
+                                       vcRdd: VariantContextRDD,
+                                       hbaseTableName: String,
+                                       sequenceDictionaryId: String,
+                                       saveSequenceDictionary: Boolean = true,
+                                       numPartitions: Int = 0,
+                                       stagingFolder: String): Unit = {
+
+    val conf = HBaseConfiguration.create()
+    val hbaseContext = new HBaseContext(sc, conf)
+
+    saveSampleMetadataToHBase(hbaseTableName + "_meta", vcRdd.samples)
+
+    if (saveSequenceDictionary) saveSequenceDictionaryToHBase(hbaseTableName + "_meta", vcRdd.sequences, sequenceDictionaryId)
+
+    val rddMaybeRepar = if (numPartitions > 0) vcRdd.rdd.repartition(numPartitions)
+    else vcRdd.rdd
+
+    val data: RDD[VariantContext] = vcRdd.rdd
+
+    val genodata = rddMaybeRepar.mapPartitions((iterator) => {
+      val genotypebaos: java.io.ByteArrayOutputStream = new ByteArrayOutputStream()
+      val genotypeEncoder = EncoderFactory.get().binaryEncoder(genotypebaos, null)
+
+      val genotypeDatumWriter: DatumWriter[Genotype] = new SpecificDatumWriter[Genotype](
+        scala.reflect.classTag[Genotype]
+          .runtimeClass
+          .asInstanceOf[Class[Genotype]])
+
+      val genotypesForHbase: Iterator[(Array[Byte], List[(String, Array[Byte])])] = iterator.map((putRecord) => {
+        val myRowKey = Bytes.toBytes(putRecord.variant.variant.getContigName + "_" +
+          String.format("%10s", putRecord.variant.variant.getStart.toString).replace(' ', '0') + "_" +
+          putRecord.variant.variant.getReferenceAllele + "_" +
+          putRecord.variant.variant.getAlternateAllele +
+          "_" + (putRecord.variant.variant.getEnd - putRecord.variant.variant.getStart))
+
+        val genotypes: List[(String, Array[Byte])] = putRecord.genotypes.map((geno) => {
+          genotypebaos.reset()
+          genotypeDatumWriter.write(geno, genotypeEncoder)
+          genotypeEncoder.flush()
+          genotypebaos.flush()
+          (geno.getSampleId, genotypebaos.toByteArray)
+        }).toList
+
+        (myRowKey, genotypes)
+      })
+      genotypesForHbase
+    })
+
+    val familyHBaseWriterOptions = new java.util.HashMap[Array[Byte], FamilyHFileWriteOptions]
+
+    val f1Options = new FamilyHFileWriteOptions("GZ", "ROW", 128, "FAST_DIFF")
+
+    familyHBaseWriterOptions.put(Bytes.toBytes("g"), f1Options)
+
+    genodata.hbaseBulkLoad(hbaseContext,
+      TableName.valueOf(hbaseTableName),
+      t => {
+        val data = new ListBuffer[(KeyFamilyQualifier, Array[Byte])]
+        val rowKey = t._1
+        val family = Bytes.toBytes("g")
+
+        t._2.foreach((x) => {
+
+          val qualifier: String = x._1
+          val value: Array[Byte] = x._2
+
+          val mykeyFamilyQualifier = new KeyFamilyQualifier(rowKey, family, Bytes.toBytes(qualifier))
+
+          data += Tuple2(mykeyFamilyQualifier, value)
+
+        })
+
+        data.iterator
+      },
+      stagingFolder, familyHBaseWriterOptions,
+      compactionExclude = false,
+      HConstants.DEFAULT_MAX_FILE_SIZE)
+    ("hadoop fs -chmod -R 777 " + stagingFolder) !
+    val conn = ConnectionFactory.createConnection(conf)
+    val load = new LoadIncrementalHFiles(conf)
+    load.doBulkLoad(new Path(stagingFolder), conn.getAdmin, conn.getTable(TableName.valueOf(hbaseTableName)), conn.getRegionLocator(TableName.valueOf(hbaseTableName)))
+
+  }
+
+  def deleteGenotypeSamplesFromHBase(sc: SparkContext,
+                                     hbaseTableName: String,
+                                     inputsampleIds: List[String] = null,
+                                     sampleListFile: String = null,
+                                     numPartitions: Int = 0): Unit = {
+
+    val scan = new Scan()
+    scan.setCaching(100)
+    scan.setMaxVersions(1)
+
+    val conf = HBaseConfiguration.create()
+    val hbaseContext = new HBaseContext(sc, conf)
+
+    var sampleIds: List[String] = inputsampleIds
+    if (sampleListFile != null) {
+      sampleIds = Source.fromFile(sampleListFile).getLines.toList
+    }
+
+    sampleIds.foreach(sampleId => {
+      scan.addColumn(Bytes.toBytes("g"), Bytes.toBytes(sampleId))
+    })
+
+    val resultHBaseRDD: RDD[(ImmutableBytesWritable, Result)] = hbaseContext.hbaseRDD(TableName.valueOf(hbaseTableName), scan)
+
+    hbaseContext.bulkDelete[(ImmutableBytesWritable, Result)](resultHBaseRDD,
+      TableName.valueOf(hbaseTableName),
+      putRecord => {
+        val currDelete = new Delete(putRecord._2.getRow)
+        sampleIds.foreach((sample) => {
+          currDelete.addColumns(Bytes.toBytes("g"), Bytes.toBytes(sample))
+        })
+        currDelete
+      },
+      4)
+
+  }
+
+  def loadGenotypesFromHBaseToGenotypeRDD(sc: SparkContext,
+                                          hbaseTableName: String,
+                                          sampleIds: List[String],
+                                          sequenceDictionaryId: String,
+                                          queryRegion: ReferenceRegion = null, //one-based
+                                          numPartitions: Int = 0): GenotypeRDD = {
+
+    val sequenceDictionary = loadSequenceDictionaryFromHBase(hbaseTableName + "_meta", sequenceDictionaryId)
+    val sampleMetadata = loadSampleMetadataFromHBase(hbaseTableName + "_meta", sampleIds)
+    val genotypes = loadRDDofGenotypeFromHBase(sc, hbaseTableName, sampleIds, queryRegion, numPartitions)
+    GenotypeRDD(genotypes, sequenceDictionary, sampleMetadata)
+  }
+
+  def loadGenotypesFromHBaseToVariantContextRDD(sc: SparkContext,
+                                                hbaseTableName: String,
+                                                sampleIds: List[String],
+                                                sequenceDictionaryId: String,
+                                                queryRegion: ReferenceRegion = null, //one-based
+                                                numPartitions: Int = 0): VariantContextRDD = {
+
+    val sequenceDictionary = loadSequenceDictionaryFromHBase(hbaseTableName + "_meta", sequenceDictionaryId)
+    val sampleMetadata = loadSampleMetadataFromHBase(hbaseTableName + "_meta", sampleIds)
+
+    val genotypes = loadRDDofVariantContextFromHBase(sc,
+      hbaseTableName,
+      sampleIds,
+      queryRegion = queryRegion,
+      numPartitions = numPartitions)
+
+    VariantContextRDD(genotypes, sequenceDictionary, sampleMetadata)
+
+  }
+}

--- a/pom.xml
+++ b/pom.xml
@@ -1,5 +1,15 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+
+
+  <repositories>
+    <repository>
+      <id>cloudera</id>
+      <url>https://repository.cloudera.com/artifactory/cloudera-repos/</url>
+    </repository>
+  </repositories>
+
+
   <parent>
     <groupId>org.sonatype.oss</groupId>
     <artifactId>oss-parent</artifactId>
@@ -464,6 +474,22 @@
         </exclusions>
       </dependency>
       <dependency>
+        <groupId>org.apache.spark</groupId>
+        <artifactId>spark-streaming_2.10</artifactId>
+        <version>${spark.version}</version>
+        <scope>provided</scope>
+        <exclusions>
+          <exclusion>
+            <groupId>org.apache.hadoop</groupId>
+            <artifactId>hadoop-client</artifactId>
+          </exclusion>
+          <exclusion>
+            <groupId>org.apache.hadoop</groupId>
+            <artifactId>hadoop-mapreduce</artifactId>
+          </exclusion>
+        </exclusions>
+      </dependency>
+      <dependency>
         <groupId>org.apache.avro</groupId>
         <artifactId>avro</artifactId>
         <version>${avro.version}</version>
@@ -564,6 +590,74 @@
         <artifactId>scala-guice_${scala.version.prefix}</artifactId>
         <version>4.0.1</version>
       </dependency>
+
+      <!--  apache Hbase 2.0 version of hbase dependencies, to be turned into a profile later
+      <dependency>
+        <groupId>org.apache.hbase</groupId>
+        <artifactId>hbase-hadoop2-compat</artifactId>
+        <version>2.0.0-SNAPSHOT</version>
+      </dependency>
+      <dependency>
+        <groupId>org.apache.hbase</groupId>
+        <artifactId>hbase-server</artifactId>
+        <version>2.0.0-SNAPSHOT</version>
+      </dependency>
+      <dependency>
+        <groupId>org.apache.hbase</groupId>
+        <artifactId>hbase-it</artifactId>
+        <version>2.0.0-SNAPSHOT</version>
+      </dependency>
+      <dependency>
+        <groupId>org.apache.hbase</groupId>
+        <artifactId>hbase-client</artifactId>
+        <version>2.0.0-SNAPSHOT</version>
+      </dependency>
+      <dependency>
+        <groupId>org.apache.hbase</groupId>
+        <artifactId>hbase-spark</artifactId>
+        <version>2.0.0-SNAPSHOT</version>
+      </dependency>
+      <dependency>
+        <groupId>org.apache.hbase</groupId>
+        <artifactId>hbase-common</artifactId>
+        <version>2.0.0-SNAPSHOT</version>
+      </dependency>  -->
+
+
+      <dependency>
+        <groupId>org.apache.hbase</groupId>
+        <artifactId>hbase-hadoop2-compat</artifactId>
+        <version>1.2.0-cdh5.8.0</version>
+      </dependency>
+
+      <dependency>
+        <groupId>org.apache.hbase</groupId>
+        <artifactId>hbase-server</artifactId>
+        <version>1.2.0-cdh5.8.0</version>
+      </dependency>
+
+      <dependency>
+        <groupId>org.apache.hbase</groupId>
+        <artifactId>hbase-it</artifactId>
+        <version>1.2.0-cdh5.8.0</version>
+      </dependency>
+
+      <dependency>
+        <groupId>org.apache.hbase</groupId>
+        <artifactId>hbase-client</artifactId>
+        <version>1.2.0-cdh5.8.0</version>
+      </dependency>
+
+      <dependency>
+        <groupId>org.apache.hbase</groupId>
+        <artifactId>hbase-spark</artifactId>
+        <version>1.2.0-cdh5.8.0</version>
+      </dependency>
+
+
+
+
+
     </dependencies>
   </dependencyManagement>
 

--- a/pom.xml
+++ b/pom.xml
@@ -628,30 +628,35 @@
         <groupId>org.apache.hbase</groupId>
         <artifactId>hbase-hadoop2-compat</artifactId>
         <version>1.2.0-cdh5.8.0</version>
+	<scope>provided</scope>
       </dependency>
 
       <dependency>
         <groupId>org.apache.hbase</groupId>
         <artifactId>hbase-server</artifactId>
         <version>1.2.0-cdh5.8.0</version>
+	<scope>provided</scope>
       </dependency>
 
       <dependency>
         <groupId>org.apache.hbase</groupId>
         <artifactId>hbase-it</artifactId>
         <version>1.2.0-cdh5.8.0</version>
+	<scope>provided</scope>
       </dependency>
 
       <dependency>
         <groupId>org.apache.hbase</groupId>
         <artifactId>hbase-client</artifactId>
         <version>1.2.0-cdh5.8.0</version>
+	<scope>provided</scope>
       </dependency>
 
       <dependency>
         <groupId>org.apache.hbase</groupId>
         <artifactId>hbase-spark</artifactId>
         <version>1.2.0-cdh5.8.0</version>
+	<scope>provided</scope>
       </dependency>
 
 


### PR DESCRIPTION
Requesting here a first pass review for the integration of HBase input and output functions into Master.

The code in this PR excludes the "custom encoding" options for clarity and thus sticks with saving the full Avro schema of a Genotype as the values stored in HBase.

Todo:
- [ ] Add Unit tests using an embedded mini-hbase cluster
- [ ] Add more parameter checking and informative error messages, such as if database table doesn't exist
- [ ] Integrate and rebase against upcoming changes to Genotype schemas when available

Questions:
- This PR has a new hbase/HBaseFunctions.scala module parallel to RDD in the package structure in adam-core, is this OK, or other suggestions?

- For the first round of HBase code integration I suggest we target CDH HBase only as that is where we are doing testing and deployment.  In future we can add a profile for POM for  Apache Hbase 2.0, though this  would seem to require use of HBase 2.0 snapshot as Spark support doesn't exist in the last official non-cloudera apache release.



