### PR TITLE
HBase as a separate repo

### DIFF
--- a/adam-cli/pom.xml
+++ b/adam-cli/pom.xml
@@ -160,6 +160,10 @@
       <scope>test</scope>
     </dependency>
     <dependency>
+      <groupId>org.bdgenomics.bdghbase</groupId>
+      <artifactId>bdghbase-core</artifactId>
+    </dependency>
+    <dependency>
       <groupId>org.scala-lang</groupId>
       <artifactId>scala-library</artifactId>
     </dependency>

--- a/adam-cli/src/main/scala/org/bdgenomics/adam/cli/Vcf2HBase.scala
+++ b/adam-cli/src/main/scala/org/bdgenomics/adam/cli/Vcf2HBase.scala
@@ -1,0 +1,83 @@
+/**
+ * Licensed to Big Data Genomics (BDG) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The BDG licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.bdgenomics.adam.cli
+
+import org.apache.spark.SparkContext
+import org.bdgenomics.adam.hbase.HBaseFunctions
+import org.bdgenomics.adam.instrumentation.Timers._
+import org.bdgenomics.adam.models.{ RecordGroupDictionary, SequenceDictionary, SnpTable }
+import org.bdgenomics.adam.projections.{ AlignmentRecordField, Filter }
+import org.bdgenomics.adam.rdd.ADAMContext._
+import org.bdgenomics.adam.rdd.ADAMSaveAnyArgs
+import org.bdgenomics.adam.rdd.read.{ AlignedReadRDD, AlignmentRecordRDD, MDTagging }
+import org.bdgenomics.adam.rich.RichVariant
+import org.bdgenomics.formats.avro.AlignmentRecord
+import org.bdgenomics.utils.cli._
+import org.bdgenomics.utils.misc.Logging
+import org.kohsuke.args4j.{ Argument, Option => Args4jOption }
+
+object Vcf2HBase extends BDGCommandCompanion {
+  val commandName = "Vcf2HBase"
+  val commandDescription = "Write a VCF file to HBase"
+
+  def apply(cmdLine: Array[String]) = {
+    new Vcf2HBase(Args4j[Vcf2HBaseArgs](cmdLine))
+  }
+}
+
+class Vcf2HBaseArgs extends Args4jBase {
+
+  @Argument(required = true, metaVar = "VCF", usage = "The VCF file to convert", index = 0)
+  var vcfPath: String = _
+
+  @Args4jOption(required = true, name = "-hbase_table", usage = "HBase table name in which to load VCF file")
+  var hbaseTable: String = null
+
+  @Args4jOption(required = true, name = "-seq_dict_id", usage = "User defined name to apply to the sequence dictionary create from this VCF, or name of existing sequence dictionary to be used")
+  var seqDictId: String = null
+
+  @Args4jOption(required = false, name = "-use_existing_seqdict", usage = "Use an existing sequence dictionary, don't write a new one")
+  var useExistingSeqDict: Boolean = false
+
+  @Args4jOption(required = false, name = "-repartition", usage = "Repartition into N partitions prior to writing to HBase")
+  var repartitionNum: Int = 0
+
+  @Args4jOption(required = true, name = "-staging_folder", usage = "Location for temporary files during bulk load")
+  var stagingFolder: String = null
+
+}
+
+class Vcf2HBase(protected val args: Vcf2HBaseArgs) extends BDGSparkCommand[Vcf2HBaseArgs] with Logging {
+  val companion = Transform
+
+  def run(sc: SparkContext) {
+
+    val vcRdd = sc.loadVcf(args.vcfPath)
+
+    val hbaseConnection = new HBaseFunctions.ADAMHBaseConnection(sc)
+    HBaseFunctions.saveVariantContextRDDToHBaseBulk(hbaseConnection,
+      vcRdd,
+      args.hbaseTable,
+      args.seqDictId,
+      true,
+      Some(args.repartitionNum),
+      args.stagingFolder)
+
+  }
+
+}

--- a/pom.xml
+++ b/pom.xml
@@ -416,6 +416,11 @@
         <version>${bdg-utils.version}</version>
       </dependency>
       <dependency>
+        <groupId>org.bdgenomics.bdghbase</groupId>
+        <artifactId>bdghbase-core</artifactId>
+        <version>0.0.1-SNAPSHOT</version>
+      </dependency>
+      <dependency>
         <groupId>org.apache.hadoop</groupId>
         <artifactId>hadoop-client</artifactId>
         <version>${hadoop.version}</version>


### PR DESCRIPTION
Requires: https://github.com/jpdna/bdghbase commit  809c554

This PR is a stub for any changes to ADAM to make use of HBase code as a separate repo, and discussion of that approach.

I decided to try splitting out the HBase code into a different repo, bdghbase above.
The motivation I see for this are:

1) We may have a number of different data backends including HBase -  Kudu for one.  It may be better not to put these all into the main ADAM repo.

2) I wasn't able to yet find a way to get "provided" dependency for hbase library code to work, so it will be bloating the compiled hbase module for now , better to keep that out of main ADAM, even if its working fine.

3) Testing with CI is going to be a pain for hbase, for the moment tests are going to require that an hbase instance is accessible, as I can't seem to get the mock "mini" hbase cluster to work.  Thus this complicates testing and CI, so better to keep that complexity in separate repo.

4) nice to have fast compilation time for the hbase code under development

Choice of separate repo or not seems irrelevant to how adam-shell or downstream applications using ADAM as a library would be built, I can interact with ADAM and hbase from adam-shell just as before using this PR.   

- I plan to add a "hbase" profile that will turn of the hbase dependencies in ADAM, sound good?

- I will clearly have to publish bdghbase to maven was currently do for bdg-utils and other seperate bdg repos.

- I'm not sure how to handle the CLI in this instance for hbase.  We could include the vcf2Hbase CLI code as it currently is in this PR, and perhaps it would only work in the -hbase profile was turned on.  We'd want the command and cli help to also be different based on the profile.
This doesn't seem ideal to me though - if bdghbase (or bdgkudu) is to be a separate repo, I feel like the CLI code should be in that repo as well, but I am not sure how to best integrate it with the current ADAM CLI, thoughts?

For now I am looking for general comments on this approach.  I'll ask later for review of the hbase code, as I am nearly done addressing the comments in: #1246



