### PR TITLE
[ADAM-1307] move_to_spark_2 fails after moving to scala 2.11.

### DIFF
--- a/scripts/move_to_spark_2.sh
+++ b/scripts/move_to_spark_2.sh
@@ -6,8 +6,8 @@ svp="\${scala.version.prefix}"
 substitution_cmd="s/_$svp/-spark2_$svp/g"
 
 find . -name "pom.xml" -exec sed \
-    -e "/utils-/ s/_2\.10/-spark2_2.10/g" \
-    -e "/adam-/ s/_2\.10/-spark2_2.10/g" \
+    -e "/utils-/ s/_2\.1/-spark2_2.1/g" \
+    -e "/adam-/ s/_2\.1/-spark2_2.1/g" \
     -e "/utils-/ $substitution_cmd" \
     -e "/adam-/ $substitution_cmd" \
     -e "/spark.version/ s/1.6.3/2.0.0/g" \


### PR DESCRIPTION
The sed command that moved to Spark 2 looked for _2.10 in the ADAM pom artifact names. This commit fixes that issue by looking for _2.1 instead, which matches both Scala 2.10 and 2.11, as well as the eventual Scala 2.12. Resolves #1307.