### PR TITLE
[ADAM-1322] Skip git commit plugin if .git is missing.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -195,6 +195,7 @@
             <gitDescribe>
               <always>true</always>
             </gitDescribe>
+            <failOnNoGitDirectory>false</failOnNoGitDirectory>
           </configuration>
         </plugin>
         <plugin>


### PR DESCRIPTION
Resolves #1322.