### PR TITLE
[ADAM-1442] Fix thread pool deadlock in GenomicRDD.pipe

### DIFF
--- a/adam-core/src/main/scala/org/bdgenomics/adam/rdd/read/AnySAMOutFormatter.scala
+++ b/adam-core/src/main/scala/org/bdgenomics/adam/rdd/read/AnySAMOutFormatter.scala
@@ -39,28 +39,27 @@ class AnySAMOutFormatter extends OutFormatter[AlignmentRecord] {
    */
   def read(is: InputStream): Iterator[AlignmentRecord] = {
 
-    // make converter and empty dicts
-    val converter = new SAMRecordConverter
-
     // make reader
     val reader = SamReaderFactory.makeDefault()
       .open(SamInputResource.of(is))
 
-    // make iterator from said reader
-    val iter = reader.iterator()
+    SAMIteratorConverter(reader)
+  }
+}
 
-    @tailrec def convertIterator(iter: SAMRecordIterator,
-                                 records: ListBuffer[AlignmentRecord] = ListBuffer.empty): Iterator[AlignmentRecord] = {
-      if (!iter.hasNext) {
-        iter.close()
-        records.toIterator
-      } else {
-        val nextRecords = records += converter.convert(iter.next)
-        convertIterator(iter, nextRecords)
-      }
-    }
+private case class SAMIteratorConverter(val reader: SamReader) extends Iterator[AlignmentRecord] {
 
-    // convert the iterator
-    convertIterator(iter)
+  val iter = reader.iterator()
+
+  // make converter and empty dicts
+  val converter = new SAMRecordConverter
+
+  def hasNext: Boolean = {
+    iter.hasNext
+  }
+
+  def next: AlignmentRecord = {
+    assert(iter.hasNext)
+    converter.convert(iter.next)
   }
 }


### PR DESCRIPTION
Resolves #1442. Eliminates use of thread pool in GenomicRDD and instead launches the InFormatterRunner (which extends `Callable`) as a thread and runs the OutFormatterRunner in the original thread that launched the piped subprocess.

Additionally, rewrote the `AnySAMOutFormatter` to improve performance.

With this, BWA-on-Cannoli works (https://github.com/heuermh/cannoli/pull/2).