### PR TITLE
[ADAM-1467] Skip `concat` call if there is only one shard.

### DIFF
--- a/adam-core/src/main/scala/org/bdgenomics/adam/rdd/ParallelFileMerger.scala
+++ b/adam-core/src/main/scala/org/bdgenomics/adam/rdd/ParallelFileMerger.scala
@@ -329,8 +329,10 @@ private[rdd] object ParallelFileMerger extends Logging {
       val maybeUnqualifiedPath = indexToPath(idx, tmpPathString)
       fs.makeQualified(maybeUnqualifiedPath)
     })
-    fs.concat(outputPaths.head,
-      outputPaths.tail.toArray)
+    if (outputPaths.size > 1) {
+      fs.concat(outputPaths.head,
+        outputPaths.tail.toArray)
+    }
 
     fs.rename(outputPaths.head, outputPath)
   }


### PR DESCRIPTION
Resolves #1467.