### PR TITLE
[ADAM-1393] fix missing reads when transforming fastq to adam

### DIFF
--- a/adam-core/src/main/java/org/bdgenomics/adam/io/FastqRecordReader.java
+++ b/adam-core/src/main/java/org/bdgenomics/adam/io/FastqRecordReader.java
@@ -280,7 +280,6 @@ abstract class FastqRecordReader extends RecordReader<Void, Text> {
         // ID line
         readName.clear();
         long skipped = appendLineInto(readName, true);
-        pos += skipped;
         if (skipped == 0) {
             return false; // EOF
         }
@@ -327,7 +326,7 @@ abstract class FastqRecordReader extends RecordReader<Void, Text> {
      */
     private int appendLineInto(final Text dest, final boolean eofOk) throws EOFException, IOException {
         Text buf = new Text();
-        int bytesRead = lineReader.readLine(buf, MAX_LINE_LENGTH);
+        int bytesRead = lineReader.readLine(buf, (int) Math.min(MAX_LINE_LENGTH, end - start));
 
         if (bytesRead < 0 || (bytesRead == 0 && !eofOk)) {
             throw new EOFException();


### PR DESCRIPTION
To fix #1393, don't double count the length of the readname line. In addition, to prevent the length of a line is longer than MAX_LINE_LENGTH in https://github.com/bigdatagenomics/adam/blob/master/adam-core/src/main/java/org/bdgenomics/adam/io/FastqRecordReader.java#L330