### PR TITLE
[ADAM-1499] Enable reuse of broadcasted objects in region join.

### DIFF
--- a/adam-core/src/main/scala/org/bdgenomics/adam/rdd/GenomicRDD.scala
+++ b/adam-core/src/main/scala/org/bdgenomics/adam/rdd/GenomicRDD.scala
@@ -431,8 +431,8 @@ trait GenomicRDD[T, U <: GenomicRDD[T, U]] {
   /**
    * Performs a broadcast inner join between this RDD and data that has been broadcast.
    *
-   * In a broadcast join, the left RDD is collected to the driver,
-   * and broadcast to all the nodes in the cluster (broadcastTree). The key equality
+   * In a broadcast join, the left side of the join (broadcastTree) is broadcast to
+   * to all the nodes in the cluster. The key equality
    * function used for this join is the reference region overlap function. Since this
    * is an inner join, all values who do not overlap a value from the other
    * RDD are dropped. As compared to broadcastRegionJoin, this function allows the
@@ -499,12 +499,12 @@ trait GenomicRDD[T, U <: GenomicRDD[T, U]] {
   /**
    * Performs a broadcast right outer join between this RDD and data that has been broadcast.
    *
-   * In a broadcast join, the left RDD is collected to the driver,
-   * and broadcast to all the nodes in the cluster (broadcastTree). The key equality
+   * In a broadcast join, the left side of the join (broadcastTree) is broadcast to
+   * to all the nodes in the cluster. The key equality
    * function used for this join is the reference region overlap function. Since this
-   * is a right outer join, all values in the left RDD that do not overlap a
+   * is a right outer join, all values in the left table that do not overlap a
    * value from the right RDD are dropped. If a value from the right RDD does
-   * not overlap any values in the left RDD, it will be paired with a `None`
+   * not overlap any values in the left table, it will be paired with a `None`
    * in the product of the join. As compared to broadcastRegionJoin, this function allows the
    * broadcast object to be reused across multiple joins.
    *
@@ -600,8 +600,8 @@ trait GenomicRDD[T, U <: GenomicRDD[T, U]] {
   /**
    * Performs a broadcast inner join between this RDD and another RDD.
    *
-   * In a broadcast join, the left RDD (this RDD) is collected to the driver,
-   * and broadcast to all the nodes in the cluster. The key equality function
+   * In a broadcast join, the left side of the join (broadcastTree) is broadcast to
+   * to all the nodes in the cluster. The key equality function
    * used for this join is the reference region overlap function. Since this
    * is an inner join, all values who do not overlap a value from the other
    * RDD are dropped. As compared to broadcastRegionJoin, this function allows
@@ -632,8 +632,8 @@ trait GenomicRDD[T, U <: GenomicRDD[T, U]] {
   /**
    * Performs a broadcast right outer join between this RDD and another RDD.
    *
-   * In a broadcast join, the left RDD (this RDD) is collected to the driver,
-   * and broadcast to all the nodes in the cluster. The key equality function
+   * In a broadcast join, the left side of the join (broadcastTree) is broadcast to
+   * to all the nodes in the cluster. The key equality function
    * used for this join is the reference region overlap function. Since this
    * is a right outer join, all values in the left RDD that do not overlap a
    * value from the right RDD are dropped. If a value from the right RDD does
@@ -667,12 +667,12 @@ trait GenomicRDD[T, U <: GenomicRDD[T, U]] {
   /**
    * Performs a broadcast right outer join between this RDD and another RDD.
    *
-   * In a broadcast join, the left RDD (this RDD) is collected to the driver,
-   * and broadcast to all the nodes in the cluster. The key equality function
+   * In a broadcast join, the left side of the join (broadcastTree) is broadcast to
+   * to all the nodes in the cluster. The key equality function
    * used for this join is the reference region overlap function. Since this
-   * is a right outer join, all values in the left RDD that do not overlap a
+   * is a right outer join, all values in the left table that do not overlap a
    * value from the right RDD are dropped. If a value from the right RDD does
-   * not overlap any values in the left RDD, it will be paired with a `None`
+   * not overlap any values in the left table, it will be paired with a `None`
    * in the product of the join. As compared to broadcastRegionJoin, this
    * function allows the broadcast object to be reused across multiple joins.
    *

--- a/docs/source/55_api.md
+++ b/docs/source/55_api.md
@@ -267,18 +267,18 @@ functions. For example, given the following code:
 
 ```scala
 val reads = sc.loadAlignments("my/reads.adam")
-val panel = sc.loadFeatures("my/panel/features.adam")
+val features = sc.loadFeatures("my/features.adam")
 
-val readsByFeature = panel.broadcastRegionJoin(reads)
+val readsByFeature = features.broadcastRegionJoin(reads)
 ```
 
-We can get a handle to the broadcast panel by rewriting the code as:
+We can get a handle to the broadcast features by rewriting the code as:
 
 ```scala
 val reads = sc.loadAlignments("my/reads.adam")
-val bcastPanel = sc.loadFeatures("my/panel/features.adam").broadcast()
+val bcastFeatures = sc.loadFeatures("my/features.adam").broadcast()
 
-val readsByFeature = reads.broadcastRegionJoinAgainst(bcastPanel)
+val readsByFeature = reads.broadcastRegionJoinAgainst(bcastFeatures)
 ```
 
 ## Using ADAM's Pipe API {#pipes}

--- a/docs/source/55_api.md
+++ b/docs/source/55_api.md
@@ -253,10 +253,33 @@ Join call | action | Availability
 ```dataset1.leftOuterShuffleRegionJoin(dataset2)```|perform a left outer join | ShuffleRegionJoin
 ```dataset1.rightOuterShuffleRegionJoin(dataset2)``` ```dataset1.rightOuterBroadcastRegionJoin(dataset2)```|perform a right outer join | ShuffleRegionJoin BroadcastRegionJoin
 ```dataset1.shuffleRegionJoinAndGroupByLeft(dataset2)``` |perform an inner join and group joined values by the records on the left | ShuffleRegionJoin
-```dataset1.broadcastRegionJoinnAndGroupByRight(dataset2)``` | perform an inner join and group joined values by the records on the right | ShuffleRegionJoin
+```dataset1.broadcastRegionJoinAndGroupByRight(dataset2)``` | perform an inner join and group joined values by the records on the right | ShuffleRegionJoin
 ```dataset1.rightOuterShuffleRegionJoinAndGroupByLeft(dataset2)```|perform a right outer join and group joined values by the records on the left | ShuffleRegionJoin
 ```rightOuterBroadcastRegionJoinAndGroupByRight``` | perform a right outer join and group joined values by the records on the right | BroadcastRegionJoin
 
+One common pattern involves joining a single dataset against many datasets. An
+example of this is joining an RDD of features (e.g., gene/exon coordinates)
+against many different RDD's of reads. If the object that is being used many
+times (gene/exon coordinates, in this case), we can force that object to be
+broadcast once and reused many times with the `broadcast()` function. This
+pairs with the `broadcastRegionJoin` and `rightOuterBroadcastRegionJoin`
+functions. For example, given the following code:
+
+```scala
+val reads = sc.loadAlignments("my/reads.adam")
+val panel = sc.loadFeatures("my/panel/features.adam")
+
+val readsByFeature = panel.broadcastRegionJoin(reads)
+```
+
+We can get a handle to the broadcast panel by rewriting the code as:
+
+```scala
+val reads = sc.loadAlignments("my/reads.adam")
+val bcastPanel = sc.loadFeatures("my/panel/features.adam").broadcast()
+
+val readsByFeature = reads.broadcastRegionJoinAgainst(bcastPanel)
+```
 
 ## Using ADAM's Pipe API {#pipes}
 

--- a/pom.xml
+++ b/pom.xml
@@ -496,7 +496,7 @@
       </dependency>
       <dependency>
         <groupId>org.apache.parquet</groupId>
-        <!-- This library has no Scala 2.11 version, but using the 2 dot 10 version seems to work. -->
+        <!-- This library has no Scala 2.11 version, but using the 2.10 version seems to work. -->
         <artifactId>parquet-scala_2.10</artifactId>
         <version>${parquet.version}</version>
         <exclusions>

--- a/pom.xml
+++ b/pom.xml
@@ -496,7 +496,7 @@
       </dependency>
       <dependency>
         <groupId>org.apache.parquet</groupId>
-        <!-- This library has no Scala 2.11 version, but using the 2.10 version seems to work. -->
+        <!-- This library has no Scala 2.11 version, but using the 2 dot 10 version seems to work. -->
         <artifactId>parquet-scala_2.10</artifactId>
         <version>${parquet.version}</version>
         <exclusions>


### PR DESCRIPTION
Resolves #1499.