### PR TITLE
[ADAM-1362] Fixing issue where FromKnowns consensus model fails if no reads hit a target.

### DIFF
--- a/adam-core/src/main/scala/org/bdgenomics/adam/algorithms/consensus/ConsensusGeneratorFromKnowns.scala
+++ b/adam-core/src/main/scala/org/bdgenomics/adam/algorithms/consensus/ConsensusGeneratorFromKnowns.scala
@@ -49,9 +49,7 @@ private[adam] class ConsensusGeneratorFromKnowns(rdd: RDD[Variant]) extends Cons
   def targetsToAdd(): Option[RDD[IndelRealignmentTarget]] = {
 
     Some(rdd.filter(v => v.getReferenceAllele.length != v.getAlternateAllele.length)
-      .map(v => ReferenceRegion(v.getContigName,
-        v.getStart,
-        v.getStart + v.getReferenceAllele.length))
+      .map(v => ReferenceRegion(v))
       .map(r => new IndelRealignmentTarget(Some(r), r)))
   }
 
@@ -76,16 +74,20 @@ private[adam] class ConsensusGeneratorFromKnowns(rdd: RDD[Variant]) extends Cons
    * @return Consensus sequences to use for realignment.
    */
   def findConsensus(reads: Iterable[RichAlignmentRecord]): Iterable[Consensus] = {
-    val table = indelTable.value
+    if (reads.isEmpty) {
+      Iterable.empty
+    } else {
+      val table = indelTable.value
 
-    // get region
-    val start = reads.map(_.record.getStart).min
-    val end = reads.map(_.getEnd).max
-    val refId = reads.head.record.getContigName
+      // get region
+      val start = reads.map(_.record.getStart).min
+      val end = reads.map(_.getEnd).max
+      val refId = reads.head.record.getContigName
 
-    val region = ReferenceRegion(refId, start, end + 1)
+      val region = ReferenceRegion(refId, start, end + 1)
 
-    // get reads
-    table.getIndelsInRegion(region)
+      // get reads
+      table.getIndelsInRegion(region)
+    }
   }
 }

--- a/adam-core/src/main/scala/org/bdgenomics/adam/rdd/read/realignment/RealignIndels.scala
+++ b/adam-core/src/main/scala/org/bdgenomics/adam/rdd/read/realignment/RealignIndels.scala
@@ -203,17 +203,20 @@ private[read] object RealignIndels extends Serializable with Logging {
       .sortBy(_._2.head)
 
     // fold over sequences and append - sequence is sorted at start
-    val ref = readRefs.reverse.foldRight[(String, Long)](("", readRefs.head._2.head))((refReads: (String, NumericRange[Long]), reference: (String, Long)) => {
-      if (refReads._2.end < reference._2) {
-        reference
-      } else if (reference._2 >= refReads._2.head) {
-        (reference._1 + refReads._1.substring((reference._2 - refReads._2.head).toInt), refReads._2.end)
-      } else {
-        // there is a gap in the sequence
-        throw new IllegalArgumentException("Current sequence has a gap at " + reference._2 + "with " + refReads._2.head + "," + refReads._2.end +
-          ". Discarded " + tossedReads + " in region when reconstructing region; reads may not have MD tag attached.")
-      }
-    })
+    val ref = readRefs.reverse.foldRight[(String, Long)](
+      ("", readRefs.head._2.head))(
+        (refReads: (String, NumericRange[Long]), reference: (String, Long)) => {
+          if (refReads._2.end < reference._2) {
+            reference
+          } else if (reference._2 >= refReads._2.head) {
+            (reference._1 + refReads._1.substring((reference._2 - refReads._2.head).toInt),
+              refReads._2.end)
+          } else {
+            // there is a gap in the sequence
+            throw new IllegalArgumentException("Current sequence has a gap at " + reference._2 + "with " + refReads._2.head + "," + refReads._2.end +
+              ". Discarded " + tossedReads + " in region when reconstructing region; reads may not have MD tag attached.")
+          }
+        })
 
     (ref._1, readRefs.head._2.head, ref._2)
   }
