### PR TITLE
Update dependency and plugin versions

### DIFF
--- a/adam-apis/pom.xml
+++ b/adam-apis/pom.xml
@@ -93,14 +93,17 @@
     <dependency>
       <groupId>org.scala-lang</groupId>
       <artifactId>scala-library</artifactId>
+      <scope>compile</scope>
     </dependency>
     <dependency>
       <groupId>org.apache.hadoop</groupId>
       <artifactId>hadoop-client</artifactId>
+      <!-- provided scope from parent -->
     </dependency>
     <dependency>
       <groupId>org.apache.spark</groupId>
       <artifactId>spark-core_${scala.version.prefix}</artifactId>
+      <!-- provided scope from parent -->
     </dependency>
     <dependency>
       <groupId>org.bdgenomics.utils</groupId>
@@ -111,10 +114,12 @@
     <dependency>
       <groupId>org.bdgenomics.bdg-formats</groupId>
       <artifactId>bdg-formats</artifactId>
+      <scope>compile</scope>
     </dependency>
     <dependency>
       <groupId>org.bdgenomics.adam</groupId>
       <artifactId>adam-core_${scala.version.prefix}</artifactId>
+      <scope>compile</scope>
     </dependency>
     <dependency>
       <groupId>org.bdgenomics.adam</groupId>
@@ -125,10 +130,12 @@
     <dependency>
       <groupId>org.slf4j</groupId>
       <artifactId>slf4j-log4j12</artifactId>
+      <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>args4j</groupId>
       <artifactId>args4j</artifactId>
+      <scope>compile</scope>
     </dependency>
     <dependency>
       <groupId>org.scalatest</groupId>

--- a/adam-assembly/pom.xml
+++ b/adam-assembly/pom.xml
@@ -115,6 +115,22 @@
     <dependency>
       <groupId>org.bdgenomics.adam</groupId>
       <artifactId>adam-cli_${scala.version.prefix}</artifactId>
+      <scope>compile</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.slf4j</groupId>
+      <artifactId>jcl-over-slf4j</artifactId>
+      <scope>runtime</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.slf4j</groupId>
+      <artifactId>jul-to-slf4j</artifactId>
+      <scope>runtime</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.slf4j</groupId>
+      <artifactId>slf4j-log4j12</artifactId>
+      <scope>runtime</scope>
     </dependency>
   </dependencies>
 </project>

--- a/adam-cli/pom.xml
+++ b/adam-cli/pom.xml
@@ -108,10 +108,12 @@
     <dependency>
       <groupId>org.apache.hadoop</groupId>
       <artifactId>hadoop-client</artifactId>
+      <!-- provided scope from parent -->
     </dependency>
     <dependency>
       <groupId>org.apache.spark</groupId>
       <artifactId>spark-core_${scala.version.prefix}</artifactId>
+      <!-- provided scope from parent -->
     </dependency>
     <dependency>
       <groupId>org.bdgenomics.utils</groupId>
@@ -122,26 +124,32 @@
     <dependency>
       <groupId>org.bdgenomics.utils</groupId>
       <artifactId>utils-misc_${scala.version.prefix}</artifactId>
+      <scope>compile</scope>
     </dependency>
     <dependency>
       <groupId>org.bdgenomics.utils</groupId>
       <artifactId>utils-io_${scala.version.prefix}</artifactId>
+      <scope>compile</scope>
     </dependency>
     <dependency>
       <groupId>org.bdgenomics.utils</groupId>
       <artifactId>utils-cli_${scala.version.prefix}</artifactId>
+      <scope>compile</scope>
     </dependency>
     <dependency>
       <groupId>org.bdgenomics.utils</groupId>
       <artifactId>utils-metrics_${scala.version.prefix}</artifactId>
+      <scope>compile</scope>
     </dependency>
     <dependency>
       <groupId>org.bdgenomics.bdg-formats</groupId>
       <artifactId>bdg-formats</artifactId>
+      <scope>compile</scope>
     </dependency>
     <dependency>
       <groupId>org.bdgenomics.adam</groupId>
       <artifactId>adam-core_${scala.version.prefix}</artifactId>
+      <scope>compile</scope>
     </dependency>
     <dependency>
       <groupId>org.bdgenomics.adam</groupId>
@@ -152,6 +160,7 @@
     <dependency>
       <groupId>org.bdgenomics.adam</groupId>
       <artifactId>adam-apis_${scala.version.prefix}</artifactId>
+      <scope>compile</scope>
     </dependency>
     <dependency>
       <groupId>org.bdgenomics.adam</groupId>
