### PR TITLE
[ADAM-1381] Fix Variant end position.

### DIFF
--- a/adam-core/src/main/scala/org/bdgenomics/adam/converters/VariantContextConverter.scala
+++ b/adam-core/src/main/scala/org/bdgenomics/adam/converters/VariantContextConverter.scala
@@ -106,6 +106,16 @@ private[adam] object VariantContextConverter {
     }
   }
 
+  private val OPT_NON_REF = Some(Allele.create("<NON_REF>", false))
+
+  private def optNonRef(v: Variant): Option[Allele] = {
+    if (v.getAlternateAllele != null) {
+      None
+    } else {
+      OPT_NON_REF
+    }
+  }
+
   /**
    * Converts the alleles in a variant into a Java collection of htsjdk alleles.
    *
@@ -115,7 +125,8 @@ private[adam] object VariantContextConverter {
    */
   private def convertAlleles(v: Variant): java.util.Collection[Allele] = {
     val asSeq = Seq(convertAlleleOpt(v.getReferenceAllele, true),
-      convertAlleleOpt(v.getAlternateAllele)).flatten
+      convertAlleleOpt(v.getAlternateAllele),
+      optNonRef(v)).flatten
 
     asSeq
   }
@@ -1848,7 +1859,7 @@ private[adam] class VariantContextConverter(
       val builder = new VariantContextBuilder()
         .chr(v.getContigName)
         .start(v.getStart + 1)
-        .stop(v.getStart + v.getReferenceAllele.length)
+        .stop(v.getEnd)
         .alleles(VariantContextConverter.convertAlleles(v))
 
       // bind the conversion functions and fold

--- a/adam-core/src/test/scala/org/bdgenomics/adam/rdd/ADAMContextSuite.scala
+++ b/adam-core/src/test/scala/org/bdgenomics/adam/rdd/ADAMContextSuite.scala
@@ -399,8 +399,6 @@ class ADAMContextSuite extends ADAMFunSuite {
     val path = new File(testFile("gvcf_dir/gvcf_multiallelic.g.vcf")).getParent()
 
     val variants = sc.loadVcf(path).toVariantRDD
-    // Not sure that the count should be 7 below, however the current failure to read the mult-allelic site happens
-    // before this assertion is even reached
     assert(variants.rdd.count === 6)
   }
 

--- a/adam-core/src/test/scala/org/bdgenomics/adam/rdd/variant/VariantContextRDDSuite.scala
+++ b/adam-core/src/test/scala/org/bdgenomics/adam/rdd/variant/VariantContextRDDSuite.scala
@@ -42,6 +42,7 @@ class VariantContextRDDSuite extends ADAMFunSuite {
     val v0 = Variant.newBuilder
       .setContigName("chr11")
       .setStart(17409572L)
+      .setEnd(17409573L)
       .setReferenceAllele("T")
       .setAlternateAllele("C")
       .setNames(ImmutableList.of("rs3131972", "rs201888535"))


### PR DESCRIPTION
Resolves #1381. Sets variant end position to the proper site for symbolic alleles.