@@ -406,7 +409,7 @@ private[read] class RealignIndels(
     var qualityScores = List[(Int, Int)]()
 
     // calculate mismatch quality score for all admissable alignment offsets
-    for (i <- 0 until (reference.length - read.length)) {
+    for (i <- 0 to (reference.length - read.length)) {
       val qualityScore = sumMismatchQualityIgnoreCigar(read, reference.substring(i, i + read.length), qualities)
       qualityScores = (qualityScore, i) :: qualityScores
     }

--- a/adam-core/src/test/scala/org/bdgenomics/adam/algorithms/consensus/ConsensusGeneratorFromKnownsSuite.scala
+++ b/adam-core/src/test/scala/org/bdgenomics/adam/algorithms/consensus/ConsensusGeneratorFromKnownsSuite.scala
@@ -1,0 +1,64 @@
+/**
+ * Licensed to Big Data Genomics (BDG) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The BDG licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.bdgenomics.adam.algorithms.consensus
+
+import org.apache.spark.SparkContext
+import org.apache.spark.rdd.RDD
+import org.bdgenomics.adam.rdd.ADAMContext._
+import org.bdgenomics.adam.rich.RichAlignmentRecord
+import org.bdgenomics.adam.util.ADAMFunSuite
+import org.bdgenomics.formats.avro.AlignmentRecord
+
+class ConsensusGeneratorFromKnownsSuite extends ADAMFunSuite {
+
+  def cg(sc: SparkContext): ConsensusGenerator = {
+    val path = testFile("random.vcf")
+    ConsensusGenerator.fromKnownIndels(sc.loadVariants(path))
+  }
+
+  sparkTest("no consensuses for empty target") {
+    val c = cg(sc)
+    assert(c.findConsensus(Iterable.empty).isEmpty)
+  }
+
+  sparkTest("no consensuses for reads that don't overlap a target") {
+    val c = cg(sc)
+    val read = AlignmentRecord.newBuilder
+      .setStart(1L)
+      .setEnd(2L)
+      .setContigName("notAContig")
+      .build
+    assert(c.findConsensus(Iterable(new RichAlignmentRecord(read))).isEmpty)
+  }
+
+  sparkTest("return a consensus for read overlapping a single target") {
+    val c = cg(sc)
+    val read = AlignmentRecord.newBuilder
+      .setStart(19189L)
+      .setEnd(19191L)
+      .setContigName("2")
+      .build
+    val consensuses = c.findConsensus(Iterable(new RichAlignmentRecord(read)))
+    assert(consensuses.size === 1)
+    assert(consensuses.head.consensus === "")
+    assert(consensuses.head.index.referenceName === "2")
+    assert(consensuses.head.index.start === 19190L)
+    assert(consensuses.head.index.end === 19192L)
+  }
+}
+

--- a/adam-core/src/test/scala/org/bdgenomics/adam/rdd/read/realignment/RealignIndelsSuite.scala
+++ b/adam-core/src/test/scala/org/bdgenomics/adam/rdd/read/realignment/RealignIndelsSuite.scala
@@ -109,8 +109,9 @@ class RealignIndelsSuite extends ADAMFunSuite {
     def checkReference(readReference: (String, Long, Long)) {
       // the first three lines of artificial.fasta
       val refStr = "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAGGGGGGGGGGAAAAAAAAAAGGGGGGGGGGAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA"
-      val startIndex = Math.min(readReference._2.toInt, 120)
-      val stopIndex = Math.min(readReference._3.toInt, 180)
+      val startIndex = readReference._2.toInt
+      val stopIndex = readReference._3.toInt
+      assert(readReference._1.length === stopIndex - startIndex)
       assert(readReference._1 === refStr.substring(startIndex, stopIndex))
     }
 


### PR DESCRIPTION
Fixes #1362:

* Adding ConsensusGeneratorFromKnownsSuite.
* ConsensusGeneratorFromKnowns drops any targets that did not get hit with any reads, instead of trying to identify the full reference region overlapped by reads. While this case (target with no reads) cannot happen in the FromReads consensus model, it can happen in the FromKnowns model (e.g., use all known INDELs from 1000G with a WES dataset).
* Additionally, tracked down a minor off by one bug in RealignIndels that caused one index in the consensus sequence to not get tested. This could cause reads that aligned to the end of the target to not get realigned.
* To improve legibility, broke up a set of long lines in RealignIndels.