@@ -162,14 +171,17 @@
     <dependency>
       <groupId>org.scala-lang</groupId>
       <artifactId>scala-library</artifactId>
+      <scope>compile</scope>
     </dependency>
     <dependency>
       <groupId>org.slf4j</groupId>
       <artifactId>slf4j-log4j12</artifactId>
+      <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>args4j</groupId>
       <artifactId>args4j</artifactId>
+      <scope>compile</scope>
     </dependency>
     <dependency>
       <groupId>org.scalatest</groupId>
@@ -179,6 +191,7 @@
     <dependency>
       <groupId>net.codingwell</groupId>
       <artifactId>scala-guice_${scala.version.prefix}</artifactId>
+      <scope>compile</scope>
     </dependency>
   </dependencies>
 </project>

--- a/adam-cli/src/test/resources/log4j.properties
+++ b/adam-cli/src/test/resources/log4j.properties
@@ -16,3 +16,6 @@ log4j.appender.logfile.threshold=INFO
 log4j.appender.logfile.layout=org.apache.log4j.PatternLayout
 log4j.appender.logfile.layout.ConversionPattern=%d{yyyy-MM-dd HH:mm:ss} %-5p %c{1}:%L - %m%n
 log4j.appender.logfile.encoding=UTF-8
+
+# Tell Parquet to shut up
+log4j.logger.org.apache.parquet=ERROR

--- a/adam-core/pom.xml
+++ b/adam-core/pom.xml
@@ -99,70 +99,87 @@
     <dependency>
       <groupId>org.bdgenomics.utils</groupId>
       <artifactId>utils-metrics_${scala.version.prefix}</artifactId>
+      <scope>compile</scope>
     </dependency>
     <dependency>
       <groupId>org.bdgenomics.utils</groupId>
       <artifactId>utils-io_${scala.version.prefix}</artifactId>
+      <scope>compile</scope>
     </dependency>
     <dependency>
       <groupId>org.bdgenomics.utils</groupId>
       <artifactId>utils-cli_${scala.version.prefix}</artifactId>
+      <scope>compile</scope>
     </dependency>
     <dependency>
       <groupId>org.bdgenomics.utils</groupId>
       <artifactId>utils-intervalrdd_${scala.version.prefix}</artifactId>
+      <scope>compile</scope>
     </dependency>
     <dependency>
       <groupId>com.esotericsoftware.kryo</groupId>
       <artifactId>kryo</artifactId>
+      <scope>compile</scope>
     </dependency>
     <dependency>
       <groupId>org.bdgenomics.bdg-formats</groupId>
       <artifactId>bdg-formats</artifactId>
+      <scope>compile</scope>
     </dependency>
     <dependency>
       <groupId>commons-io</groupId>
       <artifactId>commons-io</artifactId>
+      <scope>compile</scope>
     </dependency>
     <dependency>
       <groupId>org.scala-lang</groupId>
       <artifactId>scala-library</artifactId>
+      <scope>compile</scope>
     </dependency>
     <dependency>
       <groupId>org.apache.hadoop</groupId>
       <artifactId>hadoop-client</artifactId>
+      <!-- provided scope from parent -->
     </dependency>
     <dependency>
       <groupId>org.apache.spark</groupId>
       <artifactId>spark-core_${scala.version.prefix}</artifactId>
+      <!-- provided scope from parent -->
     </dependency>
     <dependency>
       <groupId>it.unimi.dsi</groupId>
       <artifactId>fastutil</artifactId>
+      <scope>compile</scope>
     </dependency>
     <dependency>
       <groupId>org.apache.avro</groupId>
       <artifactId>avro</artifactId>
+      <scope>compile</scope>
     </dependency>
     <dependency>
       <groupId>org.slf4j</groupId>
       <artifactId>slf4j-log4j12</artifactId>
+      <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>org.apache.parquet</groupId>
       <artifactId>parquet-avro</artifactId>
+      <scope>compile</scope>
     </dependency>
     <dependency>
       <groupId>org.apache.parquet</groupId>
       <artifactId>parquet-scala_2.10</artifactId>
+      <scope>compile</scope>
     </dependency>
     <dependency>
       <groupId>org.seqdoop</groupId>
       <artifactId>hadoop-bam</artifactId>
+      <scope>compile</scope>
     </dependency>
     <dependency>
       <groupId>com.github.samtools</groupId>
       <artifactId>htsjdk</artifactId>
+      <scope>compile</scope>
     </dependency>
     <dependency>
       <groupId>org.scalatest</groupId>
@@ -172,18 +189,17 @@
     <dependency>
       <groupId>org.apache.httpcomponents</groupId>
       <artifactId>httpclient</artifactId>
