### PR TITLE
[ADAM-1383] Use gt instead of gteq in FASTQ input format line size checks

### DIFF
--- a/adam-core/src/main/java/org/bdgenomics/adam/io/InterleavedFastqInputFormat.java
+++ b/adam-core/src/main/java/org/bdgenomics/adam/io/InterleavedFastqInputFormat.java
@@ -71,7 +71,7 @@ public final class InterleavedFastqInputFormat extends FileInputFormat<Void, Tex
          *   formatted pair of FASTQ records.
          */
         protected boolean checkBuffer(final int bufferLength, final Text buffer) {
-            return (bufferLength >= 2 &&
+            return (bufferLength > 2 &&
                     buffer.getBytes()[0] == '@' &&
                     buffer.getBytes()[bufferLength - 2] == '/' &&
                     buffer.getBytes()[bufferLength - 1] == '1');

--- a/adam-core/src/main/java/org/bdgenomics/adam/io/SingleFastqInputFormat.java
+++ b/adam-core/src/main/java/org/bdgenomics/adam/io/SingleFastqInputFormat.java
@@ -62,7 +62,7 @@ public final class SingleFastqInputFormat extends FileInputFormat<Void, Text> {
          *   formatted pair of FASTQ records.
          */
         protected boolean checkBuffer(final int bufferLength, final Text buffer) {
-            return (bufferLength >= 0 &&
+            return (bufferLength > 0 &&
                     buffer.getBytes()[0] == '@');
         }
 


### PR DESCRIPTION
Resolves #1383.