### PR TITLE
[ADAM-1459] Don't split FASTQ when compressed.

### DIFF
--- a/adam-core/src/main/java/org/bdgenomics/adam/io/InterleavedFastqInputFormat.java
+++ b/adam-core/src/main/java/org/bdgenomics/adam/io/InterleavedFastqInputFormat.java
@@ -19,8 +19,12 @@ package org.bdgenomics.adam.io;
 
 import java.io.EOFException;
 import java.io.IOException;
+import org.apache.hadoop.fs.Path;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.io.Text;
+import org.apache.hadoop.io.compress.CompressionCodec;
+import org.apache.hadoop.io.compress.CompressionCodecFactory;
+import org.apache.hadoop.mapreduce.JobContext;
 import org.apache.hadoop.mapreduce.InputSplit;
 import org.apache.hadoop.mapreduce.RecordReader;
 import org.apache.hadoop.mapreduce.TaskAttemptContext;
@@ -42,6 +46,21 @@ import org.apache.hadoop.mapreduce.lib.input.FileSplit;
  * found at https://github.com/HadoopGenomics/Hadoop-BAM/blob/master/src/main/java/org/seqdoop/hadoop_bam/FastqInputFormat.java
  */
 public final class InterleavedFastqInputFormat extends FileInputFormat<Void, Text> {
+
+    /**
+     * For now, we do not support splittable compression codecs. As in, we will
+     * read the compressed data, but we will not allow it to be splittable. We
+     * will fix this in #1457.
+     *
+     * @param context The job context to get the configuration from.
+     * @param filename The path the input file is saved at.
+     * @return Returns false if this file is compressed.
+     */
+    @Override protected boolean isSplitable(JobContext context, Path filename) {
+        Configuration conf = context.getConfiguration();
+        final CompressionCodec codec = new CompressionCodecFactory(context.getConfiguration()).getCodec(filename);
+        return (codec == null);
+    }
 
     /**
      * A record reader for the interleaved FASTQ format.

--- a/adam-core/src/main/java/org/bdgenomics/adam/io/SingleFastqInputFormat.java
+++ b/adam-core/src/main/java/org/bdgenomics/adam/io/SingleFastqInputFormat.java
@@ -19,8 +19,12 @@ package org.bdgenomics.adam.io;
 
 import java.io.EOFException;
 import java.io.IOException;
+import org.apache.hadoop.fs.Path;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.io.Text;
+import org.apache.hadoop.io.compress.CompressionCodec;
+import org.apache.hadoop.io.compress.CompressionCodecFactory;
+import org.apache.hadoop.mapreduce.JobContext;
 import org.apache.hadoop.mapreduce.InputSplit;
 import org.apache.hadoop.mapreduce.RecordReader;
 import org.apache.hadoop.mapreduce.TaskAttemptContext;
@@ -34,6 +38,21 @@ import org.apache.hadoop.mapreduce.lib.input.FileSplit;
  * found at https://github.com/HadoopGenomics/Hadoop-BAM/blob/master/src/main/java/org/seqdoop/hadoop_bam/FastqInputFormat.java
  */
 public final class SingleFastqInputFormat extends FileInputFormat<Void, Text> {
+
+    /**
+     * For now, we do not support splittable compression codecs. As in, we will
+     * read the compressed data, but we will not allow it to be splittable. We
+     * will fix this in #1457.
+     *
+     * @param context The job context to get the configuration from.
+     * @param filename The path the input file is saved at.
+     * @return Returns false if this file is compressed.
+     */
+    @Override protected boolean isSplitable(JobContext context, Path filename) {
+        Configuration conf = context.getConfiguration();
+        final CompressionCodec codec = new CompressionCodecFactory(context.getConfiguration()).getCodec(filename);
+        return (codec == null);
+    }
 
     /**
      * A record reader for the standard FASTQ format.


### PR DESCRIPTION
Resolves #1459.