### PR TITLE
Make ADAMContext and JavaADAMContext constructors public

### DIFF
--- a/adam-apis/src/main/scala/org/bdgenomics/adam/apis/java/JavaADAMContext.scala
+++ b/adam-apis/src/main/scala/org/bdgenomics/adam/apis/java/JavaADAMContext.scala
@@ -40,7 +40,7 @@ object JavaADAMContext {
   implicit def toADAMContext(jac: JavaADAMContext): ADAMContext = jac.ac
 }
 
-class JavaADAMContext private (val ac: ADAMContext) extends Serializable {
+class JavaADAMContext(val ac: ADAMContext) extends Serializable {
 
   /**
    * @return Returns the Java Spark Context associated with this Java ADAM Context.

--- a/adam-apis/src/test/scala/org/bdgenomics/adam/apis/java/JavaADAMContextSuite.scala
+++ b/adam-apis/src/test/scala/org/bdgenomics/adam/apis/java/JavaADAMContextSuite.scala
@@ -20,11 +20,16 @@ package org.bdgenomics.adam.apis.java
 import org.apache.spark.rdd.RDD
 import org.apache.spark.api.java.JavaRDD._
 import org.apache.spark.api.java.JavaRDD
+import org.bdgenomics.adam.rdd.ADAMContext
 import org.bdgenomics.adam.rdd.ADAMContext._
 import org.bdgenomics.adam.util.ADAMFunSuite
 import org.bdgenomics.formats.avro.AlignmentRecord
 
 class JavaADAMContextSuite extends ADAMFunSuite {
+
+  sparkTest("ctr is accessible") {
+    new JavaADAMContext(new ADAMContext(sc))
+  }
 
   sparkTest("can read and write a small .SAM file") {
     val path = copyResource("small.sam")

--- a/adam-core/src/main/scala/org/bdgenomics/adam/rdd/ADAMContext.scala
+++ b/adam-core/src/main/scala/org/bdgenomics/adam/rdd/ADAMContext.scala
@@ -156,7 +156,7 @@ import org.bdgenomics.adam.rdd.ADAMContext._
  *
  * @param sc The SparkContext to wrap.
  */
-class ADAMContext private (@transient val sc: SparkContext) extends Serializable with Logging {
+class ADAMContext(@transient val sc: SparkContext) extends Serializable with Logging {
 
   /**
    * @param samHeader The header to extract a sequence dictionary from.

--- a/adam-core/src/test/scala/org/bdgenomics/adam/rdd/ADAMContextSuite.scala
+++ b/adam-core/src/test/scala/org/bdgenomics/adam/rdd/ADAMContextSuite.scala
@@ -48,6 +48,10 @@ case class TestSaveArgs(var outputPath: String) extends ADAMSaveAnyArgs {
 
 class ADAMContextSuite extends ADAMFunSuite {
 
+  sparkTest("ctr is accessible") {
+    new ADAMContext(sc)
+  }
+
   sparkTest("sc.loadParquet should not fail on unmapped reads") {
     val readsFilepath = testFile("unmapped.sam")
 


### PR DESCRIPTION
Fixes #1296 

This came up again when I was making code style fixes to adam-apis (e.g. https://github.com/bigdatagenomics/adam/blob/master/adam-apis/src/test/java/org/bdgenomics/adam/apis/java/JavaADAMAnnotationConduit.java#L44).