### PR TITLE
Bump bdg-formats correctly to 0.11.1, not SNAPSHOT.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -30,7 +30,7 @@
     <hadoop.version>2.7.3</hadoop.version>
     <hadoop-bam.version>7.8.0</hadoop-bam.version>
     <slf4j.version>1.7.22</slf4j.version>
-    <bdg-formats.version>0.11.1-SNAPSHOT</bdg-formats.version>
+    <bdg-formats.version>0.11.1</bdg-formats.version>
     <bdg-utils.version>0.2.13</bdg-utils.version>
     <htsjdk.version>2.9.1</htsjdk.version>
     <scoverage.plugin.version>1.1.1</scoverage.plugin.version>


### PR DESCRIPTION
Sorry @heuermh, I accidentally left this change out...