### PR TITLE
[ADAM-1483] Remove collapse parameter from AlignmentRecordRDD.toCoverage

### DIFF
--- a/adam-core/src/main/scala/org/bdgenomics/adam/rdd/feature/CoverageRDD.scala
+++ b/adam-core/src/main/scala/org/bdgenomics/adam/rdd/feature/CoverageRDD.scala
@@ -108,9 +108,11 @@ case class CoverageRDD(rdd: RDD[Coverage],
    * For example, adjacent records Coverage("chr1", 1, 10, 3.0) and Coverage("chr1", 10, 20, 3.0)
    * would be merged into one record Coverage("chr1", 1, 20, 3.0).
    *
+   * @note Data must be sorted before collapse is called.
+   *
    * @return merged tuples of adjacent ReferenceRegions and coverage.
    */
-  def collapse: CoverageRDD = {
+  def collapse(): CoverageRDD = {
     val newRDD: RDD[Coverage] = rdd
       .mapPartitions(iter => {
         if (iter.hasNext) {

--- a/adam-core/src/test/scala/org/bdgenomics/adam/rdd/read/AlignmentRecordRDDSuite.scala
+++ b/adam-core/src/test/scala/org/bdgenomics/adam/rdd/read/AlignmentRecordRDDSuite.scala
@@ -103,7 +103,7 @@ class AlignmentRecordRDDSuite extends ADAMFunSuite {
 
     // get pileup at position 30
     val pointCoverage = reads.filterByOverlappingRegion(ReferenceRegion("artificial", 30, 31)).rdd.count
-    val coverage: CoverageRDD = reads.toCoverage(false)
+    val coverage: CoverageRDD = reads.toCoverage()
     assert(coverage.rdd.filter(r => r.start == 30).first.count == pointCoverage)
   }
 
@@ -113,7 +113,7 @@ class AlignmentRecordRDDSuite extends ADAMFunSuite {
 
     // get pileup at position 30
     val pointCoverage = reads.filterByOverlappingRegions(Array(ReferenceRegion("artificial", 30, 31)).toList).rdd.count
-    val coverage: CoverageRDD = reads.toCoverage(false)
+    val coverage: CoverageRDD = reads.toCoverage()
     assert(coverage.rdd.filter(r => r.start == 30).first.count == pointCoverage)
   }
 
@@ -122,7 +122,10 @@ class AlignmentRecordRDDSuite extends ADAMFunSuite {
     val reads: AlignmentRecordRDD = sc.loadAlignments(inputPath)
 
     // repartition reads to 1 partition to acheive maximal merging of coverage
-    val coverage: CoverageRDD = reads.transform(_.repartition(1)).toCoverage(true)
+    val coverage: CoverageRDD = reads.transform(_.repartition(1))
+      .toCoverage()
+      .sort()
+      .collapse()
 
     assert(coverage.rdd.count == 18)
     assert(coverage.flatten.rdd.count == 170)

--- a/docs/source/50_cli.md
+++ b/docs/source/50_cli.md
@@ -277,6 +277,8 @@ following options:
   negative strand. Conflicts with `-only_positive_strands`.
 * `-only_positive_strands`: Only computes coverage for reads aligned on the
   positive strand. Conflicts with `-only_negative_strands`.
+* `-sort_lexicographically`: Sorts coverage by position. Contigs are ordered
+  lexicographically. Only applies if running with `-collapse`.
 
 ## Conversion tools {#conversions}
 


### PR DESCRIPTION
Resolves #1483. Instead of providing a parameter in the `toCoverage` method to allow users to collapse the coverage, makes the `toCoverage` method stupid. This makes the `toCoverage` method simpler and the behavior easier to reason about.