### PR TITLE
[ADAM-1339] Use glob-safe method to load VCF header metadata for Parquet

### DIFF
--- a/adam-core/src/main/scala/org/bdgenomics/adam/rdd/ADAMContext.scala
+++ b/adam-core/src/main/scala/org/bdgenomics/adam/rdd/ADAMContext.scala
@@ -277,8 +277,10 @@ class ADAMContext(@transient val sc: SparkContext) extends Serializable with Log
   }
 
   private def loadHeaderLines(filePath: String): Seq[VCFHeaderLine] = {
-    val header = readVcfHeader(filePath + "/_header")
-    headerLines(header)
+    getFsAndFilesWithFilter(filePath, new FileFilter("_header"))
+      .map(p => headerLines(readVcfHeader(p.toString)))
+      .flatten
+      .distinct
   }
 
   /**


### PR DESCRIPTION
Resolves #1339.