### PR TITLE
[ADAM-1280] Silence CRAM logging in tests.

### DIFF
--- a/adam-core/src/test/scala/org/bdgenomics/adam/util/ADAMFunSuite.scala
+++ b/adam-core/src/test/scala/org/bdgenomics/adam/util/ADAMFunSuite.scala
@@ -17,9 +17,14 @@
  */
 package org.bdgenomics.adam.util
 
+import htsjdk.samtools.util.Log
+import java.util.logging.Level
 import org.bdgenomics.utils.misc.SparkFunSuite
 
-trait ADAMFunSuite extends SparkFunSuite {
+abstract class ADAMFunSuite extends SparkFunSuite {
+
+  // added to resolve #1280
+  Log.setGlobalLogLevel(Log.LogLevel.ERROR)
 
   override val appName: String = "adam"
   override val properties: Map[String, String] = Map(


### PR DESCRIPTION
Resolves #1280.

I tried for a while but couldn't silence the Parquet logging in the tests. We're still on Parquet 1.8.1, which messes with the Java util logging package, while Parquet 1.9.0 upgrades to Log4j. I figured that we'll punt on silencing the Parquet logs until we upgrade to 1.9.0, since that should then be a trivial fix.