-    </dependency>
-    <dependency>
-      <groupId>com.netflix.servo</groupId>
-      <artifactId>servo-core</artifactId>
+      <scope>compile</scope>
     </dependency>
     <dependency>
       <groupId>org.mockito</groupId>
       <artifactId>mockito-core</artifactId>
+      <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>com.google.guava</groupId>
       <artifactId>guava</artifactId>
+      <scope>compile</scope>
     </dependency>
   </dependencies>
 </project>

--- a/adam-core/src/test/resources/log4j.properties
+++ b/adam-core/src/test/resources/log4j.properties
@@ -16,3 +16,6 @@ log4j.appender.logfile.threshold=INFO
 log4j.appender.logfile.layout=org.apache.log4j.PatternLayout
 log4j.appender.logfile.layout.ConversionPattern=%d{yyyy-MM-dd HH:mm:ss} %-5p %c{1}:%L - %m%n
 log4j.appender.logfile.encoding=UTF-8
+
+# Tell Parquet to shut up
+log4j.logger.org.apache.parquet=ERROR

--- a/pom.xml
+++ b/pom.xml
@@ -16,9 +16,12 @@
   <description>A fast, scalable genome analysis system</description>
   <url>http://bdgenomics.org/</url>
 
+  <prerequisites>
+    <maven>3.1.1</maven>
+  </prerequisites>
   <properties>
     <java.version>1.8</java.version>
-    <avro.version>1.8.0</avro.version>
+    <avro.version>1.8.1</avro.version>
     <scala.version>2.10.6</scala.version>
     <scala.version.prefix>2.10</scala.version.prefix>
     <spark.version>1.6.3</spark.version>
@@ -26,7 +29,7 @@
     <!-- Edit the following line to configure the Hadoop (HDFS) version. -->
     <hadoop.version>2.7.3</hadoop.version>
     <hadoop-bam.version>7.8.0</hadoop-bam.version>
-    <slf4j.version>1.7.21</slf4j.version>
+    <slf4j.version>1.7.22</slf4j.version>
     <bdg-formats.version>0.10.1</bdg-formats.version>
     <bdg-utils.version>0.2.13</bdg-utils.version>
     <htsjdk.version>2.9.1</htsjdk.version>
@@ -76,17 +79,17 @@
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-assembly-plugin</artifactId>
-          <version>2.5.5</version>
+          <version>2.6</version>
         </plugin>
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-javadoc-plugin</artifactId>
-          <version>2.10.3</version>
+          <version>2.10.4</version>
         </plugin>
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-release-plugin</artifactId>
-          <version>2.5.2</version>
+          <version>2.5.3</version>
           <configuration>
             <mavenExecutorId>forked-path</mavenExecutorId>
             <useReleaseProfile>false</useReleaseProfile>
@@ -111,7 +114,7 @@
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-clean-plugin</artifactId>
-          <version>2.6.1</version>
+          <version>3.0.0</version>
         </plugin>
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
@@ -160,7 +163,7 @@
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-jar-plugin</artifactId>
-          <version>2.6</version>
+          <version>3.0.1</version>
         </plugin>
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
@@ -171,6 +174,11 @@
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-shade-plugin</artifactId>
           <version>2.4.3</version>
+        </plugin>
+        <plugin>
+          <groupId>org.apache.maven.plugins</groupId>
+          <artifactId>maven-source-plugin</artifactId>
+          <version>3.0.1</version>
         </plugin>
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
@@ -227,7 +235,7 @@
         <plugin>
           <groupId>org.codehaus.mojo</groupId>
           <artifactId>build-helper-maven-plugin</artifactId>
-          <version>1.10</version>
+          <version>1.12</version>
         </plugin>
         <plugin>
           <groupId>org.scalariform</groupId>
@@ -325,7 +333,7 @@
       <dependency>
         <groupId>commons-io</groupId>
         <artifactId>commons-io</artifactId>
-        <version>2.4</version>
+        <version>2.5</version>
       </dependency>
       <dependency>
         <groupId>it.unimi.dsi</groupId>
@@ -462,6 +470,18 @@
             <groupId>org.apache.hadoop</groupId>
             <artifactId>hadoop-mapreduce</artifactId>
           </exclusion>
+          <exclusion>
+            <groupId>org.slf4j</groupId>
+            <artifactId>jcl-over-slf4j</artifactId>
+          </exclusion>
+          <exclusion>
+            <groupId>org.slf4j</groupId>
+            <artifactId>jul-to-slf4j</artifactId>
+          </exclusion>
+          <exclusion>
+            <groupId>org.slf4j</groupId>
+            <artifactId>slf4j-log4j12</artifactId>
+          </exclusion>
         </exclusions>
       </dependency>
       <dependency>
