### PR TITLE
[ADAM-1225] Move helper functions from ADAMFunSuite to SparkFunSuite.

### DIFF
--- a/adam-core/src/test/scala/org/bdgenomics/adam/util/ADAMFunSuite.scala
+++ b/adam-core/src/test/scala/org/bdgenomics/adam/util/ADAMFunSuite.scala
@@ -17,14 +17,7 @@
  */
 package org.bdgenomics.adam.util
 
-import com.google.common.io.Resources
-import java.io.File
-import java.net.{ URI, URL }
-import java.nio.file.{ Files, Path }
-
 import org.bdgenomics.utils.misc.SparkFunSuite
-
-import scala.io.Source
 
 trait ADAMFunSuite extends SparkFunSuite {
 
@@ -36,54 +29,5 @@ trait ADAMFunSuite extends SparkFunSuite {
     "spark.kryo.registrationRequired" -> "true"
   )
 
-  def resourceUrl(path: String): URL = ClassLoader.getSystemClassLoader.getResource(path)
-
-  def tmpFile(path: String): String = Files.createTempDirectory("").toAbsolutePath.toString + "/" + path
-
-  /**
-   * Creates temporary file for saveAsParquet().
-   * This helper function is required because createTempFile creates an actual file, not
-   * just a name.  Whereas, this returns the name of something that could be mkdir'ed, in the
-   * same location as createTempFile() uses, so therefore the returned path from this method
-   * should be suitable for saveAsParquet().
-   *
-   * @param suffix Suffix of file being created
-   * @return Absolute path to temporary file location
-   */
-  def tmpLocation(suffix: String = ".adam"): String = {
-    val tempFile = File.createTempFile("TempSuite", "")
-    val tempDir = tempFile.getParentFile
-    new File(tempDir, tempFile.getName + suffix).getAbsolutePath
-  }
-
-  def checkFiles(expectedPath: String, actualPath: String): Unit = {
-    val actualFile = Source.fromFile(actualPath)
-    val actualLines = actualFile.getLines.toList
-
-    val expectedFile = Source.fromFile(expectedPath)
-    val expectedLines = expectedFile.getLines.toList
-
-    assert(expectedLines.size === actualLines.size)
-    expectedLines.zip(actualLines).zipWithIndex.foreach {
-      case ((expected, actual), idx) =>
-        assert(
-          expected == actual,
-          s"Line ${idx + 1} differs.\nExpected:\n${expectedLines.mkString("\n")}\n\nActual:\n${actualLines.mkString("\n")}"
-        )
-    }
-  }
-
-  def copyResourcePath(name: String): Path = {
-    val tempFile = Files.createTempFile(name, "." + name.split('.').tail.mkString("."))
-    Files.write(tempFile, Resources.toByteArray(getClass().getResource("/" + name)))
-  }
-
-  def copyResource(name: String): String = {
-    copyResourcePath(name).toString
-  }
-
-  def copyResourceUri(name: String): URI = {
-    copyResourcePath(name).toUri
-  }
 }
 

--- a/pom.xml
+++ b/pom.xml
@@ -28,7 +28,7 @@
     <hadoop-bam.version>7.7.0</hadoop-bam.version>
     <slf4j.version>1.7.21</slf4j.version>
     <bdg-formats.version>0.9.0</bdg-formats.version>
-    <bdg-utils.version>0.2.8</bdg-utils.version>
+    <bdg-utils.version>0.2.9</bdg-utils.version>
     <htsjdk.version>2.5.0</htsjdk.version>
     <scoverage.plugin.version>1.1.1</scoverage.plugin.version>
   </properties>


### PR DESCRIPTION
Resolves #1225. Depends on https://github.com/bigdatagenomics/utils/pull/89 and a bdg-utils 0.2.9 release.