### PR TITLE
[ADAM-1517] Move to Parquet 1.8.2 in preparation for moving to Spark 2.2.0

### DIFF
--- a/adam-apis/pom.xml
+++ b/adam-apis/pom.xml
@@ -91,6 +91,18 @@
 
   <dependencies>
     <dependency>
+      <groupId>org.apache.parquet</groupId>
+      <artifactId>parquet-avro</artifactId>
+      <version>1.8.1</version>
+      <scope>provided</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.parquet</groupId>
+      <artifactId>parquet-scala_2.10</artifactId>
+      <version>1.8.1</version>
+      <scope>provided</scope>
+    </dependency>
+    <dependency>
       <groupId>org.scala-lang</groupId>
       <artifactId>scala-library</artifactId>
       <scope>compile</scope>

--- a/adam-assembly/pom.xml
+++ b/adam-assembly/pom.xml
@@ -71,6 +71,10 @@
                   <pattern>org.apache.avro</pattern>
                   <shadedPattern>org.bdgenomics.avro</shadedPattern>
                 </relocation>
+                <relocation>
+                  <pattern>org.apache.parquet</pattern>
+                  <shadedPattern>org.bdgenomics.parquet</shadedPattern>
+                </relocation>
               </relocations>
             </configuration>
           </execution>
@@ -117,6 +121,16 @@
     </plugins>
   </build>
   <dependencies>
+    <dependency>
+      <groupId>org.apache.parquet</groupId>
+      <artifactId>parquet-avro</artifactId>
+      <scope>compile</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.parquet</groupId>
+      <artifactId>parquet-scala_2.10</artifactId>
+      <scope>compile</scope>
+    </dependency>
     <dependency>
       <groupId>org.bdgenomics.adam</groupId>
       <artifactId>adam-cli_${scala.version.prefix}</artifactId>

--- a/adam-assembly/pom.xml
+++ b/adam-assembly/pom.xml
@@ -66,6 +66,12 @@
               <transformers>
                 <transformer implementation="org.apache.maven.plugins.shade.resource.ServicesResourceTransformer"/>
               </transformers>
+              <relocations>
+                <relocation>
+                  <pattern>org.apache.avro</pattern>
+                  <shadedPattern>org.bdgenomics.avro</shadedPattern>
+                </relocation>
+              </relocations>
             </configuration>
           </execution>
         </executions>

--- a/adam-cli/pom.xml
+++ b/adam-cli/pom.xml
@@ -106,6 +106,18 @@
   </build>
   <dependencies>
     <dependency>
+      <groupId>org.apache.parquet</groupId>
+      <artifactId>parquet-avro</artifactId>
+      <version>1.8.1</version>
+      <scope>provided</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.parquet</groupId>
+      <artifactId>parquet-scala_2.10</artifactId>
+      <version>1.8.1</version>
+      <scope>provided</scope>
+    </dependency>
+    <dependency>
       <groupId>org.apache.hadoop</groupId>
       <artifactId>hadoop-client</artifactId>
       <!-- provided scope from parent -->

--- a/adam-core/pom.xml
+++ b/adam-core/pom.xml
@@ -240,12 +240,14 @@
     <dependency>
       <groupId>org.apache.parquet</groupId>
       <artifactId>parquet-avro</artifactId>
-      <scope>compile</scope>
+      <version>1.8.1</version>
+      <scope>provided</scope>
     </dependency>
     <dependency>
       <groupId>org.apache.parquet</groupId>
       <artifactId>parquet-scala_2.10</artifactId>
-      <scope>compile</scope>
+      <version>1.8.1</version>
+      <scope>provided</scope>
     </dependency>
     <dependency>
       <groupId>org.seqdoop</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -25,7 +25,7 @@
     <scala.version>2.10.6</scala.version>
     <scala.version.prefix>2.10</scala.version.prefix>
     <spark.version>1.6.3</spark.version>
-    <parquet.version>1.8.1</parquet.version>
+    <parquet.version>1.8.2</parquet.version>
     <!-- Edit the following line to configure the Hadoop (HDFS) version. -->
     <hadoop.version>2.7.3</hadoop.version>
     <hadoop-bam.version>7.8.0</hadoop-bam.version>


### PR DESCRIPTION
Bumps Parquet version to 1.8.2. Relocates `org.apache.avro` to `org.bdgenomics.avro`. Resolves #1517 pending release of and bump to Spark 2.2.0.