### PR TITLE
[ADAM-1337] Remove os.{flush,close} calls after writing VCF header.

### DIFF
--- a/adam-core/src/main/scala/org/bdgenomics/adam/rdd/VCFHeaderUtils.scala
+++ b/adam-core/src/main/scala/org/bdgenomics/adam/rdd/VCFHeaderUtils.scala
@@ -70,9 +70,8 @@ private[rdd] object VCFHeaderUtils {
     // write the header
     vcw.writeHeader(header)
 
-    // close the writer and the underlying stream
+    // close the writer
+    // vcw.close calls close on the underlying stream, see ADAM-1337
     vcw.close()
-    os.flush()
-    os.close()
   }
 }


### PR DESCRIPTION
Resolves #1337. The VCF writer calls close on the underlying stream.