### PR TITLE
[ADAM-1497] Add union to GenomicRDD.

### DIFF
--- a/adam-core/src/main/scala/org/bdgenomics/adam/models/RecordGroupDictionary.scala
+++ b/adam-core/src/main/scala/org/bdgenomics/adam/models/RecordGroupDictionary.scala
@@ -59,6 +59,11 @@ object RecordGroupDictionary {
 case class RecordGroupDictionary(recordGroups: Seq[RecordGroup]) {
 
   /**
+   * The number of record groups in the dictionary.
+   */
+  def size: Int = recordGroups.size
+
+  /**
    * @return Returns true if this dictionary contains no record groups.
    */
   def isEmpty: Boolean = {

--- a/adam-core/src/main/scala/org/bdgenomics/adam/models/SequenceDictionary.scala
+++ b/adam-core/src/main/scala/org/bdgenomics/adam/models/SequenceDictionary.scala
@@ -119,6 +119,11 @@ class SequenceDictionary(val records: Vector[SequenceRecord]) extends Serializab
   private val hasSequenceOrdering = records.forall(_.referenceIndex.isDefined)
 
   /**
+   * The number of sequences in the dictionary.
+   */
+  def size: Int = records.size
+
+  /**
    * @param that Sequence dictionary to compare against.
    * @return True if each record in this dictionary exists in the other dictionary.
    */

--- a/adam-core/src/main/scala/org/bdgenomics/adam/rdd/GenomicRDD.scala
+++ b/adam-core/src/main/scala/org/bdgenomics/adam/rdd/GenomicRDD.scala
@@ -118,6 +118,13 @@ trait GenomicRDD[T, U <: GenomicRDD[T, U]] {
   }
 
   /**
+   * Unions together multiple genomic RDDs.
+   *
+   * @param rdds RDDs to union with this RDD.
+   */
+  def union(rdds: U*): U
+
+  /**
    * Applies a function that transforms the underlying RDD into a new RDD.
    *
    * @param tFn A function that transforms the underlying RDD.
@@ -400,7 +407,9 @@ trait GenomicRDD[T, U <: GenomicRDD[T, U]] {
    */
   def broadcastRegionJoin[X, Y <: GenomicRDD[X, Y], Z <: GenomicRDD[(T, X), Z]](
     genomicRdd: GenomicRDD[X, Y])(
-      implicit tTag: ClassTag[T], xTag: ClassTag[X]): GenomicRDD[(T, X), Z] = InnerBroadcastJoin.time {
+      implicit tTag: ClassTag[T],
+      xTag: ClassTag[X],
+      txTag: ClassTag[(T, X)]): GenomicRDD[(T, X), Z] = InnerBroadcastJoin.time {
 
     // key the RDDs and join
     GenericGenomicRDD[(T, X)](InnerTreeRegionJoin[T, X]().broadcastAndJoin(
@@ -429,7 +438,9 @@ trait GenomicRDD[T, U <: GenomicRDD[T, U]] {
    */
   def rightOuterBroadcastRegionJoin[X, Y <: GenomicRDD[X, Y], Z <: GenomicRDD[(Option[T], X), Z]](
     genomicRdd: GenomicRDD[X, Y])(
-      implicit tTag: ClassTag[T], xTag: ClassTag[X]): GenomicRDD[(Option[T], X), Z] = RightOuterBroadcastJoin.time {
+      implicit tTag: ClassTag[T],
+      xTag: ClassTag[X],
+      otxTag: ClassTag[(Option[T], X)]): GenomicRDD[(Option[T], X), Z] = RightOuterBroadcastJoin.time {
 
     // key the RDDs and join
     GenericGenomicRDD[(Option[T], X)](RightOuterTreeRegionJoin[T, X]().broadcastAndJoin(
@@ -493,7 +504,9 @@ trait GenomicRDD[T, U <: GenomicRDD[T, U]] {
    *   overlapped in the genomic coordinate space.
    */
   def broadcastRegionJoinAndGroupByRight[X, Y <: GenomicRDD[X, Y], Z <: GenomicRDD[(Iterable[T], X), Z]](genomicRdd: GenomicRDD[X, Y])(
-    implicit tTag: ClassTag[T], xTag: ClassTag[X]): GenomicRDD[(Iterable[T], X), Z] = BroadcastJoinAndGroupByRight.time {
+    implicit tTag: ClassTag[T],
+    xTag: ClassTag[X],
+    itxTag: ClassTag[(Iterable[T], X)]): GenomicRDD[(Iterable[T], X), Z] = BroadcastJoinAndGroupByRight.time {
 
     // key the RDDs and join
     GenericGenomicRDD[(Iterable[T], X)](InnerTreeRegionJoinAndGroupByRight[T, X]().broadcastAndJoin(
@@ -521,7 +534,9 @@ trait GenomicRDD[T, U <: GenomicRDD[T, U]] {
    *   right RDD that did not overlap a key in the left RDD.
    */
   def rightOuterBroadcastRegionJoinAndGroupByRight[X, Y <: GenomicRDD[X, Y], Z <: GenomicRDD[(Iterable[T], X), Z]](genomicRdd: GenomicRDD[X, Y])(
-    implicit tTag: ClassTag[T], xTag: ClassTag[X]): GenomicRDD[(Iterable[T], X), Z] = RightOuterBroadcastJoinAndGroupByRight.time {
+    implicit tTag: ClassTag[T],
+    xTag: ClassTag[X],
+    itxTag: ClassTag[(Iterable[T], X)]): GenomicRDD[(Iterable[T], X), Z] = RightOuterBroadcastJoinAndGroupByRight.time {
 
     // key the RDDs and join
     GenericGenomicRDD[(Iterable[T], X)](RightOuterTreeRegionJoinAndGroupByRight[T, X]().broadcastAndJoin(
@@ -551,7 +566,9 @@ trait GenomicRDD[T, U <: GenomicRDD[T, U]] {
   def shuffleRegionJoin[X, Y <: GenomicRDD[X, Y], Z <: GenomicRDD[(T, X), Z]](
     genomicRdd: GenomicRDD[X, Y],
     optPartitions: Option[Int] = None)(
-      implicit tTag: ClassTag[T], xTag: ClassTag[X]): GenomicRDD[(T, X), Z] = InnerShuffleJoin.time {
+      implicit tTag: ClassTag[T],
+      xTag: ClassTag[X],
+      txTag: ClassTag[(T, X)]): GenomicRDD[(T, X), Z] = InnerShuffleJoin.time {
 
     val (partitionSize, endSequences) = joinPartitionSizeAndSequences(optPartitions,
       genomicRdd)
@@ -586,7 +603,9 @@ trait GenomicRDD[T, U <: GenomicRDD[T, U]] {
   def rightOuterShuffleRegionJoin[X, Y <: GenomicRDD[X, Y], Z <: GenomicRDD[(Option[T], X), Z]](
     genomicRdd: GenomicRDD[X, Y],
     optPartitions: Option[Int] = None)(
-      implicit tTag: ClassTag[T], xTag: ClassTag[X]): GenomicRDD[(Option[T], X), Z] = RightOuterShuffleJoin.time {
+      implicit tTag: ClassTag[T],
+      xTag: ClassTag[X],
+      otxTag: ClassTag[(Option[T], X)]): GenomicRDD[(Option[T], X), Z] = RightOuterShuffleJoin.time {
 
     val (partitionSize, endSequences) = joinPartitionSizeAndSequences(optPartitions,
       genomicRdd)
@@ -624,7 +643,9 @@ trait GenomicRDD[T, U <: GenomicRDD[T, U]] {
   def leftOuterShuffleRegionJoin[X, Y <: GenomicRDD[X, Y], Z <: GenomicRDD[(T, Option[X]), Z]](
     genomicRdd: GenomicRDD[X, Y],
     optPartitions: Option[Int] = None)(
-      implicit tTag: ClassTag[T], xTag: ClassTag[X]): GenomicRDD[(T, Option[X]), Z] = LeftOuterShuffleJoin.time {
+      implicit tTag: ClassTag[T],
+      xTag: ClassTag[X],
+      toxTag: ClassTag[(T, Option[X])]): GenomicRDD[(T, Option[X]), Z] = LeftOuterShuffleJoin.time {
 
     val (partitionSize, endSequences) = joinPartitionSizeAndSequences(optPartitions,
       genomicRdd)
@@ -661,7 +682,9 @@ trait GenomicRDD[T, U <: GenomicRDD[T, U]] {
   def fullOuterShuffleRegionJoin[X, Y <: GenomicRDD[X, Y], Z <: GenomicRDD[(Option[T], Option[X]), Z]](
     genomicRdd: GenomicRDD[X, Y],
     optPartitions: Option[Int] = None)(
-      implicit tTag: ClassTag[T], xTag: ClassTag[X]): GenomicRDD[(Option[T], Option[X]), Z] = FullOuterShuffleJoin.time {
+      implicit tTag: ClassTag[T],
+      xTag: ClassTag[X],
+      otoxTag: ClassTag[(Option[T], Option[X])]): GenomicRDD[(Option[T], Option[X]), Z] = FullOuterShuffleJoin.time {
 
     val (partitionSize, endSequences) = joinPartitionSizeAndSequences(optPartitions,
       genomicRdd)
@@ -699,7 +722,9 @@ trait GenomicRDD[T, U <: GenomicRDD[T, U]] {
   def shuffleRegionJoinAndGroupByLeft[X, Y <: GenomicRDD[X, Y], Z <: GenomicRDD[(T, Iterable[X]), Z]](
     genomicRdd: GenomicRDD[X, Y],
     optPartitions: Option[Int] = None)(
-      implicit tTag: ClassTag[T], xTag: ClassTag[X]): GenomicRDD[(T, Iterable[X]), Z] = ShuffleJoinAndGroupByLeft.time {
+      implicit tTag: ClassTag[T],
+      xTag: ClassTag[X],
+      tixTag: ClassTag[(T, Iterable[X])]): GenomicRDD[(T, Iterable[X]), Z] = ShuffleJoinAndGroupByLeft.time {
 
     val (partitionSize, endSequences) = joinPartitionSizeAndSequences(optPartitions,
       genomicRdd)
@@ -739,7 +764,9 @@ trait GenomicRDD[T, U <: GenomicRDD[T, U]] {
   def rightOuterShuffleRegionJoinAndGroupByLeft[X, Y <: GenomicRDD[X, Y], Z <: GenomicRDD[(Option[T], Iterable[X]), Z]](
     genomicRdd: GenomicRDD[X, Y],
     optPartitions: Option[Int] = None)(
-      implicit tTag: ClassTag[T], xTag: ClassTag[X]): GenomicRDD[(Option[T], Iterable[X]), Z] = RightOuterShuffleJoinAndGroupByLeft.time {
+      implicit tTag: ClassTag[T],
+      xTag: ClassTag[X],
+      otixTag: ClassTag[(Option[T], Iterable[X])]): GenomicRDD[(Option[T], Iterable[X]), Z] = RightOuterShuffleJoinAndGroupByLeft.time {
 
     val (partitionSize, endSequences) = joinPartitionSizeAndSequences(optPartitions,
       genomicRdd)
@@ -759,9 +786,17 @@ trait GenomicRDD[T, U <: GenomicRDD[T, U]] {
   }
 }
 
-private case class GenericGenomicRDD[T](rdd: RDD[T],
-                                        sequences: SequenceDictionary,
-                                        regionFn: T => Seq[ReferenceRegion]) extends GenomicRDD[T, GenericGenomicRDD[T]] {
+private case class GenericGenomicRDD[T](
+    rdd: RDD[T],
+    sequences: SequenceDictionary,
+    regionFn: T => Seq[ReferenceRegion])(implicit tTag: ClassTag[T]) extends GenomicRDD[T, GenericGenomicRDD[T]] {
+
+  def union(rdds: GenericGenomicRDD[T]*): GenericGenomicRDD[T] = {
+    val iterableRdds = rdds.toSeq
+    GenericGenomicRDD(rdd.context.union(rdd, iterableRdds.map(_.rdd): _*),
+      iterableRdds.map(_.sequences).fold(sequences)(_ ++ _),
+      regionFn)
+  }
 
   protected def buildTree(
     rdd: RDD[(ReferenceRegion, T)])(

--- a/adam-core/src/main/scala/org/bdgenomics/adam/rdd/contig/NucleotideContigFragmentRDD.scala
+++ b/adam-core/src/main/scala/org/bdgenomics/adam/rdd/contig/NucleotideContigFragmentRDD.scala
@@ -119,6 +119,12 @@ case class NucleotideContigFragmentRDD(
     FragmentConverter.convertRdd(rdd)
   }
 
+  def union(rdds: NucleotideContigFragmentRDD*): NucleotideContigFragmentRDD = {
+    val iterableRdds = rdds.toSeq
+    NucleotideContigFragmentRDD(rdd.context.union(rdd, iterableRdds.map(_.rdd): _*),
+      iterableRdds.map(_.sequences).fold(sequences)(_ ++ _))
+  }
+
   /**
    * Replaces the underlying RDD with a new RDD.
    *

--- a/adam-core/src/main/scala/org/bdgenomics/adam/rdd/feature/CoverageRDD.scala
+++ b/adam-core/src/main/scala/org/bdgenomics/adam/rdd/feature/CoverageRDD.scala
@@ -74,6 +74,12 @@ case class CoverageRDD(rdd: RDD[Coverage],
     IntervalArray(rdd, CoverageArray.apply(_, _))
   }
 
+  def union(rdds: CoverageRDD*): CoverageRDD = {
+    val iterableRdds = rdds.toSeq
+    CoverageRDD(rdd.context.union(rdd, iterableRdds.map(_.rdd): _*),
+      iterableRdds.map(_.sequences).fold(sequences)(_ ++ _))
+  }
+
   /**
    * Saves coverage as feature file.
    *

--- a/adam-core/src/main/scala/org/bdgenomics/adam/rdd/feature/FeatureRDD.scala
+++ b/adam-core/src/main/scala/org/bdgenomics/adam/rdd/feature/FeatureRDD.scala
@@ -250,6 +250,12 @@ case class FeatureRDD(rdd: RDD[Feature],
     IntervalArray(rdd, FeatureArray.apply(_, _))
   }
 
+  def union(rdds: FeatureRDD*): FeatureRDD = {
+    val iterableRdds = rdds.toSeq
+    FeatureRDD(rdd.context.union(rdd, iterableRdds.map(_.rdd): _*),
+      iterableRdds.map(_.sequences).fold(sequences)(_ ++ _))
+  }
+
   /**
    * Java friendly save function. Automatically detects the output format.
    *

--- a/adam-core/src/main/scala/org/bdgenomics/adam/rdd/fragment/FragmentRDD.scala
+++ b/adam-core/src/main/scala/org/bdgenomics/adam/rdd/fragment/FragmentRDD.scala
@@ -125,6 +125,13 @@ case class FragmentRDD(rdd: RDD[Fragment],
     copy(rdd = newRdd)
   }
 
+  def union(rdds: FragmentRDD*): FragmentRDD = {
+    val iterableRdds = rdds.toSeq
+    FragmentRDD(rdd.context.union(rdd, iterableRdds.map(_.rdd): _*),
+      iterableRdds.map(_.sequences).fold(sequences)(_ ++ _),
+      iterableRdds.map(_.recordGroups).fold(recordGroups)(_ ++ _))
+  }
+
   /**
    * Essentially, splits up the reads in a Fragment.
    *

--- a/adam-core/src/main/scala/org/bdgenomics/adam/rdd/read/AlignmentRecordRDD.scala
+++ b/adam-core/src/main/scala/org/bdgenomics/adam/rdd/read/AlignmentRecordRDD.scala
@@ -152,6 +152,13 @@ case class AlignmentRecordRDD(
     IntervalArray(rdd, AlignmentRecordArray.apply(_, _))
   }
 
+  def union(rdds: AlignmentRecordRDD*): AlignmentRecordRDD = {
+    val iterableRdds = rdds.toSeq
+    AlignmentRecordRDD(rdd.context.union(rdd, iterableRdds.map(_.rdd): _*),
+      iterableRdds.map(_.sequences).fold(sequences)(_ ++ _),
+      iterableRdds.map(_.recordGroups).fold(recordGroups)(_ ++ _))
+  }
+
   /**
    * Convert this set of reads into fragments.
    *

--- a/adam-core/src/main/scala/org/bdgenomics/adam/rdd/variant/VariantContextRDD.scala
+++ b/adam-core/src/main/scala/org/bdgenomics/adam/rdd/variant/VariantContextRDD.scala
@@ -98,6 +98,15 @@ case class VariantContextRDD(rdd: RDD[VariantContext],
     IntervalArray(rdd, VariantContextArray.apply(_, _))
   }
 
+  def union(rdds: VariantContextRDD*): VariantContextRDD = {
+    val iterableRdds = rdds.toSeq
+    VariantContextRDD(
+      rdd.context.union(rdd, iterableRdds.map(_.rdd): _*),
+      iterableRdds.map(_.sequences).fold(sequences)(_ ++ _),
+      (samples ++ iterableRdds.flatMap(_.samples)).distinct,
+      (headerLines ++ iterableRdds.flatMap(_.headerLines)).distinct)
+  }
+
   /**
    * @return Returns a GenotypeRDD containing the Genotypes in this RDD.
    */

--- a/adam-core/src/main/scala/org/bdgenomics/adam/rdd/variant/VariantRDD.scala
+++ b/adam-core/src/main/scala/org/bdgenomics/adam/rdd/variant/VariantRDD.scala
@@ -104,6 +104,13 @@ case class VariantRDD(rdd: RDD[Variant],
       contigs)
   }
 
+  def union(rdds: VariantRDD*): VariantRDD = {
+    val iterableRdds = rdds.toSeq
+    VariantRDD(rdd.context.union(rdd, iterableRdds.map(_.rdd): _*),
+      iterableRdds.map(_.sequences).fold(sequences)(_ ++ _),
+      (headerLines ++ iterableRdds.flatMap(_.headerLines)).distinct)
+  }
+
   /**
    * Java-friendly method for saving to Parquet.
    *

--- a/adam-core/src/test/scala/org/bdgenomics/adam/rdd/contig/NucleotideContigFragmentRDDSuite.scala
+++ b/adam-core/src/test/scala/org/bdgenomics/adam/rdd/contig/NucleotideContigFragmentRDDSuite.scala
@@ -21,12 +21,20 @@ import java.io.File
 
 import com.google.common.io.Files
 import org.bdgenomics.adam.models._
+import org.bdgenomics.adam.rdd.ADAMContext._
 import org.bdgenomics.adam.util.ADAMFunSuite
 import org.bdgenomics.formats.avro._
-
 import scala.collection.mutable.ListBuffer
 
 class NucleotideContigFragmentRDDSuite extends ADAMFunSuite {
+
+  sparkTest("union two ncf rdds together") {
+    val fragments1 = sc.loadFasta(testFile("HLA_DQB1_05_01_01_02.fa"), 10000L)
+    val fragments2 = sc.loadFasta(testFile("artificial.fa"))
+    val union = fragments1.union(fragments2)
+    assert(union.rdd.count === (fragments1.rdd.count + fragments2.rdd.count))
+    assert(union.sequences.size === 2)
+  }
 
   sparkTest("generate sequence dict from fasta") {
     val contig0 = Contig.newBuilder

--- a/adam-core/src/test/scala/org/bdgenomics/adam/rdd/feature/CoverageRDDSuite.scala
+++ b/adam-core/src/test/scala/org/bdgenomics/adam/rdd/feature/CoverageRDDSuite.scala
@@ -64,6 +64,8 @@ class CoverageRDDSuite extends ADAMFunSuite {
     val inputPath = testFile("sample_coverage.bed")
     val coverage = sc.loadCoverage(inputPath)
     assert(coverage.rdd.count() == 3)
+    val selfUnion = coverage.union(coverage)
+    assert(selfUnion.rdd.count === 6)
   }
 
   sparkTest("correctly filters coverage with predicate") {

--- a/adam-core/src/test/scala/org/bdgenomics/adam/rdd/feature/FeatureRDDSuite.scala
+++ b/adam-core/src/test/scala/org/bdgenomics/adam/rdd/feature/FeatureRDDSuite.scala
@@ -733,6 +733,15 @@ class FeatureRDDSuite extends ADAMFunSuite with TypeCheckedTripleEquals {
     assert(c0.filter(_._1.isEmpty).forall(_._2.size == 1))
   }
 
+  sparkTest("union two feature rdds together") {
+    val features1 = sc.loadGtf(testFile("Homo_sapiens.GRCh37.75.trun100.gtf"))
+    val features2 = sc.loadGff3(testFile("dvl1.200.gff3"))
+    val union = features1.union(features2)
+    assert(union.rdd.count === (features1.rdd.count + features2.rdd.count))
+    // only a single contig between the two
+    assert(union.sequences.size === 1)
+  }
+
   sparkTest("estimate sequence dictionary contig lengths from GTF format") {
     val inputPath = testFile("Homo_sapiens.GRCh37.75.trun100.gtf")
     val features = sc.loadGtf(inputPath)

--- a/adam-core/src/test/scala/org/bdgenomics/adam/rdd/fragment/FragmentRDDSuite.scala
+++ b/adam-core/src/test/scala/org/bdgenomics/adam/rdd/fragment/FragmentRDDSuite.scala
@@ -267,4 +267,15 @@ class FragmentRDDSuite extends ADAMFunSuite {
     assert(qualityScoreCounts(30) === 92899)
     assert(qualityScoreCounts(10) === 7101)
   }
+
+  sparkTest("union two rdds of fragments together") {
+    val reads1 = sc.loadAlignments(testFile("bqsr1.sam")).toFragments
+    val reads2 = sc.loadAlignments(testFile("small.sam")).toFragments
+    val union = reads1.union(reads2)
+    assert(union.rdd.count === (reads1.rdd.count + reads2.rdd.count))
+    // all of the contigs small.sam has are in bqsr1.sam
+    assert(union.sequences.size === reads1.sequences.size)
+    // small.sam has no record groups
+    assert(union.recordGroups.size === reads1.recordGroups.size)
+  }
 }

--- a/adam-core/src/test/scala/org/bdgenomics/adam/rdd/read/AlignmentRecordRDDSuite.scala
+++ b/adam-core/src/test/scala/org/bdgenomics/adam/rdd/read/AlignmentRecordRDDSuite.scala
@@ -942,4 +942,15 @@ class AlignmentRecordRDDSuite extends ADAMFunSuite {
     assert(qualityScoreCounts(30) === 92899)
     assert(qualityScoreCounts(10) === 7101)
   }
+
+  sparkTest("union two read files together") {
+    val reads1 = sc.loadAlignments(testFile("bqsr1.sam"))
+    val reads2 = sc.loadAlignments(testFile("small.sam"))
+    val union = reads1.union(reads2)
+    assert(union.rdd.count === (reads1.rdd.count + reads2.rdd.count))
+    // all of the contigs small.sam has are in bqsr1.sam
+    assert(union.sequences.size === reads1.sequences.size)
+    // small.sam has no record groups
+    assert(union.recordGroups.size === reads1.recordGroups.size)
+  }
 }

--- a/adam-core/src/test/scala/org/bdgenomics/adam/rdd/variant/GenotypeRDDSuite.scala
+++ b/adam-core/src/test/scala/org/bdgenomics/adam/rdd/variant/GenotypeRDDSuite.scala
@@ -22,6 +22,15 @@ import org.bdgenomics.adam.util.ADAMFunSuite
 
 class GenotypeRDDSuite extends ADAMFunSuite {
 
+  sparkTest("union two genotype rdds together") {
+    val genotype1 = sc.loadGenotypes(testFile("gvcf_dir/gvcf_multiallelic.g.vcf"))
+    val genotype2 = sc.loadGenotypes(testFile("small.vcf"))
+    val union = genotype1.union(genotype2)
+    assert(union.rdd.count === (genotype1.rdd.count + genotype2.rdd.count))
+    assert(union.sequences.size === (genotype1.sequences.size + genotype2.sequences.size))
+    assert(union.samples.size === 4)
+  }
+
   sparkTest("use broadcast join to pull down genotypes mapped to targets") {
     val genotypesPath = testFile("small.vcf")
     val targetsPath = testFile("small.1.bed")

--- a/adam-core/src/test/scala/org/bdgenomics/adam/rdd/variant/VariantContextRDDSuite.scala
+++ b/adam-core/src/test/scala/org/bdgenomics/adam/rdd/variant/VariantContextRDDSuite.scala
@@ -62,6 +62,15 @@ class VariantContextRDDSuite extends ADAMFunSuite {
         .build))
   }
 
+  sparkTest("union two variant context rdds together") {
+    val vc1 = sc.loadVcf(testFile("gvcf_dir/gvcf_multiallelic.g.vcf"))
+    val vc2 = sc.loadVcf(testFile("small.vcf"))
+    val union = vc1.union(vc2)
+    assert(union.rdd.count === (vc1.rdd.count + vc2.rdd.count))
+    assert(union.sequences.size === (vc1.sequences.size + vc2.sequences.size))
+    assert(union.samples.size === 4)
+  }
+
   sparkTest("can write, then read in .vcf file") {
     val path = new File(tempDir, "test.vcf")
     variants.saveAsVcf(TestSaveArgs(path.getAbsolutePath), false)

--- a/adam-core/src/test/scala/org/bdgenomics/adam/rdd/variant/VariantRDDSuite.scala
+++ b/adam-core/src/test/scala/org/bdgenomics/adam/rdd/variant/VariantRDDSuite.scala
@@ -22,6 +22,14 @@ import org.bdgenomics.adam.util.ADAMFunSuite
 
 class VariantRDDSuite extends ADAMFunSuite {
 
+  sparkTest("union two variant rdds together") {
+    val variant1 = sc.loadVariants(testFile("gvcf_dir/gvcf_multiallelic.g.vcf"))
+    val variant2 = sc.loadVariants(testFile("small.vcf"))
+    val union = variant1.union(variant2)
+    assert(union.rdd.count === (variant1.rdd.count + variant2.rdd.count))
+    assert(union.sequences.size === (variant1.sequences.size + variant2.sequences.size))
+  }
+
   sparkTest("use broadcast join to pull down variants mapped to targets") {
     val variantsPath = testFile("small.vcf")
     val targetsPath = testFile("small.1.bed")


### PR DESCRIPTION
Resolves #1497. Also adds `size` methods to `SequenceDictionary` and `RecordGroupDictionary`. Requires the addition of a `ClassTag` to the `GenericGenomicRDD` case class.