### PR TITLE
Support deduping fragments

### DIFF
--- a/adam-core/src/main/scala/org/bdgenomics/adam/rdd/ADAMContext.scala
+++ b/adam-core/src/main/scala/org/bdgenomics/adam/rdd/ADAMContext.scala
@@ -1560,7 +1560,7 @@ class ADAMContext(@transient val sc: SparkContext) extends Serializable with Log
       if (filesAreQuerynameSorted(filePath)) {
         log.info(s"Loading $filePath as queryname sorted SAM/BAM and converting to Fragments.")
         sc.hadoopConfiguration.setBoolean(BAMInputFormat.KEEP_PAIRED_READS_TOGETHER_PROPERTY,
-                                          true)        
+          true)
         loadBam(filePath).querynameSortedToFragments
       } else {
         log.info(s"Loading $filePath as SAM/BAM and converting to Fragments.")

--- a/adam-core/src/main/scala/org/bdgenomics/adam/rdd/ADAMContext.scala
+++ b/adam-core/src/main/scala/org/bdgenomics/adam/rdd/ADAMContext.scala
@@ -486,6 +486,51 @@ class ADAMContext(@transient val sc: SparkContext) extends Serializable with Log
   }
 
   /**
+   * Checks to see if a set of SAM/BAM/CRAM files are queryname sorted.
+   *
+   * If we are loading fragments and the SAM/BAM/CRAM files are sorted by the
+   * read names, this implies that all of the reads in a pair are consecutive in
+   * the file. If this is the case, we can configure Hadoop-BAM to keep all of
+   * the reads from a fragment in a single split. This allows us to eliminate
+   * an expensive groupBy when loading a BAM file as fragments.
+   *
+   * @param filePath The file path to load reads from. Globs/directories are
+   *   supported.
+   * @param stringency The validation stringency to use when reading the header.
+   * @return Returns true if all files described by the filepath are queryname
+   *   sorted.
+   */
+  private[rdd] def filesAreQuerynameSorted(filePath: String,
+                                           stringency: ValidationStringency = ValidationStringency.STRICT): Boolean = {
+    val path = new Path(filePath)
+
+    val bamFiles = getFsAndFiles(path)
+    val filteredFiles = bamFiles.filter(p => {
+      val pPath = p.getName()
+      pPath.endsWith(".bam") || pPath.endsWith(".cram") ||
+        pPath.endsWith(".sam") || pPath.startsWith("part-")
+    })
+
+    filteredFiles
+      .forall(fp => {
+        try {
+          // the sort order is saved in the file header
+          sc.hadoopConfiguration.set(SAMHeaderReader.VALIDATION_STRINGENCY_PROPERTY, stringency.toString)
+          val samHeader = SAMHeaderReader.readSAMHeaderFrom(fp, sc.hadoopConfiguration)
+
+          samHeader.getSortOrder == SAMFileHeader.SortOrder.queryname
+        } catch {
+          case e: Throwable => {
+            log.error(
+              s"Loading header failed for $fp:n${e.getMessage}\n\t${e.getStackTrace.take(25).map(_.toString).mkString("\n\t")}"
+            )
+            false
+          }
+        }
+      })
+  }
+
+  /**
    * Loads a SAM/BAM file.
    *
    * This reads the sequence and record group dictionaries from the SAM/BAM file
@@ -1510,8 +1555,17 @@ class ADAMContext(@transient val sc: SparkContext) extends Serializable with Log
     if (filePath.endsWith(".sam") ||
       filePath.endsWith(".bam") ||
       filePath.endsWith(".cram")) {
-      log.info(s"Loading $filePath as SAM/BAM and converting to Fragments.")
-      loadBam(filePath).toFragments
+
+      // check to see if the input files are all queryname sorted
+      if (filesAreQuerynameSorted(filePath)) {
+        log.info(s"Loading $filePath as queryname sorted SAM/BAM and converting to Fragments.")
+        sc.hadoopConfiguration.setBoolean(BAMInputFormat.KEEP_PAIRED_READS_TOGETHER_PROPERTY,
+                                          true)        
+        loadBam(filePath).querynameSortedToFragments
+      } else {
+        log.info(s"Loading $filePath as SAM/BAM and converting to Fragments.")
+        loadBam(filePath).toFragments
+      }
     } else if (filePath.endsWith(".reads.adam")) {
       log.info(s"Loading $filePath as ADAM AlignmentRecords and converting to Fragments.")
       loadAlignments(filePath).toFragments

--- a/adam-core/src/main/scala/org/bdgenomics/adam/rdd/fragment/FragmentRDD.scala
+++ b/adam-core/src/main/scala/org/bdgenomics/adam/rdd/fragment/FragmentRDD.scala
@@ -19,6 +19,7 @@ package org.bdgenomics.adam.rdd.fragment
 
 import org.apache.spark.rdd.RDD
 import org.bdgenomics.adam.converters.AlignmentRecordConverter
+import org.bdgenomics.adam.instrumentation.Timers._
 import org.bdgenomics.adam.models.{
   RecordGroupDictionary,
   ReferenceRegion,
@@ -29,6 +30,7 @@ import org.bdgenomics.adam.rdd.{ AvroReadGroupGenomicRDD, JavaSaveArgs }
 import org.bdgenomics.adam.rdd.read.{
   AlignedReadRDD,
   AlignmentRecordRDD,
+  MarkDuplicates,
   UnalignedReadRDD
 }
 import org.bdgenomics.adam.serialization.AvroSerializer
@@ -122,6 +124,16 @@ case class FragmentRDD(rdd: RDD[Fragment],
     } else {
       AlignedReadRDD(newRdd, sequences, recordGroups)
     }
+  }
+
+  /**
+   * Marks reads as possible fragment duplicates.
+   *
+   * @return A new RDD where reads have the duplicate read flag set. Duplicate
+   *   reads are NOT filtered out.
+   */
+  def markDuplicates(): FragmentRDD = MarkDuplicatesInDriver.time {
+    replaceRdd(MarkDuplicates(this))
   }
 
   /**

--- a/adam-core/src/main/scala/org/bdgenomics/adam/rdd/read/AlignmentRecordRDD.scala
+++ b/adam-core/src/main/scala/org/bdgenomics/adam/rdd/read/AlignmentRecordRDD.scala
@@ -113,6 +113,29 @@ sealed trait AlignmentRecordRDD extends AvroReadGroupGenomicRDD[AlignmentRecord,
   }
 
   /**
+   * Groups all reads by record group and read name.
+   *
+   * @return SingleReadBuckets with primary, secondary and unmapped reads
+   */
+  private def locallyGroupReadsByFragment(): RDD[SingleReadBucket] = {
+    SingleReadBucket.fromQuerynameSorted(rdd)
+  }
+
+  /**
+   * Convert this set of reads into fragments.
+   *
+   * Assumes that reads are sorted by readname.
+   * *
+   * @return Returns a FragmentRDD where all reads have been grouped together by
+   *   the original sequence fragment they come from.
+   */
+  private[rdd] def querynameSortedToFragments: FragmentRDD = {
+    FragmentRDD(locallyGroupReadsByFragment().map(_.toFragment),
+      sequences,
+      recordGroups)
+  }
+
+  /**
    * Converts this set of reads into a corresponding CoverageRDD.
    *
    * @param collapse Determines whether to merge adjacent coverage elements with the same score a single coverage.

--- a/adam-core/src/main/scala/org/bdgenomics/adam/rdd/read/SingleReadBucket.scala
+++ b/adam-core/src/main/scala/org/bdgenomics/adam/rdd/read/SingleReadBucket.scala
@@ -90,6 +90,10 @@ private[read] object SingleReadBucket extends Logging {
         fromGroupedReads(reads)
       })
   }
+
+  def apply(fragment: Fragment): SingleReadBucket = {
+    fromGroupedReads(fragment.getAlignments.toIterable)
+  }
 }
 
 /**

--- a/adam-core/src/test/scala/org/bdgenomics/adam/rdd/read/MarkDuplicatesSuite.scala
+++ b/adam-core/src/test/scala/org/bdgenomics/adam/rdd/read/MarkDuplicatesSuite.scala
@@ -204,4 +204,107 @@ class MarkDuplicatesSuite extends ADAMFunSuite {
     assert(dups.forall(p => p.getReadName.startsWith("poor")))
   }
 
+  private def markDuplicateFragments(reads: AlignmentRecord*): Array[AlignmentRecord] = {
+    AlignedReadRDD(sc.parallelize(reads), SequenceDictionary.empty, rgd)
+      .toFragments
+      .markDuplicates()
+      .toReads
+      .rdd
+      .collect()
+  }
+
+  sparkTest("single fragment") {
+    val read = createMappedRead("0", 100, 200)
+    val marked = markDuplicateFragments(read)
+    // Can't have duplicates with a single read, should return the read unchanged.
+    assert(marked(0) == read)
+  }
+
+  sparkTest("fragments at different positions") {
+    val read1 = createMappedRead("0", 42, 142)
+    val read2 = createMappedRead("0", 43, 143)
+    val marked = markDuplicateFragments(read1, read2)
+    // Reads shouldn't be modified
+    assert(marked.contains(read1) && marked.contains(read2))
+  }
+
+  sparkTest("fragments at the same position") {
+    val poorReads = for (i <- 0 until 10) yield {
+      createMappedRead("1", 42, 142, avgPhredScore = 20, readName = "poor%d".format(i))
+    }
+    val bestRead = createMappedRead("1", 42, 142, avgPhredScore = 30, readName = "best")
+    val marked = markDuplicateFragments(List(bestRead) ++ poorReads: _*)
+    val (dups, nonDup) = marked.partition(p => p.getDuplicateRead)
+    assert(nonDup.size == 1 && nonDup(0) == bestRead)
+    assert(dups.forall(p => p.getReadName.startsWith("poor")))
+  }
+
+  sparkTest("fragments at the same position with clipping") {
+    val poorClippedReads = for (i <- 0 until 5) yield {
+      createMappedRead("1", 44, 142, numClippedBases = 2, avgPhredScore = 20, readName = "poorClipped%d".format(i))
+    }
+    val poorUnclippedReads = for (i <- 0 until 5) yield {
+      createMappedRead("1", 42, 142, avgPhredScore = 20, readName = "poorUnclipped%d".format(i))
+    }
+    val bestRead = createMappedRead("1", 42, 142, avgPhredScore = 30, readName = "best")
+    val marked = markDuplicateFragments(List(bestRead) ++ poorClippedReads ++ poorUnclippedReads: _*)
+    val (dups, nonDup) = marked.partition(p => p.getDuplicateRead)
+    assert(nonDup.size == 1 && nonDup(0) == bestRead)
+    assert(dups.forall(p => p.getReadName.startsWith("poor")))
+  }
+
+  sparkTest("fragments on reverse strand") {
+    val poorReads = for (i <- 0 until 7) yield {
+      createMappedRead("10", 42, 142, isNegativeStrand = true, avgPhredScore = 20, readName = "poor%d".format(i))
+    }
+    val bestRead = createMappedRead("10", 42, 142, isNegativeStrand = true, avgPhredScore = 30, readName = "best")
+    val marked = markDuplicateFragments(List(bestRead) ++ poorReads: _*)
+    val (dups, nonDup) = marked.partition(p => p.getDuplicateRead)
+    assert(nonDup.size == 1 && nonDup(0) == bestRead)
+    assert(dups.forall(p => p.getReadName.startsWith("poor")))
+  }
+
+  sparkTest("unmapped fragments") {
+    val unmappedReads = for (i <- 0 until 10) yield createUnmappedRead()
+    val marked = markDuplicateFragments(unmappedReads: _*)
+    assert(marked.size == unmappedReads.size)
+    // Unmapped reads should never be marked duplicates
+    assert(marked.forall(p => !p.getDuplicateRead))
+  }
+
+  sparkTest("read pairs as fragments") {
+    val poorPairs = for (
+      i <- 0 until 10;
+      read <- createPair("0", 10, 110, "0", 110, 210, avgPhredScore = 20, readName = "poor%d".format(i))
+    ) yield read
+    val bestPair = createPair("0", 10, 110, "0", 110, 210, avgPhredScore = 30, readName = "best")
+    val marked = markDuplicateFragments(bestPair ++ poorPairs: _*)
+    val (dups, nonDups) = marked.partition(_.getDuplicateRead)
+    assert(nonDups.size == 2 && nonDups.forall(p => p.getReadName.toString == "best"))
+    assert(dups.forall(p => p.getReadName.startsWith("poor")))
+  }
+
+  sparkTest("read pairs with fragments as fragments") {
+    val fragments = for (i <- 0 until 10) yield {
+      createMappedRead("2", 33, 133, avgPhredScore = 40, readName = "fragment%d".format(i))
+    }
+    // Even though the phred score is lower, pairs always score higher than fragments
+    val pairs = createPair("2", 33, 133, "2", 100, 200, avgPhredScore = 20, readName = "pair")
+    val marked = markDuplicateFragments(fragments ++ pairs: _*)
+    val (dups, nonDups) = marked.partition(_.getDuplicateRead)
+    assert(nonDups.size == 2 && nonDups.forall(p => p.getReadName.toString == "pair"))
+    assert(dups.size == 10 && dups.forall(p => p.getReadName.startsWith("fragment")))
+  }
+
+  sparkTest("chimeric fragments") {
+    val poorPairs = for (
+      i <- 0 until 10;
+      read <- createPair("ref0", 10, 110, "ref1", 110, 210, avgPhredScore = 20, readName = "poor%d".format(i))
+    ) yield read
+    val bestPair = createPair("ref0", 10, 110, "ref1", 110, 210, avgPhredScore = 30, readName = "best")
+    val marked = markDuplicateFragments(bestPair ++ poorPairs: _*)
+    val (dups, nonDups) = marked.partition(_.getDuplicateRead)
+    assert(nonDups.size == 2 && nonDups.forall(p => p.getReadName.toString == "best"))
+    assert(dups.forall(p => p.getReadName.startsWith("poor")))
+  }
 }

--- a/docs/source/50_cli.md
+++ b/docs/source/50_cli.md
@@ -422,6 +422,9 @@ fragment representations.
 `fragments2reads` takes the [default options](#default-args). Additionally,
 `fragments2reads` takes the following options:
 
+* `-mark_duplicate_reads`: Marks reads as fragment duplicates. Running mark
+  duplicates on fragments improves performance by eliminating one `groupBy`
+  (and therefore, a shuffle) versus running on reads.
 * `-sort_reads`: Sorts reads by alignment position. Unmapped reads are
   placed at the end of all reads. Contigs are ordered by sequence record
   index.


### PR DESCRIPTION
Resolves #1302 and #1303. Needs more tests and a Pandoc update. Also, I'm thinking the `reads2fragments` and `fragments2reads` CLIs should be merged down to a `transformFragments` CLI. Any disagreement?