### PR TITLE
[ADAM-1476] Treat `.` ALT allele as symbolic non-ref.

### DIFF
--- a/adam-core/src/main/scala/org/bdgenomics/adam/converters/VariantContextConverter.scala
+++ b/adam-core/src/main/scala/org/bdgenomics/adam/converters/VariantContextConverter.scala
@@ -190,9 +190,11 @@ class VariantContextConverter(
   def convert(
     vc: HtsjdkVariantContext): Seq[ADAMVariantContext] = {
 
+    log.info("Processing %s with alt alleles %s.".format(vc, vc.getAlternateAlleles.toList.mkString(",")))
+
     try {
       vc.getAlternateAlleles.toList match {
-        case List(NON_REF_ALLELE) => {
+        case List(NON_REF_ALLELE) | List() => {
           val variant = variantFormatFn(vc, None, 0)
           val genotypes = vc.getGenotypes.map(g => {
             genotypeFormatFn(g, variant, NON_REF_ALLELE, 0, Some(1), false)

--- a/adam-core/src/test/resources/test.vcf
+++ b/adam-core/src/test/resources/test.vcf
@@ -1,0 +1,24 @@
+##fileformat=VCFv4.1
+##fileDate=20090805
+##source=myImputationProgramV3.1
+##reference=file:///seq/references/1000GenomesPilot-NCBI36.fasta
+##contig=<ID=20,length=62435964,assembly=B36,md5=f126cdf8a6e0c7f379d618ff66beb2da,species="Homo sapiens",taxonomy=x>
+##phasing=partial
+##INFO=<ID=NS,Number=1,Type=Integer,Description="Number of Samples With Data">
+##INFO=<ID=DP,Number=1,Type=Integer,Description="Total Depth">
+##INFO=<ID=AF,Number=A,Type=Float,Description="Allele Frequency">
+##INFO=<ID=AA,Number=1,Type=String,Description="Ancestral Allele">
+##INFO=<ID=DB,Number=0,Type=Flag,Description="dbSNP membership, build 129">
+##INFO=<ID=H2,Number=0,Type=Flag,Description="HapMap2 membership">
+##FILTER=<ID=q10,Description="Quality below 10">
+##FILTER=<ID=s50,Description="Less than 50% of samples have data">
+##FORMAT=<ID=GT,Number=1,Type=String,Description="Genotype">
+##FORMAT=<ID=GQ,Number=1,Type=Integer,Description="Genotype Quality">
+##FORMAT=<ID=DP,Number=1,Type=Integer,Description="Read Depth">
+##FORMAT=<ID=HQ,Number=2,Type=Integer,Description="Haplotype Quality">
+#CHROM	POS	ID	REF	ALT	QUAL	FILTER	INFO	FORMAT	NA00001	NA00002	NA00003
+20	14370	rs6054257	G	A	29	PASS	NS=3;DP=14;AF=0.5;DB;H2	GT:GQ:DP:HQ	0|0:48:1:51,51	1|0:48:8:51,51	1/1:43:5:.,.
+20	17330	.	T	A	3	q10	NS=3;DP=11;AF=0.017	GT:GQ:DP:HQ	0|0:49:3:58,50	0|1:3:5:65,3	0/0:41:3
+20	1110696	rs6040355	A	G,T	67	PASS	NS=2;DP=10;AF=0.333,0.667;AA=T;DB	GT:GQ:DP:HQ	1|2:21:6:23,27	2|1:2:0:18,2	2/2:35:4
+20	1230237	.	T	.	47	PASS	NS=3;DP=13;AA=T	GT:GQ:DP:HQ	0|0:54:7:56,60	0|0:48:4:51,51	0/0:61:2
+20	1234567	microsat1	GTC	G,GTCT	50	PASS	NS=3;DP=9;AA=G	GT:GQ:DP	0/1:35:4	0/2:17:2	1/1:40:3

--- a/adam-core/src/test/scala/org/bdgenomics/adam/rdd/ADAMContextSuite.scala
+++ b/adam-core/src/test/scala/org/bdgenomics/adam/rdd/ADAMContextSuite.scala
@@ -182,31 +182,37 @@ class ADAMContextSuite extends ADAMFunSuite {
   sparkTest("can read a gzipped .vcf file") {
     val path = testFile("test.vcf.gz")
     val vcs = sc.loadVcf(path)
-    assert(vcs.rdd.count === 6)
+    assert(vcs.rdd.count === 7)
+  }
+
+  sparkTest("can read a vcf file with an empty alt") {
+    val path = testFile("test.vcf")
+    val vcs = sc.loadVariants(path)
+    assert(vcs.rdd.count === 7)
   }
 
   sparkTest("can read a BGZF gzipped .vcf file with .gz file extension") {
     val path = testFile("test.vcf.bgzf.gz")
     val vcs = sc.loadVcf(path)
-    assert(vcs.rdd.count === 6)
+    assert(vcs.rdd.count === 7)
   }
 
   sparkTest("can read a BGZF gzipped .vcf file with .bgz file extension") {
     val path = testFile("test.vcf.bgz")
     val vcs = sc.loadVcf(path)
-    assert(vcs.rdd.count === 6)
+    assert(vcs.rdd.count === 7)
   }
 
   ignore("can read an uncompressed BCFv2.2 file") { // see https://github.com/samtools/htsjdk/issues/507
     val path = testFile("test.uncompressed.bcf")
     val vcs = sc.loadVcf(path)
-    assert(vcs.rdd.count === 6)
+    assert(vcs.rdd.count === 7)
   }
 
   ignore("can read a BGZF compressed BCFv2.2 file") { // see https://github.com/samtools/htsjdk/issues/507
     val path = testFile("test.compressed.bcf")
     val vcs = sc.loadVcf(path)
-    assert(vcs.rdd.count === 6)
+    assert(vcs.rdd.count === 7)
   }
 
   sparkTest("loadIndexedVcf with 1 ReferenceRegion") {
@@ -392,7 +398,7 @@ class ADAMContextSuite extends ADAMFunSuite {
     val path = testFile("bqsr1.vcf").replace("bqsr1", "*")
 
     val variants = sc.loadVcf(path).toVariantRDD
-    assert(variants.rdd.count === 715)
+    assert(variants.rdd.count === 722)
   }
 
   sparkTest("load vcf from a directory") {


### PR DESCRIPTION
Resolves #1476.