### PR TITLE
[ADAM-1549] Make regions provided to filterByOverlappingRegions an Iterable.

### DIFF
--- a/adam-core/src/main/scala/org/bdgenomics/adam/rdd/GenomicRDD.scala
+++ b/adam-core/src/main/scala/org/bdgenomics/adam/rdd/GenomicRDD.scala
@@ -382,7 +382,7 @@ trait GenomicRDD[T, U <: GenomicRDD[T, U]] {
    * @return Returns a new GenomicRDD containing only data that overlaps the
    *   querys region.
    */
-  def filterByOverlappingRegions(querys: List[ReferenceRegion]): U = {
+  def filterByOverlappingRegions(querys: Iterable[ReferenceRegion]): U = {
     replaceRdd(rdd.filter(elem => {
 
       val regions = getReferenceRegions(elem)


### PR DESCRIPTION
Resolves #1549.