### PR TITLE
[ADAM-1334] Clean up serialization issues in Broadcast region join.

### DIFF
--- a/adam-core/src/main/scala/org/bdgenomics/adam/models/ReferenceRegion.scala
+++ b/adam-core/src/main/scala/org/bdgenomics/adam/models/ReferenceRegion.scala
@@ -20,7 +20,7 @@ package org.bdgenomics.adam.models
 import com.esotericsoftware.kryo.io.{ Input, Output }
 import com.esotericsoftware.kryo.{ Kryo, Serializer }
 import org.bdgenomics.formats.avro._
-import org.bdgenomics.utils.intervalarray.Interval
+import org.bdgenomics.utils.interval.array.Interval
 import scala.math.{ max, min }
 
 trait ReferenceOrdering[T <: ReferenceRegion] extends Ordering[T] {

--- a/adam-core/src/main/scala/org/bdgenomics/adam/rdd/GenomicRDD.scala
+++ b/adam-core/src/main/scala/org/bdgenomics/adam/rdd/GenomicRDD.scala
@@ -32,7 +32,7 @@ import org.bdgenomics.adam.models.{
 }
 import org.bdgenomics.formats.avro.{ Contig, RecordGroupMetadata, Sample }
 import org.bdgenomics.utils.cli.SaveArgs
-import org.bdgenomics.utils.intervalarray.IntervalArray
+import org.bdgenomics.utils.interval.array.IntervalArray
 import scala.annotation.tailrec
 import scala.collection.JavaConversions._
 import scala.reflect.ClassTag
@@ -386,9 +386,7 @@ trait GenomicRDD[T, U <: GenomicRDD[T, U]] {
 
   protected def buildTree(
     rdd: RDD[(ReferenceRegion, T)])(
-      implicit tTag: ClassTag[T]): IntervalArray[ReferenceRegion, T] = {
-    IntervalArray(rdd)
-  }
+      implicit tTag: ClassTag[T]): IntervalArray[ReferenceRegion, T]
 
   /**
    * Performs a broadcast inner join between this RDD and another RDD.
@@ -767,6 +765,12 @@ trait GenomicRDD[T, U <: GenomicRDD[T, U]] {
 private case class GenericGenomicRDD[T](rdd: RDD[T],
                                         sequences: SequenceDictionary,
                                         regionFn: T => Seq[ReferenceRegion]) extends GenomicRDD[T, GenericGenomicRDD[T]] {
+
+  protected def buildTree(
+    rdd: RDD[(ReferenceRegion, T)])(
+      implicit tTag: ClassTag[T]): IntervalArray[ReferenceRegion, T] = {
+    IntervalArray(rdd)
+  }
 
   protected def replaceRdd(newRdd: RDD[T]): GenericGenomicRDD[T] = {
     copy(rdd = newRdd)

--- a/adam-core/src/main/scala/org/bdgenomics/adam/rdd/TreeRegionJoin.scala
+++ b/adam-core/src/main/scala/org/bdgenomics/adam/rdd/TreeRegionJoin.scala
@@ -20,7 +20,7 @@ package org.bdgenomics.adam.rdd
 import org.apache.spark.rdd.RDD
 import org.bdgenomics.adam.instrumentation.Timers._
 import org.bdgenomics.adam.models.ReferenceRegion
-import org.bdgenomics.utils.intervalarray.IntervalArray
+import org.bdgenomics.utils.interval.array.IntervalArray
 import scala.reflect.ClassTag
 
 /**

--- a/adam-core/src/main/scala/org/bdgenomics/adam/rdd/feature/FeatureRDD.scala
+++ b/adam-core/src/main/scala/org/bdgenomics/adam/rdd/feature/FeatureRDD.scala
@@ -28,9 +28,36 @@ import org.bdgenomics.adam.rdd.{
   JavaSaveArgs,
   SAMHeaderWriter
 }
+import org.bdgenomics.adam.serialization.AvroSerializer
 import org.bdgenomics.formats.avro.{ Feature, Strand }
+import org.bdgenomics.utils.interval.array.{
+  IntervalArray,
+  IntervalArraySerializer
+}
 import org.bdgenomics.utils.misc.Logging
 import scala.collection.JavaConversions._
+import scala.reflect.ClassTag
+
+private[adam] case class FeatureArray(
+    array: Array[(ReferenceRegion, Feature)],
+    maxIntervalWidth: Long) extends IntervalArray[ReferenceRegion, Feature] {
+
+  protected def replace(arr: Array[(ReferenceRegion, Feature)],
+                        maxWidth: Long): IntervalArray[ReferenceRegion, Feature] = {
+    FeatureArray(arr, maxWidth)
+  }
+}
+
+private[adam] class FeatureArraySerializer extends IntervalArraySerializer[ReferenceRegion, Feature, FeatureArray] {
+
+  protected val kSerializer = new ReferenceRegionSerializer
+  protected val tSerializer = new AvroSerializer[Feature]
+
+  protected def builder(arr: Array[(ReferenceRegion, Feature)],
+                        maxIntervalWidth: Long): FeatureArray = {
+    FeatureArray(arr, maxIntervalWidth)
+  }
+}
 
 private trait FeatureOrdering[T <: Feature] extends Ordering[T] {
   def allowNull(s: java.lang.String): java.lang.Integer = {
@@ -212,6 +239,11 @@ object FeatureRDD {
  */
 case class FeatureRDD(rdd: RDD[Feature],
                       sequences: SequenceDictionary) extends AvroGenomicRDD[Feature, FeatureRDD] with Logging {
+
+  protected def buildTree(rdd: RDD[(ReferenceRegion, Feature)])(
+    implicit tTag: ClassTag[Feature]): IntervalArray[ReferenceRegion, Feature] = {
+    IntervalArray(rdd, FeatureArray.apply(_, _))
+  }
 
   /**
    * Java friendly save function. Automatically detects the output format.

--- a/adam-core/src/main/scala/org/bdgenomics/adam/serialization/ADAMKryoRegistrator.scala
+++ b/adam-core/src/main/scala/org/bdgenomics/adam/serialization/ADAMKryoRegistrator.scala
@@ -139,11 +139,30 @@ class ADAMKryoRegistrator extends KryoRegistrator {
     kryo.register(classOf[org.bdgenomics.adam.models.SequenceDictionary])
     kryo.register(classOf[org.bdgenomics.adam.models.SequenceRecord])
     kryo.register(classOf[org.bdgenomics.adam.models.SnpTable])
-    kryo.register(classOf[org.bdgenomics.adam.models.VariantContext])
+    kryo.register(classOf[org.bdgenomics.adam.models.VariantContext],
+      new org.bdgenomics.adam.models.VariantContextSerializer)
 
     // org.bdgenomics.adam.rdd
     kryo.register(classOf[org.bdgenomics.adam.rdd.GenomeBins])
     kryo.register(Class.forName("org.bdgenomics.adam.rdd.SortedIntervalPartitionJoinAndGroupByLeft$$anonfun$postProcessHits$1"))
+
+    // IntervalArray registrations for org.bdgenomics.adam.rdd
+    kryo.register(classOf[org.bdgenomics.adam.rdd.read.AlignmentRecordArray],
+      new org.bdgenomics.adam.rdd.read.AlignmentRecordArraySerializer)
+    kryo.register(classOf[org.bdgenomics.adam.rdd.feature.CoverageArray],
+      new org.bdgenomics.adam.rdd.feature.CoverageArraySerializer(kryo))
+    kryo.register(classOf[org.bdgenomics.adam.rdd.feature.FeatureArray],
+      new org.bdgenomics.adam.rdd.feature.FeatureArraySerializer)
+    kryo.register(classOf[org.bdgenomics.adam.rdd.fragment.FragmentArray],
+      new org.bdgenomics.adam.rdd.fragment.FragmentArraySerializer)
+    kryo.register(classOf[org.bdgenomics.adam.rdd.variant.GenotypeArray],
+      new org.bdgenomics.adam.rdd.variant.GenotypeArraySerializer)
+    kryo.register(classOf[org.bdgenomics.adam.rdd.contig.NucleotideContigFragmentArray],
+      new org.bdgenomics.adam.rdd.contig.NucleotideContigFragmentArraySerializer)
+    kryo.register(classOf[org.bdgenomics.adam.rdd.variant.VariantArray],
+      new org.bdgenomics.adam.rdd.variant.VariantArraySerializer)
+    kryo.register(classOf[org.bdgenomics.adam.rdd.variant.VariantContextArray],
+      new org.bdgenomics.adam.rdd.variant.VariantContextArraySerializer)
 
     // org.bdgenomics.adam.rdd.read
     kryo.register(classOf[org.bdgenomics.adam.rdd.read.FlagStatMetrics])
@@ -219,24 +238,6 @@ class ADAMKryoRegistrator extends KryoRegistrator {
     kryo.register(classOf[org.bdgenomics.formats.avro.VariantAnnotationMessage])
     kryo.register(classOf[org.bdgenomics.formats.avro.VariantCallingAnnotations],
       new AvroSerializer[org.bdgenomics.formats.avro.VariantCallingAnnotations])
-
-    // org.bdgenomics.utils.intervalarray
-    // this is only exposed officially through the genomicrdd trait, thus, we'll only
-    // register it for said traits
-    kryo.register(classOf[org.bdgenomics.utils.intervalarray.IntervalArray[org.bdgenomics.adam.models.ReferenceRegion, org.bdgenomics.formats.avro.AlignmentRecord]],
-      new org.bdgenomics.utils.intervalarray.IntervalArraySerializer[org.bdgenomics.adam.models.ReferenceRegion, org.bdgenomics.formats.avro.AlignmentRecord](kryo))
-    kryo.register(classOf[org.bdgenomics.utils.intervalarray.IntervalArray[org.bdgenomics.adam.models.ReferenceRegion, org.bdgenomics.formats.avro.Feature]],
-      new org.bdgenomics.utils.intervalarray.IntervalArraySerializer[org.bdgenomics.adam.models.ReferenceRegion, org.bdgenomics.formats.avro.Feature](kryo))
-    kryo.register(classOf[org.bdgenomics.utils.intervalarray.IntervalArray[org.bdgenomics.adam.models.ReferenceRegion, org.bdgenomics.formats.avro.Fragment]],
-      new org.bdgenomics.utils.intervalarray.IntervalArraySerializer[org.bdgenomics.adam.models.ReferenceRegion, org.bdgenomics.formats.avro.Fragment](kryo))
-    kryo.register(classOf[org.bdgenomics.utils.intervalarray.IntervalArray[org.bdgenomics.adam.models.ReferenceRegion, org.bdgenomics.formats.avro.Genotype]],
-      new org.bdgenomics.utils.intervalarray.IntervalArraySerializer[org.bdgenomics.adam.models.ReferenceRegion, org.bdgenomics.formats.avro.Genotype](kryo))
-    kryo.register(classOf[org.bdgenomics.utils.intervalarray.IntervalArray[org.bdgenomics.adam.models.ReferenceRegion, org.bdgenomics.formats.avro.NucleotideContigFragment]],
-      new org.bdgenomics.utils.intervalarray.IntervalArraySerializer[org.bdgenomics.adam.models.ReferenceRegion, org.bdgenomics.formats.avro.NucleotideContigFragment](kryo))
-    kryo.register(classOf[org.bdgenomics.utils.intervalarray.IntervalArray[org.bdgenomics.adam.models.ReferenceRegion, org.bdgenomics.formats.avro.Variant]],
-      new org.bdgenomics.utils.intervalarray.IntervalArraySerializer[org.bdgenomics.adam.models.ReferenceRegion, org.bdgenomics.formats.avro.Variant](kryo))
-    kryo.register(classOf[org.bdgenomics.utils.intervalarray.IntervalArray[org.bdgenomics.adam.models.ReferenceRegion, org.bdgenomics.adam.models.VariantContext]],
-      new org.bdgenomics.utils.intervalarray.IntervalArraySerializer[org.bdgenomics.adam.models.ReferenceRegion, org.bdgenomics.adam.models.VariantContext](kryo))
 
     // org.codehaus.jackson.node
     kryo.register(classOf[org.codehaus.jackson.node.NullNode])

--- a/adam-core/src/test/scala/org/bdgenomics/adam/rdd/InnerTreeRegionJoinSuite.scala
+++ b/adam-core/src/test/scala/org/bdgenomics/adam/rdd/InnerTreeRegionJoinSuite.scala
@@ -19,8 +19,10 @@ package org.bdgenomics.adam.rdd
 
 import org.apache.spark.SparkContext._
 import org.bdgenomics.adam.models.ReferenceRegion
+import org.bdgenomics.adam.rdd.read.AlignmentRecordArray
 import org.bdgenomics.adam.util.ADAMFunSuite
 import org.bdgenomics.formats.avro.{ AlignmentRecord, Contig }
+import org.bdgenomics.utils.interval.array.IntervalArray
 
 class InnerTreeRegionJoinSuite extends ADAMFunSuite {
 
@@ -47,14 +49,17 @@ class InnerTreeRegionJoinSuite extends ADAMFunSuite {
     assert(InnerTreeRegionJoinSuite.getReferenceRegion(record1) ===
       InnerTreeRegionJoinSuite.getReferenceRegion(record2))
 
-    assert(InnerTreeRegionJoin[AlignmentRecord, AlignmentRecord]().partitionAndJoin(
-      rdd1,
+    val tree = IntervalArray[ReferenceRegion, AlignmentRecord](rdd1,
+      AlignmentRecordArray.apply(_, _))
+
+    assert(InnerTreeRegionJoin[AlignmentRecord, AlignmentRecord]().broadcastAndJoin(
+      tree,
       rdd2).aggregate(true)(
         InnerTreeRegionJoinSuite.merge,
         InnerTreeRegionJoinSuite.and))
 
-    assert(InnerTreeRegionJoin[AlignmentRecord, AlignmentRecord]().partitionAndJoin(
-      rdd1,
+    assert(InnerTreeRegionJoin[AlignmentRecord, AlignmentRecord]().broadcastAndJoin(
+      tree,
       rdd2)
       .aggregate(0)(
         InnerTreeRegionJoinSuite.count,
@@ -83,15 +88,18 @@ class InnerTreeRegionJoinSuite extends ADAMFunSuite {
     val baseRdd = sc.parallelize(Seq(baseRecord)).keyBy(ReferenceRegion.unstranded(_))
     val recordsRdd = sc.parallelize(Seq(record1, record2)).keyBy(ReferenceRegion.unstranded(_))
 
-    assert(InnerTreeRegionJoin[AlignmentRecord, AlignmentRecord]().partitionAndJoin(
-      baseRdd,
+    val tree = IntervalArray[ReferenceRegion, AlignmentRecord](baseRdd,
+      AlignmentRecordArray.apply(_, _))
+
+    assert(InnerTreeRegionJoin[AlignmentRecord, AlignmentRecord]().broadcastAndJoin(
+      tree,
       recordsRdd)
       .aggregate(true)(
         InnerTreeRegionJoinSuite.merge,
         InnerTreeRegionJoinSuite.and))
 
-    assert(InnerTreeRegionJoin[AlignmentRecord, AlignmentRecord]().partitionAndJoin(
-      baseRdd,
+    assert(InnerTreeRegionJoin[AlignmentRecord, AlignmentRecord]().broadcastAndJoin(
+      tree,
       recordsRdd).count() === 2)
   }
 
@@ -132,15 +140,18 @@ class InnerTreeRegionJoinSuite extends ADAMFunSuite {
     val baseRdd = sc.parallelize(Seq(baseRecord1, baseRecord2)).keyBy(ReferenceRegion.unstranded(_))
     val recordsRdd = sc.parallelize(Seq(record1, record2, record3)).keyBy(ReferenceRegion.unstranded(_))
 
-    assert(InnerTreeRegionJoin[AlignmentRecord, AlignmentRecord]().partitionAndJoin(
-      baseRdd,
+    val tree = IntervalArray[ReferenceRegion, AlignmentRecord](baseRdd,
+      AlignmentRecordArray.apply(_, _))
+
+    assert(InnerTreeRegionJoin[AlignmentRecord, AlignmentRecord]().broadcastAndJoin(
+      tree,
       recordsRdd)
       .aggregate(true)(
         InnerTreeRegionJoinSuite.merge,
         InnerTreeRegionJoinSuite.and))
 
-    assert(InnerTreeRegionJoin[AlignmentRecord, AlignmentRecord]().partitionAndJoin(
-      baseRdd,
+    assert(InnerTreeRegionJoin[AlignmentRecord, AlignmentRecord]().broadcastAndJoin(
+      tree,
       recordsRdd).count() === 3)
   }
 }

--- a/adam-core/src/test/scala/org/bdgenomics/adam/rdd/RightOuterTreeRegionJoinSuite.scala
+++ b/adam-core/src/test/scala/org/bdgenomics/adam/rdd/RightOuterTreeRegionJoinSuite.scala
@@ -19,14 +19,17 @@ package org.bdgenomics.adam.rdd
 
 import org.apache.spark.rdd.RDD
 import org.bdgenomics.adam.models.ReferenceRegion
+import org.bdgenomics.adam.rdd.read.AlignmentRecordArray
 import org.bdgenomics.formats.avro.AlignmentRecord
+import org.bdgenomics.utils.interval.array.IntervalArray
 
 class RightOuterTreeRegionJoinSuite extends OuterRegionJoinSuite {
 
   def runJoin(leftRdd: RDD[(ReferenceRegion, AlignmentRecord)],
               rightRdd: RDD[(ReferenceRegion, AlignmentRecord)]): RDD[(Option[AlignmentRecord], AlignmentRecord)] = {
-    RightOuterTreeRegionJoin[AlignmentRecord, AlignmentRecord]().partitionAndJoin(
-      leftRdd,
+    RightOuterTreeRegionJoin[AlignmentRecord, AlignmentRecord]().broadcastAndJoin(
+      IntervalArray[ReferenceRegion, AlignmentRecord](leftRdd,
+        AlignmentRecordArray.apply(_, _)),
       rightRdd)
   }
 }

--- a/pom.xml
+++ b/pom.xml
@@ -28,7 +28,7 @@
     <hadoop-bam.version>7.7.0</hadoop-bam.version>
     <slf4j.version>1.7.21</slf4j.version>
     <bdg-formats.version>0.10.1</bdg-formats.version>
-    <bdg-utils.version>0.2.10</bdg-utils.version>
+    <bdg-utils.version>0.2.11</bdg-utils.version>
     <htsjdk.version>2.5.0</htsjdk.version>
     <scoverage.plugin.version>1.1.1</scoverage.plugin.version>
   </properties>

--- a/scripts/move_to_scala_2.10.sh
+++ b/scripts/move_to_scala_2.10.sh
@@ -12,7 +12,7 @@ then
 fi
 
 find . -name "pom.xml" -exec sed -e "s/2.11.8/2.10.6/g" \
-    -e "s/2.11/2.10/g" -i.2.10.bak \
+    -e "/bdg-utils.version/! s/2.11/2.10/g" -i.2.10.bak \
     -e "/no Scala/ s/Scala 2.10/Scala 2.11/g" -i.2.10.bak \
     '{}' \;
 find . -name "*.2.10.bak" -exec rm -f {} \;

--- a/scripts/move_to_scala_2.11.sh
+++ b/scripts/move_to_scala_2.11.sh
@@ -12,7 +12,7 @@ then
 fi
 
 find . -name "pom.xml" -exec sed -e "s/2.10.6/2.11.8/g" \
-    -e "/bdg-utils.version/! s/2.10/2.11/g" \
+    -e "s/2.10/2.11/g" \
     -i.2.11.bak '{}' \;
 # keep parquet-scala at parquet-scala_2.10
 find . -name "pom.xml" -exec sed -e "s/parquet-scala_2.11/parquet-scala_2.10/g" -i.2.11.2.bak '{}' \;


### PR DESCRIPTION
Resolves #1334. Eliminates type erasure problems by having different concrete implementations per each broadcast. Depends on https://github.com/bigdatagenomics/utils/pull/97.