### PR TITLE
Update move_to_spark_2.sh

### DIFF
--- a/scripts/move_to_spark_2.sh
+++ b/scripts/move_to_spark_2.sh
@@ -11,4 +11,5 @@ find . -name "pom.xml" -exec sed \
     -e "/utils-/ $substitution_cmd" \
     -e "/adam-/ $substitution_cmd" \
     -e "/spark.version/ s/1.6.3/2.0.0/g" \
+    -e "/SNAPSHOT/ s/0.20.1/0.20.0/g" \
     -i.spark2.bak '{}' \;


### PR DESCRIPTION
Fix adam-parent_2.11 SNAPSHOT version

In maven repository, adam-parent-spark2_2.11 is available only in version 0.20.0 and not in version 0.20.1 as coded in the pom.xml

Link:
https://mvnrepository.com/artifact/org.bdgenomics.adam/adam-parent-spark2_2.11