### PR TITLE
Fixes parsing variant annotations for multi-allelic rows

### DIFF
--- a/adam-core/src/main/scala/org/bdgenomics/adam/converters/VariantContextConverter.scala
+++ b/adam-core/src/main/scala/org/bdgenomics/adam/converters/VariantContextConverter.scala
@@ -230,7 +230,9 @@ private[adam] class VariantContextConverter(
             val idx = vc.getAlleleIndex(allele)
             require(idx >= 1, "Unexpected index for alternate allele: " + vc.toString)
 
-            val variant = variantFormatFn(vc, Some(allele.getDisplayString), idx)
+            //Variant annotations only contain values for alternate alleles so we need to subtract one from real index
+            val variantIdx = idx - 1
+            val variant = variantFormatFn(vc, Some(allele.getDisplayString), variantIdx)
             val genotypes = vc.getGenotypes.map(g => {
               genotypeFormatFn(g, variant, allele, idx, referenceModelIndex, true)
             })

--- a/adam-core/src/test/scala/org/bdgenomics/adam/rdd/ADAMContextSuite.scala
+++ b/adam-core/src/test/scala/org/bdgenomics/adam/rdd/ADAMContextSuite.scala
@@ -404,6 +404,18 @@ class ADAMContextSuite extends ADAMFunSuite {
     assert(variants.rdd.count === 6)
   }
 
+  sparkTest("parse annotations for multi-allelic rows") {
+    val path = new File(testFile("gvcf_dir/gvcf_multiallelic.g.vcf")).getParent()
+
+    val variants = sc.loadVcf(path).toVariantRDD
+    val multiAllelicVariants = variants.rdd.filter(_.getReferenceAllele == "TAAA").sortBy(_.getAlternateAllele.length).collect()
+
+    val mleCounts = multiAllelicVariants.map(_.getAnnotation.getAttributes.get("MLEAC"))
+    //ALT    T,TA,TAA,<NON_REF>
+    //MLEAC  0,1,1,0
+    assert(mleCounts === Array("0", "1", "1"))
+  }
+
   sparkTest("load parquet with globs") {
     val inputPath = testFile("small.sam")
     val reads = sc.loadAlignments(inputPath)


### PR DESCRIPTION
When I tried to run the code in master I had `java.lang.ArrayIndexOutOfBoundsException` exceptions in `org.bdgenomics.adam.converters.VariantContextConverter#fromArrayExtractor` whenever multi-allelic row was encountered.
It turned out the index was off by 1 when accessing multivalued annotations.

For example in `gvcf_dir/gvcf_multiallelic.g.vcf` there is a line:
```chr22	18030096	.	TAAA	T,TA,TAA,<NON_REF>	564.73	.	BaseQRankSum=-0.133;ClippingRankSum=-1.438;DP=114;MLEAC=0,1,1,0;MLEAF=0.00,0.500,0.500,0.00;MQ=69.72;MQ0=0;MQRankSum=-0.686;ReadPosRankSum=-0.013	GT:AD:DP:GQ:PL	2/3:13,3,17,17,0:50:86:602,508,1628,86,678,553,137,342,0,281,467,744,353,309,659```

ALT is `T,TA,TAA,<NON_REF>` with alt allele indexes (as returned by `vc.getAlleleIndex(allele)`): `1,2,3,4`
When accessing annotation `MLEAC=0,1,1,0` it would load indexes `1,2,3` for `T,TA,TAA` resulting in `1,1,0`.
However there is never a value for reference allele here! So instead it should be loading indexes `0,1,2` resulting in values `0,1,1`.

Incidentally test using `gvcf_dir/gvcf_multiallelic.g.vcf` wasn't breaking for you because there was always extra `0` as the last value corresponding to `<NON_REF>` - which was effecting in silent shift of values.
This becomes much easier to break in "real" VCF where there is no `<NON_REF>` anymore.