### PR TITLE
Make javac see that AlignmentRecordRDD extends GenomicRDD

### DIFF
--- a/adam-cli/src/main/scala/org/bdgenomics/adam/cli/Transform.scala
+++ b/adam-cli/src/main/scala/org/bdgenomics/adam/cli/Transform.scala
@@ -27,7 +27,7 @@ import org.bdgenomics.adam.models.SnpTable
 import org.bdgenomics.adam.projections.{ AlignmentRecordField, Filter }
 import org.bdgenomics.adam.rdd.ADAMContext._
 import org.bdgenomics.adam.rdd.ADAMSaveAnyArgs
-import org.bdgenomics.adam.rdd.read.{ AlignedReadRDD, AlignmentRecordRDD }
+import org.bdgenomics.adam.rdd.read.AlignmentRecordRDD
 import org.bdgenomics.adam.rich.RichVariant
 import org.bdgenomics.utils.cli._
 import org.bdgenomics.utils.misc.Logging
@@ -453,7 +453,7 @@ class Transform(protected val args: TransformArgs) extends BDGSparkCommand[Trans
     })
 
     // make a new aligned read rdd, that merges the two RDDs together
-    val newRdd = AlignedReadRDD(mergedRdd, mergedSd, mergedRgd)
+    val newRdd = AlignmentRecordRDD(mergedRdd, mergedSd, mergedRgd)
 
     // run our transformation
     val outputRdd = this.apply(newRdd)

--- a/adam-core/src/main/scala/org/bdgenomics/adam/rdd/fragment/FragmentRDD.scala
+++ b/adam-core/src/main/scala/org/bdgenomics/adam/rdd/fragment/FragmentRDD.scala
@@ -28,10 +28,8 @@ import org.bdgenomics.adam.models.{
 }
 import org.bdgenomics.adam.rdd.{ AvroReadGroupGenomicRDD, JavaSaveArgs }
 import org.bdgenomics.adam.rdd.read.{
-  AlignedReadRDD,
   AlignmentRecordRDD,
-  MarkDuplicates,
-  UnalignedReadRDD
+  MarkDuplicates
 }
 import org.bdgenomics.adam.serialization.AvroSerializer
 import org.bdgenomics.formats.avro._
@@ -119,11 +117,7 @@ case class FragmentRDD(rdd: RDD[Fragment],
     val newRdd = rdd.flatMap(converter.convertFragment)
 
     // are we aligned?
-    if (sequences.isEmpty) {
-      UnalignedReadRDD(newRdd, recordGroups)
-    } else {
-      AlignedReadRDD(newRdd, sequences, recordGroups)
-    }
+    AlignmentRecordRDD(newRdd, sequences, recordGroups)
   }
 
   /**

--- a/adam-core/src/main/scala/org/bdgenomics/adam/rdd/read/AlignmentRecordRDD.scala
+++ b/adam-core/src/main/scala/org/bdgenomics/adam/rdd/read/AlignmentRecordRDD.scala
@@ -83,7 +83,7 @@ private[adam] class AlignmentRecordArraySerializer extends IntervalArraySerializ
   }
 }
 
-sealed trait AlignmentRecordRDD extends AvroReadGroupGenomicRDD[AlignmentRecord, AlignmentRecordRDD] {
+abstract class AlignmentRecordRDD extends AvroReadGroupGenomicRDD[AlignmentRecord, AlignmentRecordRDD] {
 
   protected def buildTree(rdd: RDD[(ReferenceRegion, AlignmentRecord)])(
     implicit tTag: ClassTag[AlignmentRecord]): IntervalArray[ReferenceRegion, AlignmentRecord] = {

--- a/adam-core/src/main/scala/org/bdgenomics/adam/rdd/read/AlignmentRecordRDD.scala
+++ b/adam-core/src/main/scala/org/bdgenomics/adam/rdd/read/AlignmentRecordRDD.scala
@@ -83,12 +83,19 @@ private[adam] class AlignmentRecordArraySerializer extends IntervalArraySerializ
   }
 }
 
-abstract class AlignmentRecordRDD extends AvroReadGroupGenomicRDD[AlignmentRecord, AlignmentRecordRDD] {
+object AlignmentRecordRDD {
 
-  protected def buildTree(rdd: RDD[(ReferenceRegion, AlignmentRecord)])(
-    implicit tTag: ClassTag[AlignmentRecord]): IntervalArray[ReferenceRegion, AlignmentRecord] = {
-    IntervalArray(rdd, AlignmentRecordArray.apply(_, _))
+  def unaligned(rdd: RDD[AlignmentRecord]): AlignmentRecordRDD = {
+    AlignmentRecordRDD(rdd,
+      SequenceDictionary.empty,
+      RecordGroupDictionary.empty)
   }
+}
+
+case class AlignmentRecordRDD(
+    rdd: RDD[AlignmentRecord],
+    sequences: SequenceDictionary,
+    recordGroups: RecordGroupDictionary) extends AvroReadGroupGenomicRDD[AlignmentRecord, AlignmentRecordRDD] {
 
   /**
    * Replaces the underlying RDD and SequenceDictionary and emits a new object.
@@ -98,7 +105,20 @@ abstract class AlignmentRecordRDD extends AvroReadGroupGenomicRDD[AlignmentRecor
    * @return Returns a new AlignmentRecordRDD.
    */
   protected def replaceRddAndSequences(newRdd: RDD[AlignmentRecord],
-                                       newSequences: SequenceDictionary): AlignmentRecordRDD
+                                       newSequences: SequenceDictionary): AlignmentRecordRDD = {
+    AlignmentRecordRDD(newRdd,
+      newSequences,
+      recordGroups)
+  }
+
+  protected def replaceRdd(newRdd: RDD[AlignmentRecord]): AlignmentRecordRDD = {
+    copy(rdd = newRdd)
+  }
+
+  protected def buildTree(rdd: RDD[(ReferenceRegion, AlignmentRecord)])(
+    implicit tTag: ClassTag[AlignmentRecord]): IntervalArray[ReferenceRegion, AlignmentRecord] = {
+    IntervalArray(rdd, AlignmentRecordArray.apply(_, _))
+  }
 
   /**
    * Convert this set of reads into fragments.
@@ -930,56 +950,3 @@ abstract class AlignmentRecordRDD extends AvroReadGroupGenomicRDD[AlignmentRecor
     replaceRdd(finalRdd)
   }
 }
-
-case class AlignedReadRDD(rdd: RDD[AlignmentRecord],
-                          sequences: SequenceDictionary,
-                          recordGroups: RecordGroupDictionary) extends AlignmentRecordRDD {
-
-  protected def replaceRddAndSequences(newRdd: RDD[AlignmentRecord],
-                                       newSequences: SequenceDictionary): AlignmentRecordRDD = {
-    AlignedReadRDD(newRdd,
-      newSequences,
-      recordGroups)
-  }
-
-  protected def replaceRdd(newRdd: RDD[AlignmentRecord]): AlignedReadRDD = {
-    copy(rdd = newRdd)
-  }
-}
-
-object UnalignedReadRDD {
-
-  /**
-   * Creates an unaligned read RDD where no record groups are attached.
-   *
-   * @param rdd RDD of reads.
-   * @return Returns an unaligned read RDD with an empty record group dictionary.
-   */
-  private[rdd] def fromRdd(rdd: RDD[AlignmentRecord]): UnalignedReadRDD = {
-    UnalignedReadRDD(rdd, RecordGroupDictionary.empty)
-  }
-}
-
-case class UnalignedReadRDD(rdd: RDD[AlignmentRecord],
-                            recordGroups: RecordGroupDictionary) extends AlignmentRecordRDD
-    with Unaligned {
-
-  protected def replaceRdd(newRdd: RDD[AlignmentRecord]): UnalignedReadRDD = {
-    copy(rdd = newRdd)
-  }
-
-  protected def replaceRddAndSequences(newRdd: RDD[AlignmentRecord],
-                                       newSequences: SequenceDictionary): AlignmentRecordRDD = {
-
-    // are we still unaligned?
-    if (newSequences.isEmpty) {
-      UnalignedReadRDD(newRdd,
-        recordGroups)
-    } else {
-      AlignedReadRDD(newRdd,
-        newSequences,
-        recordGroups)
-    }
-  }
-}
-

