### PR TITLE
use ParsedLoci in loadIndexedBam

### DIFF
--- a/adam-core/pom.xml
+++ b/adam-core/pom.xml
@@ -121,6 +121,10 @@
       <artifactId>bdg-formats</artifactId>
     </dependency>
     <dependency>
+      <groupId>org.hammerlab</groupId>
+      <artifactId>genomic-loci_${scala.version.prefix}</artifactId>
+    </dependency>
+    <dependency>
       <groupId>commons-io</groupId>
       <artifactId>commons-io</artifactId>
     </dependency>

--- a/adam-core/src/main/scala/org/bdgenomics/adam/models/SequenceDictionary.scala
+++ b/adam-core/src/main/scala/org/bdgenomics/adam/models/SequenceDictionary.scala
@@ -17,11 +17,10 @@
  */
 package org.bdgenomics.adam.models
 
-import htsjdk.samtools.{ SAMFileHeader, SAMSequenceRecord, SAMSequenceDictionary }
+import htsjdk.samtools.{ SAMFileHeader, SAMSequenceDictionary, SAMSequenceRecord }
 import htsjdk.variant.vcf.VCFHeader
-import org.apache.avro.generic.IndexedRecord
-import org.bdgenomics.formats.avro.{ AlignmentRecord, NucleotideContigFragment, Contig }
-import scala.collection._
+import org.bdgenomics.formats.avro.{ Contig, NucleotideContigFragment }
+import org.hammerlab.genomics.reference.ContigLengths
 import scala.collection.JavaConversions._
 
 /**
@@ -118,6 +117,8 @@ class SequenceDictionary(val records: Vector[SequenceRecord]) extends Serializab
   assert(byName.size == records.length, "SequenceRecords with duplicate names aren't permitted")
 
   private val hasSequenceOrdering = records.forall(_.referenceIndex.isDefined)
+
+  def contigLengths: ContigLengths = byName.mapValues(_.length)
 
   /**
    * @param that Sequence dictionary to compare against.

--- a/pom.xml
+++ b/pom.xml
@@ -359,6 +359,11 @@
         <version>${project.version}</version>
       </dependency>
       <dependency>
+        <groupId>org.hammerlab</groupId>
+        <artifactId>genomic-loci_${scala.version.prefix}</artifactId>
+        <version>1.3.0</version>
+      </dependency>
+      <dependency>
         <groupId>org.bdgenomics.adam</groupId>
         <artifactId>adam-apis_${scala.version.prefix}</artifactId>
         <version>${project.version}</version>


### PR DESCRIPTION
I recently factored a small library for parsing string-representations of (possibly open-ended, e.g. `chr1`, `chr1:100-`) loci ranges out of guacamole and over to https://github.com/hammerlab/genomic-loci, because I was preparing to use it across a few of my projects, and in particular wanted it plus adam-core's `loadIndexedBam` functionality, which this PR adds.

@fnothaft you mentioned there is some similar loci-parsing code laying around somewhere in BDG, lmk if I should find/consider it instead / in addition to this.