### PR TITLE
[ADAM-1233] Expose header lines in Variant-related GenomicRDDs

### DIFF
--- a/adam-core/src/main/scala/org/bdgenomics/adam/converters/SupportedHeaderLines.scala
+++ b/adam-core/src/main/scala/org/bdgenomics/adam/converters/SupportedHeaderLines.scala
@@ -67,4 +67,9 @@ private[adam] object SupportedHeaderLines {
    * All format lines in VCF format.
    */
   lazy val formatHeaderLines = VariantAnnotationConverter.FORMAT_KEYS.map(_.hdrLine)
+
+  /**
+   * All supported header lines in VCF format.
+   */
+  lazy val allHeaderLines = infoHeaderLines ++ formatHeaderLines
 }

--- a/adam-core/src/main/scala/org/bdgenomics/adam/converters/SupportedHeaderLines.scala
+++ b/adam-core/src/main/scala/org/bdgenomics/adam/converters/SupportedHeaderLines.scala
@@ -29,7 +29,7 @@ import htsjdk.variant.vcf.{
 private[adam] object SupportedHeaderLines {
 
   lazy val ancestralAllele = new VCFInfoHeaderLine("AA", 1, VCFHeaderLineType.String, "Ancestral allele");
-  lazy val alleleCount = new VCFInfoHeaderLine("AC", VCFHeaderLineCount.A, VCFHeaderLineType.String, "Allele count");
+  lazy val alleleCount = new VCFInfoHeaderLine("AC", VCFHeaderLineCount.A, VCFHeaderLineType.Integer, "Allele count");
   lazy val readDepth = new VCFInfoHeaderLine("AD", VCFHeaderLineCount.R, VCFHeaderLineType.Integer, "Total read depths for each allele");
   lazy val forwardReadDepth = new VCFInfoHeaderLine("ADF", VCFHeaderLineCount.R, VCFHeaderLineType.Integer, "Read depths for each allele on the forward strand");
   lazy val reverseReadDepth = new VCFInfoHeaderLine("ADR", VCFHeaderLineCount.R, VCFHeaderLineType.Integer, "Read depths for each allele on the reverse strand");
@@ -41,7 +41,7 @@ private[adam] object SupportedHeaderLines {
   lazy val validated = new VCFInfoHeaderLine("VALIDATED", 0, VCFHeaderLineType.Flag, "Validated by follow-up experiment");
   lazy val thousandGenomes = new VCFInfoHeaderLine("1000G", 0, VCFHeaderLineType.Flag, "Membership in 1000 Genomes");
   lazy val somatic = new VCFInfoHeaderLine("SOMATIC", 0, VCFHeaderLineType.Flag, "Somatic event");
-  lazy val transcriptEffects = new VCFInfoHeaderLine("ANN", VCFHeaderLineCount.UNBOUNDED, VCFHeaderLineType.String, "Functional annotations: 'Allele | Annotation | Annotation_Impact | Gene_Name | Gene_ID | Feature_Type | Feature_ID | Transcript_BioType | Rank | HGVS.c | HGVS.p | cDNA.pos / cDNA.length | CDS.pos / CDS.length | AA.pos / AA.length | Distance | ERRORS / WARNINGS / INFO' ");
+  lazy val transcriptEffects = new VCFInfoHeaderLine("ANN", VCFHeaderLineCount.UNBOUNDED, VCFHeaderLineType.String, "Functional annotations: 'Allele | Annotation | Annotation_Impact | Gene_Name | Gene_ID | Feature_Type | Feature_ID | Transcript_BioType | Rank | HGVS.c | HGVS.p | cDNA.pos / cDNA.length | CDS.pos / CDS.length | AA.pos / AA.length | Distance | ERRORS / WARNINGS / INFO'");
 
   /**
    * All info keys in VCF format.

--- a/adam-core/src/main/scala/org/bdgenomics/adam/rdd/VCFHeaderUtils.scala
+++ b/adam-core/src/main/scala/org/bdgenomics/adam/rdd/VCFHeaderUtils.scala
@@ -1,0 +1,79 @@
+/**
+ * Licensed to Big Data Genomics (BDG) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The BDG licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.bdgenomics.adam.rdd
+
+import htsjdk.variant.variantcontext.writer.{
+  Options,
+  VariantContextWriterBuilder
+}
+import htsjdk.variant.vcf.{ VCFHeader, VCFHeaderLine }
+import htsjdk.variant.vcf.VCFHeader
+import org.apache.hadoop.conf.Configuration
+import org.apache.hadoop.fs.{ FileSystem, Path }
+
+/**
+ * Utility for writing VCF headers to a file.
+ */
+private[rdd] object VCFHeaderUtils {
+
+  /**
+   * Writes a vcf header to a file.
+   *
+   * @param header The header to write.
+   * @param path The path to write it to.
+   * @param conf The configuration to get the file system.
+   */
+  def write(header: VCFHeader,
+            path: Path,
+            conf: Configuration) {
+
+    val fs = path.getFileSystem(conf)
+
+    write(header, path, fs)
+  }
+
+  /**
+   * Writes a vcf header to a file.
+   *
+   * @param header The header to write.
+   * @param path The path to write it to.
+   * @param fs The file system to write to.
+   */
+  def write(header: VCFHeader,
+            path: Path,
+            fs: FileSystem) {
+
+    // get an output stream
+    val os = fs.create(path)
+
+    // build a vcw
+    val vcw = new VariantContextWriterBuilder()
+      .setOutputVCFStream(os)
+      .clearIndexCreator()
+      .unsetOption(Options.INDEX_ON_THE_FLY)
+      .build()
+
+    // write the header
+    vcw.writeHeader(header)
+
+    // close the writer and the underlying stream
+    vcw.close()
+    os.flush()
+    os.close()
+  }
+}

--- a/adam-core/src/main/scala/org/bdgenomics/adam/rdd/variant/GenotypeRDD.scala
+++ b/adam-core/src/main/scala/org/bdgenomics/adam/rdd/variant/GenotypeRDD.scala
@@ -17,7 +17,9 @@
  */
 package org.bdgenomics.adam.rdd.variant
 
+import htsjdk.variant.vcf.VCFHeaderLine
 import org.apache.spark.rdd.RDD
+import org.bdgenomics.adam.converters.SupportedHeaderLines
 import org.bdgenomics.adam.models.{
   ReferencePosition,
   ReferenceRegion,
@@ -36,10 +38,13 @@ import org.bdgenomics.formats.avro.{ Contig, Genotype, Sample }
  * @param rdd Called genotypes.
  * @param sequences A dictionary describing the reference genome.
  * @param samples The samples called.
+ * @param headerLines The VCF header lines that cover all INFO/FORMAT fields
+ *   needed to represent this RDD of Genotypes.
  */
 case class GenotypeRDD(rdd: RDD[Genotype],
                        sequences: SequenceDictionary,
-                       @transient samples: Seq[Sample]) extends MultisampleAvroGenomicRDD[Genotype, GenotypeRDD] {
+                       @transient samples: Seq[Sample],
+                       @transient headerLines: Seq[VCFHeaderLine] = SupportedHeaderLines.allHeaderLines) extends MultisampleAvroGenomicRDD[Genotype, GenotypeRDD] {
 
   /**
    * Java-friendly method for saving.
@@ -65,7 +70,7 @@ case class GenotypeRDD(rdd: RDD[Genotype],
         }
       }
 
-    VariantContextRDD(vcRdd, sequences, samples)
+    VariantContextRDD(vcRdd, sequences, samples, headerLines)
   }
 
   /**

--- a/adam-core/src/main/scala/org/bdgenomics/adam/rdd/variant/VariantAnnotationRDD.scala
+++ b/adam-core/src/main/scala/org/bdgenomics/adam/rdd/variant/VariantAnnotationRDD.scala
@@ -17,7 +17,9 @@
  */
 package org.bdgenomics.adam.rdd.variant
 
+import htsjdk.variant.vcf.VCFHeaderLine
 import org.apache.spark.rdd.RDD
+import org.bdgenomics.adam.converters.SupportedHeaderLines
 import org.bdgenomics.adam.models.{ ReferenceRegion, SequenceDictionary }
 import org.bdgenomics.adam.rdd.{ AvroGenomicRDD, JavaSaveArgs }
 import org.bdgenomics.formats.avro.VariantAnnotation
@@ -27,9 +29,12 @@ import org.bdgenomics.formats.avro.VariantAnnotation
  *
  * @param rdd Variant annotations.
  * @param sequences A dictionary describing the reference genome.
+ * @param headerLines The VCF header lines that cover all INFO/FORMAT fields
+ *   needed to represent this RDD of DatabaseVariantAnnotationss.
  */
 case class VariantAnnotationRDD(rdd: RDD[VariantAnnotation],
-                                sequences: SequenceDictionary) extends AvroGenomicRDD[VariantAnnotation, VariantAnnotationRDD] {
+                                sequences: SequenceDictionary,
+                                @transient headerLines: Seq[VCFHeaderLine] = SupportedHeaderLines.allHeaderLines) extends AvroGenomicRDD[VariantAnnotation, VariantAnnotationRDD] {
 
   /**
    * Java-friendly method for saving to Parquet.

--- a/adam-core/src/main/scala/org/bdgenomics/adam/rdd/variant/VariantRDD.scala
+++ b/adam-core/src/main/scala/org/bdgenomics/adam/rdd/variant/VariantRDD.scala
@@ -17,7 +17,9 @@
  */
 package org.bdgenomics.adam.rdd.variant
 
+import htsjdk.variant.vcf.VCFHeaderLine
 import org.apache.spark.rdd.RDD
+import org.bdgenomics.adam.converters.SupportedHeaderLines
 import org.bdgenomics.adam.models.{ ReferenceRegion, SequenceDictionary }
 import org.bdgenomics.adam.rdd.{ AvroGenomicRDD, JavaSaveArgs }
 import org.bdgenomics.formats.avro.Variant
@@ -27,9 +29,12 @@ import org.bdgenomics.formats.avro.Variant
  *
  * @param rdd Variants.
  * @param sequences A dictionary describing the reference genome.
+ * @param headerLines The VCF header lines that cover all INFO/FORMAT fields
+ *   needed to represent this RDD of Variants.
  */
 case class VariantRDD(rdd: RDD[Variant],
-                      sequences: SequenceDictionary) extends AvroGenomicRDD[Variant, VariantRDD] {
+                      sequences: SequenceDictionary,
+                      @transient headerLines: Seq[VCFHeaderLine] = SupportedHeaderLines.allHeaderLines) extends AvroGenomicRDD[Variant, VariantRDD] {
 
   /**
    * Java-friendly method for saving to Parquet.

--- a/adam-core/src/test/resources/sorted.lex.vcf
+++ b/adam-core/src/test/resources/sorted.lex.vcf
@@ -1,4 +1,19 @@
 ##fileformat=VCFv4.2
+##FILTER=<ID=IndelFS,Description="FS > 200.0">
+##FILTER=<ID=IndelQD,Description="QD < 2.0">
+##FILTER=<ID=IndelReadPosRankSum,Description="ReadPosRankSum < -20.0">
+##FILTER=<ID=LowQual,Description="Low quality">
+##FILTER=<ID=VQSRTrancheSNP99.50to99.60,Description="Truth sensitivity tranche level for SNP model at VQS Lod: -0.5377 <= x < -0.1787">
+##FILTER=<ID=VQSRTrancheSNP99.60to99.70,Description="Truth sensitivity tranche level for SNP model at VQS Lod: -1.0634 <= x < -0.5377">
+##FILTER=<ID=VQSRTrancheSNP99.70to99.80,Description="Truth sensitivity tranche level for SNP model at VQS Lod: -1.7119 <= x < -1.0634">
+##FILTER=<ID=VQSRTrancheSNP99.80to99.90,Description="Truth sensitivity tranche level for SNP model at VQS Lod: -2.3301 <= x < -1.7119">
+##FILTER=<ID=VQSRTrancheSNP99.90to99.95,Description="Truth sensitivity tranche level for SNP model at VQS Lod: -2.8169 <= x < -2.3301">
+##FILTER=<ID=VQSRTrancheSNP99.95to100.00+,Description="Truth sensitivity tranche level for SNP model at VQS Lod < -1918.1929">
+##FILTER=<ID=VQSRTrancheSNP99.95to100.00,Description="Truth sensitivity tranche level for SNP model at VQS Lod: -1918.1929 <= x < -2.8169">
+##FILTER=<ID=dp,Description="Insufficient read depth">
+##FILTER=<ID=gq,Description="Insufficient genotype quality">
+##FILTER=<ID=rd,Description="Insufficient supporting reads">
+##FILTER=<ID=sx,Description="Heterozygous sex chromosomes in male sample, or Y chromosome in female sample">
 ##FORMAT=<ID=AD,Number=R,Type=Integer,Description="Allelic depths for the ref and alt alleles in the order listed">
 ##FORMAT=<ID=DP,Number=1,Type=Integer,Description="Approximate read depth (reads with MQ=255 or with bad mates are filtered)">
 ##FORMAT=<ID=FT,Number=1,Type=String,Description="Genotype-level filter">
@@ -9,20 +24,41 @@
 ##FORMAT=<ID=PQ,Number=1,Type=Float,Description="Read-backed phasing quality">
 ##FORMAT=<ID=PS,Number=1,Type=Integer,Description="Phase set">
 ##FORMAT=<ID=SB,Number=4,Type=Integer,Description="Per-sample component statistics which comprise the Fisher's Exact Test to detect strand bias.">
+##GATKCommandLine=<ID=CombineVariants,Version=2.7-63-gc434461,Date="Mon Oct 14 15:08:05 EDT 2013",Epoch=1381777685067,CommandLineOptions="analysis_type=CombineVariants input_file=[] read_buffer_size=null phone_home=NO_ET gatk_key=/packages/gatk/1.5-21-g979a84a/src/eugene.fluder_mssm.edu.key tag=NA read_filter=[] intervals=[/gs01/projects/ngs/validation/exome/CEPHTrio/2.7/r1-1-1/.queueScatterGather/.qlog/r1-1-1.combined.rawGT.vcf.combine-sg/temp_01_of_20/scatter.intervals] excludeIntervals=null interval_set_rule=UNION interval_merging=ALL interval_padding=0 reference_sequence=/projects/ngs/resources/gatk/2.3/ucsc.hg19.fasta nonDeterministicRandomSeed=false disableDithering=false maxRuntime=-1 maxRuntimeUnits=MINUTES downsampling_type=BY_SAMPLE downsample_to_fraction=null downsample_to_coverage=1000 baq=OFF baqGapOpenPenalty=40.0 fix_misencoded_quality_scores=false allow_potentially_misencoded_quality_scores=false useOriginalQualities=false defaultBaseQualities=-1 performanceLog=null BQSR=null quantize_quals=0 disable_indel_quals=false emit_original_quals=false preserve_qscores_less_than=6 globalQScorePrior=-1.0 allow_bqsr_on_reduced_bams_despite_repeated_warnings=false validation_strictness=SILENT remove_program_records=false keep_program_records=false sample_rename_mapping_file=null unsafe=null disable_auto_index_creation_and_locking_when_reading_rods=false num_threads=1 num_cpu_threads_per_data_thread=1 num_io_threads=0 monitorThreadEfficiency=false num_bam_file_handles=null read_group_black_list=null pedigree=[] pedigreeString=[] pedigreeValidationType=STRICT allow_intervals_with_unindexed_bam=false generateShadowBCF=false logging_level=INFO log_to_file=null help=false version=false variant=[(RodBinding name=SNP source=/gs01/projects/ngs/validation/exome/CEPHTrio/2.7/r1-1-1/r1-1-1.recal.SNP.vcf), (RodBinding name=Indel source=/gs01/projects/ngs/validation/exome/CEPHTrio/2.7/r1-1-1/r1-1-1.filt.IND.vcf)] out=org.broadinstitute.sting.gatk.io.stubs.VariantContextWriterStub no_cmdline_in_header=org.broadinstitute.sting.gatk.io.stubs.VariantContextWriterStub sites_only=org.broadinstitute.sting.gatk.io.stubs.VariantContextWriterStub bcf=org.broadinstitute.sting.gatk.io.stubs.VariantContextWriterStub genotypemergeoption=UNSORTED filteredrecordsmergetype=KEEP_IF_ANY_UNFILTERED multipleallelesmergetype=BY_TYPE rod_priority_list=null printComplexMerges=false filteredAreUncalled=false minimalVCF=false setKey=null assumeIdenticalSamples=true minimumN=1 suppressCommandLineHeader=false mergeInfoWithMaxAC=false filter_reads_with_N_cigar=false filter_mismatching_base_and_quals=false filter_bases_not_stored=false">
 ##INFO=<ID=1000G,Number=0,Type=Flag,Description="Membership in 1000 Genomes">
 ##INFO=<ID=AA,Number=1,Type=String,Description="Ancestral allele">
-##INFO=<ID=AC,Number=A,Type=String,Description="Allele count">
+##INFO=<ID=AC,Number=A,Type=Integer,Description="Allele count">
 ##INFO=<ID=AD,Number=R,Type=Integer,Description="Total read depths for each allele">
 ##INFO=<ID=ADF,Number=R,Type=Integer,Description="Read depths for each allele on the forward strand">
 ##INFO=<ID=ADR,Number=R,Type=Integer,Description="Read depths for each allele on the reverse strand">
 ##INFO=<ID=AF,Number=A,Type=Float,Description="Allele frequency for each allele">
-##INFO=<ID=ANN,Number=.,Type=String,Description="Functional annotations: 'Allele | Annotation | Annotation_Impact | Gene_Name | Gene_ID | Feature_Type | Feature_ID | Transcript_BioType | Rank | HGVS.c | HGVS.p | cDNA.pos / cDNA.length | CDS.pos / CDS.length | AA.pos / AA.length | Distance | ERRORS / WARNINGS / INFO' ">
+##INFO=<ID=AN,Number=1,Type=Integer,Description="Total number of alleles in called genotypes">
+##INFO=<ID=ANN,Number=.,Type=String,Description="Functional annotations: 'Allele | Annotation | Annotation_Impact | Gene_Name | Gene_ID | Feature_Type | Feature_ID | Transcript_BioType | Rank | HGVS.c | HGVS.p | cDNA.pos / cDNA.length | CDS.pos / CDS.length | AA.pos / AA.length | Distance | ERRORS / WARNINGS / INFO'">
+##INFO=<ID=BaseQRankSum,Number=1,Type=Float,Description="Z-score from Wilcoxon rank sum test of Alt Vs. Ref base qualities">
 ##INFO=<ID=CIGAR,Number=A,Type=String,Description="Cigar string describing how to align alternate alleles to the reference allele">
+##INFO=<ID=ClippingRankSum,Number=1,Type=Float,Description="Z-score From Wilcoxon rank sum test of Alt vs. Ref number of hard clipped bases">
 ##INFO=<ID=DB,Number=0,Type=Flag,Description="Membership in dbSNP">
+##INFO=<ID=DP,Number=1,Type=Integer,Description="Approximate read depth; some reads may have been filtered">
+##INFO=<ID=DS,Number=0,Type=Flag,Description="Were any of the samples downsampled?">
+##INFO=<ID=END,Number=1,Type=Integer,Description="Stop position of the interval">
+##INFO=<ID=FS,Number=1,Type=Float,Description="Phred-scaled p-value using Fisher's exact test to detect strand bias">
 ##INFO=<ID=H2,Number=0,Type=Flag,Description="Membership in HapMap2">
 ##INFO=<ID=H3,Number=0,Type=Flag,Description="Membership in HapMap3">
+##INFO=<ID=HaplotypeScore,Number=1,Type=Float,Description="Consistency of the site with at most two segregating haplotypes">
+##INFO=<ID=InbreedingCoeff,Number=1,Type=Float,Description="Inbreeding coefficient as estimated from the genotype likelihoods per-sample when compared against the Hardy-Weinberg expectation">
+##INFO=<ID=MLEAC,Number=A,Type=Integer,Description="Maximum likelihood expectation (MLE) for the allele counts (not necessarily the same as the AC), for each ALT allele, in the same order as listed">
+##INFO=<ID=MLEAF,Number=A,Type=Float,Description="Maximum likelihood expectation (MLE) for the allele frequency (not necessarily the same as the AF), for each ALT allele, in the same order as listed">
+##INFO=<ID=MQ,Number=1,Type=Float,Description="RMS Mapping Quality">
+##INFO=<ID=MQ0,Number=1,Type=Integer,Description="Total Mapping Quality Zero Reads">
+##INFO=<ID=MQRankSum,Number=1,Type=Float,Description="Z-score From Wilcoxon rank sum test of Alt vs. Ref read mapping qualities">
+##INFO=<ID=NEGATIVE_TRAIN_SITE,Number=0,Type=Flag,Description="This variant was used to build the negative training set of bad variants">
+##INFO=<ID=POSITIVE_TRAIN_SITE,Number=0,Type=Flag,Description="This variant was used to build the positive training set of good variants">
+##INFO=<ID=QD,Number=1,Type=Float,Description="Variant Confidence/Quality by Depth">
+##INFO=<ID=ReadPosRankSum,Number=1,Type=Float,Description="Z-score from Wilcoxon rank sum test of Alt vs. Ref read position bias">
 ##INFO=<ID=SOMATIC,Number=0,Type=Flag,Description="Somatic event">
 ##INFO=<ID=VALIDATED,Number=0,Type=Flag,Description="Validated by follow-up experiment">
+##INFO=<ID=VQSLOD,Number=1,Type=Float,Description="Log odds ratio of being a true variant versus being false under the trained gaussian mixture model">
+##INFO=<ID=culprit,Number=1,Type=String,Description="The annotation which was the worst performing in the Gaussian mixture model, likely the reason why the variant was filtered out">
 ##contig=<ID=1,length=249250621>
 ##contig=<ID=2,length=249250621>
 ##contig=<ID=13,length=249250621>

--- a/adam-core/src/test/resources/sorted.vcf
+++ b/adam-core/src/test/resources/sorted.vcf
@@ -1,4 +1,19 @@
 ##fileformat=VCFv4.2
+##FILTER=<ID=IndelFS,Description="FS > 200.0">
+##FILTER=<ID=IndelQD,Description="QD < 2.0">
+##FILTER=<ID=IndelReadPosRankSum,Description="ReadPosRankSum < -20.0">
+##FILTER=<ID=LowQual,Description="Low quality">
+##FILTER=<ID=VQSRTrancheSNP99.50to99.60,Description="Truth sensitivity tranche level for SNP model at VQS Lod: -0.5377 <= x < -0.1787">
+##FILTER=<ID=VQSRTrancheSNP99.60to99.70,Description="Truth sensitivity tranche level for SNP model at VQS Lod: -1.0634 <= x < -0.5377">
+##FILTER=<ID=VQSRTrancheSNP99.70to99.80,Description="Truth sensitivity tranche level for SNP model at VQS Lod: -1.7119 <= x < -1.0634">
+##FILTER=<ID=VQSRTrancheSNP99.80to99.90,Description="Truth sensitivity tranche level for SNP model at VQS Lod: -2.3301 <= x < -1.7119">
+##FILTER=<ID=VQSRTrancheSNP99.90to99.95,Description="Truth sensitivity tranche level for SNP model at VQS Lod: -2.8169 <= x < -2.3301">
+##FILTER=<ID=VQSRTrancheSNP99.95to100.00+,Description="Truth sensitivity tranche level for SNP model at VQS Lod < -1918.1929">
+##FILTER=<ID=VQSRTrancheSNP99.95to100.00,Description="Truth sensitivity tranche level for SNP model at VQS Lod: -1918.1929 <= x < -2.8169">
+##FILTER=<ID=dp,Description="Insufficient read depth">
+##FILTER=<ID=gq,Description="Insufficient genotype quality">
+##FILTER=<ID=rd,Description="Insufficient supporting reads">
+##FILTER=<ID=sx,Description="Heterozygous sex chromosomes in male sample, or Y chromosome in female sample">
 ##FORMAT=<ID=AD,Number=R,Type=Integer,Description="Allelic depths for the ref and alt alleles in the order listed">
 ##FORMAT=<ID=DP,Number=1,Type=Integer,Description="Approximate read depth (reads with MQ=255 or with bad mates are filtered)">
 ##FORMAT=<ID=FT,Number=1,Type=String,Description="Genotype-level filter">
@@ -9,20 +24,41 @@
 ##FORMAT=<ID=PQ,Number=1,Type=Float,Description="Read-backed phasing quality">
 ##FORMAT=<ID=PS,Number=1,Type=Integer,Description="Phase set">
 ##FORMAT=<ID=SB,Number=4,Type=Integer,Description="Per-sample component statistics which comprise the Fisher's Exact Test to detect strand bias.">
+##GATKCommandLine=<ID=CombineVariants,Version=2.7-63-gc434461,Date="Mon Oct 14 15:08:05 EDT 2013",Epoch=1381777685067,CommandLineOptions="analysis_type=CombineVariants input_file=[] read_buffer_size=null phone_home=NO_ET gatk_key=/packages/gatk/1.5-21-g979a84a/src/eugene.fluder_mssm.edu.key tag=NA read_filter=[] intervals=[/gs01/projects/ngs/validation/exome/CEPHTrio/2.7/r1-1-1/.queueScatterGather/.qlog/r1-1-1.combined.rawGT.vcf.combine-sg/temp_01_of_20/scatter.intervals] excludeIntervals=null interval_set_rule=UNION interval_merging=ALL interval_padding=0 reference_sequence=/projects/ngs/resources/gatk/2.3/ucsc.hg19.fasta nonDeterministicRandomSeed=false disableDithering=false maxRuntime=-1 maxRuntimeUnits=MINUTES downsampling_type=BY_SAMPLE downsample_to_fraction=null downsample_to_coverage=1000 baq=OFF baqGapOpenPenalty=40.0 fix_misencoded_quality_scores=false allow_potentially_misencoded_quality_scores=false useOriginalQualities=false defaultBaseQualities=-1 performanceLog=null BQSR=null quantize_quals=0 disable_indel_quals=false emit_original_quals=false preserve_qscores_less_than=6 globalQScorePrior=-1.0 allow_bqsr_on_reduced_bams_despite_repeated_warnings=false validation_strictness=SILENT remove_program_records=false keep_program_records=false sample_rename_mapping_file=null unsafe=null disable_auto_index_creation_and_locking_when_reading_rods=false num_threads=1 num_cpu_threads_per_data_thread=1 num_io_threads=0 monitorThreadEfficiency=false num_bam_file_handles=null read_group_black_list=null pedigree=[] pedigreeString=[] pedigreeValidationType=STRICT allow_intervals_with_unindexed_bam=false generateShadowBCF=false logging_level=INFO log_to_file=null help=false version=false variant=[(RodBinding name=SNP source=/gs01/projects/ngs/validation/exome/CEPHTrio/2.7/r1-1-1/r1-1-1.recal.SNP.vcf), (RodBinding name=Indel source=/gs01/projects/ngs/validation/exome/CEPHTrio/2.7/r1-1-1/r1-1-1.filt.IND.vcf)] out=org.broadinstitute.sting.gatk.io.stubs.VariantContextWriterStub no_cmdline_in_header=org.broadinstitute.sting.gatk.io.stubs.VariantContextWriterStub sites_only=org.broadinstitute.sting.gatk.io.stubs.VariantContextWriterStub bcf=org.broadinstitute.sting.gatk.io.stubs.VariantContextWriterStub genotypemergeoption=UNSORTED filteredrecordsmergetype=KEEP_IF_ANY_UNFILTERED multipleallelesmergetype=BY_TYPE rod_priority_list=null printComplexMerges=false filteredAreUncalled=false minimalVCF=false setKey=null assumeIdenticalSamples=true minimumN=1 suppressCommandLineHeader=false mergeInfoWithMaxAC=false filter_reads_with_N_cigar=false filter_mismatching_base_and_quals=false filter_bases_not_stored=false">
 ##INFO=<ID=1000G,Number=0,Type=Flag,Description="Membership in 1000 Genomes">
 ##INFO=<ID=AA,Number=1,Type=String,Description="Ancestral allele">
-##INFO=<ID=AC,Number=A,Type=String,Description="Allele count">
+##INFO=<ID=AC,Number=A,Type=Integer,Description="Allele count">
 ##INFO=<ID=AD,Number=R,Type=Integer,Description="Total read depths for each allele">
 ##INFO=<ID=ADF,Number=R,Type=Integer,Description="Read depths for each allele on the forward strand">
 ##INFO=<ID=ADR,Number=R,Type=Integer,Description="Read depths for each allele on the reverse strand">
 ##INFO=<ID=AF,Number=A,Type=Float,Description="Allele frequency for each allele">
-##INFO=<ID=ANN,Number=.,Type=String,Description="Functional annotations: 'Allele | Annotation | Annotation_Impact | Gene_Name | Gene_ID | Feature_Type | Feature_ID | Transcript_BioType | Rank | HGVS.c | HGVS.p | cDNA.pos / cDNA.length | CDS.pos / CDS.length | AA.pos / AA.length | Distance | ERRORS / WARNINGS / INFO' ">
+##INFO=<ID=AN,Number=1,Type=Integer,Description="Total number of alleles in called genotypes">
+##INFO=<ID=ANN,Number=.,Type=String,Description="Functional annotations: 'Allele | Annotation | Annotation_Impact | Gene_Name | Gene_ID | Feature_Type | Feature_ID | Transcript_BioType | Rank | HGVS.c | HGVS.p | cDNA.pos / cDNA.length | CDS.pos / CDS.length | AA.pos / AA.length | Distance | ERRORS / WARNINGS / INFO'">
+##INFO=<ID=BaseQRankSum,Number=1,Type=Float,Description="Z-score from Wilcoxon rank sum test of Alt Vs. Ref base qualities">
 ##INFO=<ID=CIGAR,Number=A,Type=String,Description="Cigar string describing how to align alternate alleles to the reference allele">
+##INFO=<ID=ClippingRankSum,Number=1,Type=Float,Description="Z-score From Wilcoxon rank sum test of Alt vs. Ref number of hard clipped bases">
 ##INFO=<ID=DB,Number=0,Type=Flag,Description="Membership in dbSNP">
+##INFO=<ID=DP,Number=1,Type=Integer,Description="Approximate read depth; some reads may have been filtered">
+##INFO=<ID=DS,Number=0,Type=Flag,Description="Were any of the samples downsampled?">
+##INFO=<ID=END,Number=1,Type=Integer,Description="Stop position of the interval">
+##INFO=<ID=FS,Number=1,Type=Float,Description="Phred-scaled p-value using Fisher's exact test to detect strand bias">
 ##INFO=<ID=H2,Number=0,Type=Flag,Description="Membership in HapMap2">
 ##INFO=<ID=H3,Number=0,Type=Flag,Description="Membership in HapMap3">
+##INFO=<ID=HaplotypeScore,Number=1,Type=Float,Description="Consistency of the site with at most two segregating haplotypes">
+##INFO=<ID=InbreedingCoeff,Number=1,Type=Float,Description="Inbreeding coefficient as estimated from the genotype likelihoods per-sample when compared against the Hardy-Weinberg expectation">
+##INFO=<ID=MLEAC,Number=A,Type=Integer,Description="Maximum likelihood expectation (MLE) for the allele counts (not necessarily the same as the AC), for each ALT allele, in the same order as listed">
+##INFO=<ID=MLEAF,Number=A,Type=Float,Description="Maximum likelihood expectation (MLE) for the allele frequency (not necessarily the same as the AF), for each ALT allele, in the same order as listed">
+##INFO=<ID=MQ,Number=1,Type=Float,Description="RMS Mapping Quality">
+##INFO=<ID=MQ0,Number=1,Type=Integer,Description="Total Mapping Quality Zero Reads">
+##INFO=<ID=MQRankSum,Number=1,Type=Float,Description="Z-score From Wilcoxon rank sum test of Alt vs. Ref read mapping qualities">
+##INFO=<ID=NEGATIVE_TRAIN_SITE,Number=0,Type=Flag,Description="This variant was used to build the negative training set of bad variants">
+##INFO=<ID=POSITIVE_TRAIN_SITE,Number=0,Type=Flag,Description="This variant was used to build the positive training set of good variants">
+##INFO=<ID=QD,Number=1,Type=Float,Description="Variant Confidence/Quality by Depth">
+##INFO=<ID=ReadPosRankSum,Number=1,Type=Float,Description="Z-score from Wilcoxon rank sum test of Alt vs. Ref read position bias">
 ##INFO=<ID=SOMATIC,Number=0,Type=Flag,Description="Somatic event">
 ##INFO=<ID=VALIDATED,Number=0,Type=Flag,Description="Validated by follow-up experiment">
+##INFO=<ID=VQSLOD,Number=1,Type=Float,Description="Log odds ratio of being a true variant versus being false under the trained gaussian mixture model">
+##INFO=<ID=culprit,Number=1,Type=String,Description="The annotation which was the worst performing in the Gaussian mixture model, likely the reason why the variant was filtered out">
 ##contig=<ID=1,length=249250621>
 ##contig=<ID=2,length=249250621>
 ##contig=<ID=13,length=249250621>

--- a/adam-core/src/test/scala/org/bdgenomics/adam/rdd/ADAMContextSuite.scala
+++ b/adam-core/src/test/scala/org/bdgenomics/adam/rdd/ADAMContextSuite.scala
@@ -26,6 +26,7 @@ import org.apache.parquet.filter2.dsl.Dsl._
 import org.apache.parquet.filter2.predicate.FilterPredicate
 import org.apache.parquet.hadoop.metadata.CompressionCodecName
 import org.apache.spark.rdd.RDD
+import org.bdgenomics.adam.converters.SupportedHeaderLines
 import org.bdgenomics.adam.models._
 import org.bdgenomics.adam.rdd.ADAMContext._
 import org.bdgenomics.adam.rdd.read.AlignedReadRDD
@@ -148,7 +149,11 @@ class ADAMContextSuite extends ADAMFunSuite {
   sparkTest("can read a small .vcf file") {
     val path = testFile("small.vcf")
 
-    val vcs = sc.loadGenotypes(path).toVariantContextRDD.rdd.collect.sortBy(_.position)
+    val gts = sc.loadGenotypes(path)
+    assert(gts.headerLines.toSet === SupportedHeaderLines.allHeaderLines.toSet)
+    val vcRdd = gts.toVariantContextRDD
+    assert(vcRdd.headerLines.toSet === SupportedHeaderLines.allHeaderLines.toSet)
+    val vcs = vcRdd.rdd.collect.sortBy(_.position)
     assert(vcs.size === 6)
 
     val vc = vcs.head
@@ -163,30 +168,35 @@ class ADAMContextSuite extends ADAMFunSuite {
     val path = testFile("test.vcf.gz")
     val vcs = sc.loadVcf(path)
     assert(vcs.rdd.count === 6)
+    assert(vcs.headerLines.toSet === SupportedHeaderLines.allHeaderLines.toSet)
   }
 
   sparkTest("can read a BGZF gzipped .vcf file with .gz file extension") {
     val path = testFile("test.vcf.bgzf.gz")
     val vcs = sc.loadVcf(path)
     assert(vcs.rdd.count === 6)
+    assert(vcs.headerLines.toSet === SupportedHeaderLines.allHeaderLines.toSet)
   }
 
   sparkTest("can read a BGZF gzipped .vcf file with .bgz file extension") {
     val path = testFile("test.vcf.bgz")
     val vcs = sc.loadVcf(path)
     assert(vcs.rdd.count === 6)
+    assert(vcs.headerLines.toSet === SupportedHeaderLines.allHeaderLines.toSet)
   }
 
   ignore("can read an uncompressed BCFv2.2 file") { // see https://github.com/samtools/htsjdk/issues/507
     val path = testFile("test.uncompressed.bcf")
     val vcs = sc.loadVcf(path)
     assert(vcs.rdd.count === 6)
+    assert(vcs.headerLines.toSet === SupportedHeaderLines.allHeaderLines.toSet)
   }
 
   ignore("can read a BGZF compressed BCFv2.2 file") { // see https://github.com/samtools/htsjdk/issues/507
     val path = testFile("test.compressed.bcf")
     val vcs = sc.loadVcf(path)
     assert(vcs.rdd.count === 6)
+    assert(vcs.headerLines.toSet === SupportedHeaderLines.allHeaderLines.toSet)
   }
 
   sparkTest("loadIndexedVcf with 1 ReferenceRegion") {
@@ -194,6 +204,7 @@ class ADAMContextSuite extends ADAMFunSuite {
     val refRegion = ReferenceRegion("22", 16097643, 16098647)
     val vcs = sc.loadIndexedVcf(path, refRegion)
     assert(vcs.rdd.count == 17)
+    assert(vcs.headerLines.toSet === SupportedHeaderLines.allHeaderLines.toSet)
   }
 
   sparkTest("loadIndexedVcf with multiple ReferenceRegions") {
@@ -202,6 +213,7 @@ class ADAMContextSuite extends ADAMFunSuite {
     val refRegion2 = ReferenceRegion("22", 16097643, 16098647)
     val vcs = sc.loadIndexedVcf(path, Iterable(refRegion1, refRegion2))
     assert(vcs.rdd.count == 23)
+    assert(vcs.headerLines.toSet === SupportedHeaderLines.allHeaderLines.toSet)
   }
 
   (1 to 4) foreach { testNumber =>
@@ -255,6 +267,7 @@ class ADAMContextSuite extends ADAMFunSuite {
     val path = testFile("bqsr1.vcf")
 
     val variants = sc.loadVariants(path)
+    assert(variants.headerLines.toSet === SupportedHeaderLines.allHeaderLines.toSet)
     assert(variants.rdd.count === 681)
 
     val loc = tmpLocation()
@@ -264,6 +277,7 @@ class ADAMContextSuite extends ADAMFunSuite {
     // the following only reads one row group
     val adamVariants = sc.loadParquetVariants(loc, predicate = Some(pred))
     assert(adamVariants.rdd.count === 1)
+    assert(adamVariants.headerLines.toSet === SupportedHeaderLines.allHeaderLines.toSet)
   }
 
   sparkTest("saveAsParquet with file path") {

--- a/adam-core/src/test/scala/org/bdgenomics/adam/rdd/ADAMContextSuite.scala
+++ b/adam-core/src/test/scala/org/bdgenomics/adam/rdd/ADAMContextSuite.scala
@@ -26,7 +26,6 @@ import org.apache.parquet.filter2.dsl.Dsl._
 import org.apache.parquet.filter2.predicate.FilterPredicate
 import org.apache.parquet.hadoop.metadata.CompressionCodecName
 import org.apache.spark.rdd.RDD
-import org.bdgenomics.adam.converters.SupportedHeaderLines
 import org.bdgenomics.adam.models._
 import org.bdgenomics.adam.rdd.ADAMContext._
 import org.bdgenomics.adam.rdd.read.AlignedReadRDD
@@ -150,9 +149,7 @@ class ADAMContextSuite extends ADAMFunSuite {
     val path = testFile("small.vcf")
 
     val gts = sc.loadGenotypes(path)
-    assert(gts.headerLines.toSet === SupportedHeaderLines.allHeaderLines.toSet)
     val vcRdd = gts.toVariantContextRDD
-    assert(vcRdd.headerLines.toSet === SupportedHeaderLines.allHeaderLines.toSet)
     val vcs = vcRdd.rdd.collect.sortBy(_.position)
     assert(vcs.size === 6)
 
@@ -168,35 +165,30 @@ class ADAMContextSuite extends ADAMFunSuite {
     val path = testFile("test.vcf.gz")
     val vcs = sc.loadVcf(path)
     assert(vcs.rdd.count === 6)
-    assert(vcs.headerLines.toSet === SupportedHeaderLines.allHeaderLines.toSet)
   }
 
   sparkTest("can read a BGZF gzipped .vcf file with .gz file extension") {
     val path = testFile("test.vcf.bgzf.gz")
     val vcs = sc.loadVcf(path)
     assert(vcs.rdd.count === 6)
-    assert(vcs.headerLines.toSet === SupportedHeaderLines.allHeaderLines.toSet)
   }
 
   sparkTest("can read a BGZF gzipped .vcf file with .bgz file extension") {
     val path = testFile("test.vcf.bgz")
     val vcs = sc.loadVcf(path)
     assert(vcs.rdd.count === 6)
-    assert(vcs.headerLines.toSet === SupportedHeaderLines.allHeaderLines.toSet)
   }
 
   ignore("can read an uncompressed BCFv2.2 file") { // see https://github.com/samtools/htsjdk/issues/507
     val path = testFile("test.uncompressed.bcf")
     val vcs = sc.loadVcf(path)
     assert(vcs.rdd.count === 6)
-    assert(vcs.headerLines.toSet === SupportedHeaderLines.allHeaderLines.toSet)
   }
 
   ignore("can read a BGZF compressed BCFv2.2 file") { // see https://github.com/samtools/htsjdk/issues/507
     val path = testFile("test.compressed.bcf")
     val vcs = sc.loadVcf(path)
     assert(vcs.rdd.count === 6)
-    assert(vcs.headerLines.toSet === SupportedHeaderLines.allHeaderLines.toSet)
   }
 
   sparkTest("loadIndexedVcf with 1 ReferenceRegion") {
@@ -204,7 +196,6 @@ class ADAMContextSuite extends ADAMFunSuite {
     val refRegion = ReferenceRegion("22", 16097643, 16098647)
     val vcs = sc.loadIndexedVcf(path, refRegion)
     assert(vcs.rdd.count == 17)
-    assert(vcs.headerLines.toSet === SupportedHeaderLines.allHeaderLines.toSet)
   }
 
   sparkTest("loadIndexedVcf with multiple ReferenceRegions") {
@@ -213,7 +204,6 @@ class ADAMContextSuite extends ADAMFunSuite {
     val refRegion2 = ReferenceRegion("22", 16097643, 16098647)
     val vcs = sc.loadIndexedVcf(path, Iterable(refRegion1, refRegion2))
     assert(vcs.rdd.count == 23)
-    assert(vcs.headerLines.toSet === SupportedHeaderLines.allHeaderLines.toSet)
   }
 
   (1 to 4) foreach { testNumber =>
@@ -267,7 +257,6 @@ class ADAMContextSuite extends ADAMFunSuite {
     val path = testFile("bqsr1.vcf")
 
     val variants = sc.loadVariants(path)
-    assert(variants.headerLines.toSet === SupportedHeaderLines.allHeaderLines.toSet)
     assert(variants.rdd.count === 681)
 
     val loc = tmpLocation()
@@ -277,7 +266,6 @@ class ADAMContextSuite extends ADAMFunSuite {
     // the following only reads one row group
     val adamVariants = sc.loadParquetVariants(loc, predicate = Some(pred))
     assert(adamVariants.rdd.count === 1)
-    assert(adamVariants.headerLines.toSet === SupportedHeaderLines.allHeaderLines.toSet)
   }
 
   sparkTest("saveAsParquet with file path") {

--- a/adam-core/src/test/scala/org/bdgenomics/adam/rdd/variant/VariantContextRDDSuite.scala
+++ b/adam-core/src/test/scala/org/bdgenomics/adam/rdd/variant/VariantContextRDDSuite.scala
@@ -140,7 +140,6 @@ class VariantContextRDDSuite extends ADAMFunSuite {
     variants.sort()
       .saveAsVcf(outputPath,
         asSingleFile = true)
-    println(outputPath)
 
     checkFiles(outputPath, testFile("sorted.vcf"))
   }
@@ -154,7 +153,6 @@ class VariantContextRDDSuite extends ADAMFunSuite {
       .saveAsVcf(outputPath,
         asSingleFile = true)
 
-    println(outputPath)
     checkFiles(outputPath, testFile("sorted.lex.vcf"))
   }
 }

--- a/adam-core/src/test/scala/org/bdgenomics/adam/rdd/variant/VariantContextRDDSuite.scala
+++ b/adam-core/src/test/scala/org/bdgenomics/adam/rdd/variant/VariantContextRDDSuite.scala
@@ -140,6 +140,7 @@ class VariantContextRDDSuite extends ADAMFunSuite {
     variants.sort()
       .saveAsVcf(outputPath,
         asSingleFile = true)
+    println(outputPath)
 
     checkFiles(outputPath, testFile("sorted.vcf"))
   }
@@ -153,6 +154,7 @@ class VariantContextRDDSuite extends ADAMFunSuite {
       .saveAsVcf(outputPath,
         asSingleFile = true)
 
+    println(outputPath)
     checkFiles(outputPath, testFile("sorted.lex.vcf"))
   }
 }


### PR DESCRIPTION
Resolves #1233. Adds a `headerLines` field to all Variant-related GenomicRDDs. In the current implementation, this field is populated by the set of all header lines for all INFO/FORMAT fields that we support. In a future patch, we will also store the header lines that correspond to fields that do not map to a specific field in the Variant/Genotype schema, and that are stored in an
attribute map.