@@ -476,7 +496,7 @@
       </dependency>
       <dependency>
         <groupId>org.apache.parquet</groupId>
-        <!-- This library has no Scala 2.11 version, but using the 2.10 version seems to work. -->
+        <!-- This library has no Scala 2.11 version, but using the 2 dot 10 version seems to work. -->
         <artifactId>parquet-scala_2.10</artifactId>
         <version>${parquet.version}</version>
         <exclusions>
@@ -538,18 +558,7 @@
         <artifactId>httpclient</artifactId>
         <version>4.5.2</version>
       </dependency>
-      <dependency>
-        <groupId>com.netflix.servo</groupId>
-        <artifactId>servo-core</artifactId>
-        <version>0.10.0</version> <!-- note: versions 0.11.0+ (currently 0.12.3) are jdk8-only -->
-        <exclusions>
-          <exclusion>
-            <groupId>com.google.guava</groupId>
-            <artifactId>guava</artifactId>
-          </exclusion>
-        </exclusions>
-      </dependency>
-      <dependency>
+     <dependency>
         <groupId>com.google.guava</groupId>
         <artifactId>guava</artifactId>
         <version>16.0.1</version> <!-- note: version 17.0 breaks hadoop 2.6+ at runtime -->
@@ -557,13 +566,13 @@
       <dependency>
         <groupId>org.mockito</groupId>
         <artifactId>mockito-core</artifactId>
-        <version>1.10.19</version>
+        <version>2.6.4</version>
         <scope>test</scope>
       </dependency>
       <dependency>
         <groupId>net.codingwell</groupId>
         <artifactId>scala-guice_${scala.version.prefix}</artifactId>
-        <version>4.0.1</version>
+        <version>4.1.0</version>
       </dependency>
     </dependencies>
   </dependencyManagement>
@@ -584,7 +593,7 @@
           <plugin>
             <groupId>org.apache.maven.plugins</groupId>
             <artifactId>maven-source-plugin</artifactId>
-            <version>2.4</version>
+            <version>3.0.1</version>
             <executions>
               <execution>
                 <id>attach-sources</id>
@@ -598,7 +607,7 @@
           <plugin>
             <groupId>org.apache.maven.plugins</groupId>
             <artifactId>maven-javadoc-plugin</artifactId>
-            <version>2.10.3</version>
+            <version>2.10.4</version>
             <executions>
               <execution>
                 <id>attach-javadocs</id>

--- a/scripts/move_to_scala_2.11.sh
+++ b/scripts/move_to_scala_2.11.sh
@@ -16,6 +16,6 @@ find . -name "pom.xml" -exec sed -e "s/2.10.6/2.11.8/g" \
     -i.2.11.bak '{}' \;
 # keep parquet-scala at parquet-scala_2.10
 find . -name "pom.xml" -exec sed -e "s/parquet-scala_2.11/parquet-scala_2.10/g" -i.2.11.2.bak '{}' \;
-# keep maven-javadoc-plugin at version 2.10.3
-find . -name "pom.xml" -exec sed -e "s/2.11.3/2.10.3/g" -i.2.11.3.bak '{}' \;
+# keep maven-javadoc-plugin at version 2.10.4
+find . -name "pom.xml" -exec sed -e "s/2.11.4/2.10.4/g" -i.2.11.3.bak '{}' \;
 find . -name "*.2.11.*bak" -exec rm -f {} \;


### PR DESCRIPTION
Notes to self:
* https://github.com/HadoopGenomics/Hadoop-BAM/compare/7.7.0...7.7.1
* https://github.com/apache/avro/compare/release-1.8.0...release-1.8.1
* https://github.com/apache/avro/compare/release-1.8.1...release-1.8.2-rc1
* https://github.com/qos-ch/slf4j/compare/v_1.7.21...v_1.7.22
* slf4j-log4j12 is compile scoped in adam-core, that doesn't seem correct
* args4j version 2.32 is not binary compatible with 2.0.31, fix upstream in utils, may require code changes
* scoverage 1.1.1 to 1.3.0, see issue https://github.com/bigdatagenomics/utils/issues/95
* servo dependency was reported unused; older version declared in utils-metrics, may be req'd for guava exclusion
* update htsjdk 2.5.0 to 2.8.1 in separate commit, to isolate any issues
* guava is still stuck by hadoop as far as I know, follow up
* parquet 1.9.0 is available but not used in spark, spark dev mailing list was discussing a 1.8.2 release, follow up