--- a/adam-core/src/test/scala/org/bdgenomics/adam/rdd/read/AlignmentRecordRDDSuite.scala
+++ b/adam-core/src/test/scala/org/bdgenomics/adam/rdd/read/AlignmentRecordRDDSuite.scala
@@ -72,7 +72,7 @@ class AlignmentRecordRDDSuite extends ADAMFunSuite {
     val contigNames = rdd.flatMap(r => Option(r.getContigName)).distinct.collect
     val sd = new SequenceDictionary(contigNames.map(v => SequenceRecord(v, 1000000L)).toVector)
 
-    val sortedReads = AlignedReadRDD(rdd, sd, RecordGroupDictionary.empty)
+    val sortedReads = AlignmentRecordRDD(rdd, sd, RecordGroupDictionary.empty)
       .sortReadsByReferencePosition()
       .rdd
       .collect()
@@ -151,7 +151,7 @@ class AlignmentRecordRDDSuite extends ADAMFunSuite {
       }).toVector)
 
     val rdd = sc.parallelize(reads)
-    val sortedReads = AlignedReadRDD(rdd, sd, RecordGroupDictionary.empty)
+    val sortedReads = AlignmentRecordRDD(rdd, sd, RecordGroupDictionary.empty)
       .sortReadsByReferencePositionAndIndex()
       .rdd
       .collect()

--- a/adam-core/src/test/scala/org/bdgenomics/adam/rdd/read/MarkDuplicatesSuite.scala
+++ b/adam-core/src/test/scala/org/bdgenomics/adam/rdd/read/MarkDuplicatesSuite.scala
@@ -96,7 +96,7 @@ class MarkDuplicatesSuite extends ADAMFunSuite {
   }
 
   private def markDuplicates(reads: AlignmentRecord*): Array[AlignmentRecord] = {
-    AlignedReadRDD(sc.parallelize(reads), SequenceDictionary.empty, rgd)
+    AlignmentRecordRDD(sc.parallelize(reads), SequenceDictionary.empty, rgd)
       .markDuplicates()
       .rdd
       .collect()
@@ -205,7 +205,7 @@ class MarkDuplicatesSuite extends ADAMFunSuite {
   }
 
   private def markDuplicateFragments(reads: AlignmentRecord*): Array[AlignmentRecord] = {
-    AlignedReadRDD(sc.parallelize(reads), SequenceDictionary.empty, rgd)
+    AlignmentRecordRDD(sc.parallelize(reads), SequenceDictionary.empty, rgd)
       .toFragments
       .markDuplicates()
       .toReads


### PR DESCRIPTION
Resolves #1092. Prior to this, javac would not recognize the AlignmentRecordRDD trait as extending GenomicRDD. Done in two commits, as I'd like to pick the commit that makes AlignmentRecordRDD concrete over to 0.21.1, but I'd rather not delete the (Un)AlignedReadRDD classes on 0.21.1.