### PR TITLE
unroll/optimize some JavaConversions

### DIFF
--- a/adam-core/src/main/scala/org/bdgenomics/adam/models/SequenceDictionary.scala
+++ b/adam-core/src/main/scala/org/bdgenomics/adam/models/SequenceDictionary.scala
@@ -17,11 +17,12 @@
  */
 package org.bdgenomics.adam.models
 
-import htsjdk.samtools.{ SAMFileHeader, SAMSequenceRecord, SAMSequenceDictionary }
+import htsjdk.samtools.{ SAMFileHeader, SAMSequenceDictionary, SAMSequenceRecord }
 import htsjdk.variant.vcf.VCFHeader
-import org.bdgenomics.formats.avro.{ NucleotideContigFragment, Contig }
+import org.bdgenomics.formats.avro.{ Contig, NucleotideContigFragment }
+
+import scala.collection.JavaConversions.{ asScalaIterator, seqAsJavaList }
 import scala.collection._
-import scala.collection.JavaConversions._
 
 /**
  * Singleton object for creating SequenceDictionaries.
@@ -48,7 +49,7 @@ object SequenceDictionary {
    * @return A SequenceDictionary with populated sequence records.
    */
   def apply(dict: SAMSequenceDictionary): SequenceDictionary = {
-    new SequenceDictionary(dict.getSequences.map(SequenceRecord.fromSAMSequenceRecord).toVector)
+    new SequenceDictionary(dict.getSequences.iterator().map(SequenceRecord.fromSAMSequenceRecord).toVector)
   }
 
   /**
@@ -98,7 +99,7 @@ object SequenceDictionary {
    */
   def fromSAMSequenceDictionary(samDict: SAMSequenceDictionary): SequenceDictionary = {
     val samDictRecords = samDict.getSequences
-    new SequenceDictionary(samDictRecords.map(SequenceRecord.fromSAMSequenceRecord).toVector)
+    new SequenceDictionary(samDictRecords.iterator().map(SequenceRecord.fromSAMSequenceRecord).toVector)
   }
 }
 
@@ -143,7 +144,7 @@ class SequenceDictionary(val records: Vector[SequenceRecord]) extends Serializab
    * @param name The name of the contig to extract.
    * @return True if we have a sequence record for this contig.
    */
-  def containsRefName(name: String): Boolean = byName.containsKey(name)
+  def containsRefName(name: String): Boolean = byName.contains(name)
 
   /**
    * Adds a sequence record to this dictionary.
@@ -178,7 +179,7 @@ class SequenceDictionary(val records: Vector[SequenceRecord]) extends Serializab
    * @return Returns a SAM formatted sequence dictionary.
    */
   def toSAMSequenceDictionary: SAMSequenceDictionary = {
-    new SAMSequenceDictionary(records.map(_ toSAMSequenceRecord).toList)
+    new SAMSequenceDictionary(records.iterator.map(_.toSAMSequenceRecord).toList)
   }
 
   /**
@@ -222,7 +223,6 @@ class SequenceDictionary(val records: Vector[SequenceRecord]) extends Serializab
 
   private[adam] def toAvro: Seq[Contig] = {
     records.map(_.toADAMContig)
-      .toSeq
   }
 
   /**


### PR DESCRIPTION
[A `.contains` instead of a `.containsKey`](https://github.com/bigdatagenomics/adam/compare/master...ryan-williams:jc?expand=1#diff-0ed34ae1b42fa7d82a9c42d575490d99R147) is the main thing here; the latter does an O(n) conversion only to use a worse Java method (which takes `Object`, losing type-checking).

The others seem like they should save an O(n) on a `.map` by going through java/scala iterators instead of collections.