### PR TITLE
[ADAM-1562] Index off by one for VCF genotype Number=A attributes.

### DIFF
--- a/adam-core/src/main/scala/org/bdgenomics/adam/converters/VariantContextConverter.scala
+++ b/adam-core/src/main/scala/org/bdgenomics/adam/converters/VariantContextConverter.scala
@@ -1368,7 +1368,7 @@ class VariantContextConverter(
         case (false, VCFHeaderLineCount.A) => {
           (g: HtsjdkGenotype, idx: Int, indices: Array[Int]) =>
             {
-              fromArrayExtractor(g, id, toFn, idx)
+              fromArrayExtractor(g, id, toFn, idx - 1)
                 .map(kv => (kv._1, kv._2.toString))
             }
         }

--- a/adam-core/src/test/scala/org/bdgenomics/adam/converters/VariantContextConverterSuite.scala
+++ b/adam-core/src/test/scala/org/bdgenomics/adam/converters/VariantContextConverterSuite.scala
@@ -2450,7 +2450,7 @@ class VariantContextConverterSuite extends ADAMFunSuite {
     val vcb = htsjdkSNVBuilder
     val gt = GenotypeBuilder.create("NA12878",
       vcb.getAlleles(),
-      Map[String, java.lang.Object](("A_INT", "5,10,15,20")))
+      Map[String, java.lang.Object](("A_INT", "10,15,20")))
     val vc = vcb.genotypes(gt)
       .make
 


### PR DESCRIPTION
Fixes #1562 