### PR TITLE
[ADAM-1438] Add ability to save FASTA back as a single file.

### DIFF
--- a/adam-apis/src/test/java/org/bdgenomics/adam/api/java/JavaADAMContigConduit.java
+++ b/adam-apis/src/test/java/org/bdgenomics/adam/api/java/JavaADAMContigConduit.java
@@ -34,7 +34,7 @@ final class JavaADAMContigConduit {
         // make temp directory and save file
         Path tempDir = Files.createTempDirectory("javaAC");
         String fileName = tempDir.toString() + "/testRdd.contig.adam";
-        recordRdd.save(fileName);
+        recordRdd.save(fileName, true);
 
         // create a new adam context and load the file
         JavaADAMContext jac = new JavaADAMContext(ac);

--- a/adam-core/src/main/scala/org/bdgenomics/adam/rdd/feature/FeatureRDD.scala
+++ b/adam-core/src/main/scala/org/bdgenomics/adam/rdd/feature/FeatureRDD.scala
@@ -454,43 +454,6 @@ sealed abstract class FeatureRDD extends AvroGenomicRDD[Feature, FeatureProduct,
   }
 
   /**
-   * Writes an RDD to disk as text and optionally merges.
-   *
-   * @param rdd RDD to save.
-   * @param outputPath Output path to save text files to.
-   * @param asSingleFile If true, combines all partition shards.
-   * @param disableFastConcat If asSingleFile is true, disables the use of the
-   *   parallel file merging engine.
-   * @param optHeaderPath If provided, the header file to include.
-   */
-  private def writeTextRdd[T](rdd: RDD[T],
-                              outputPath: String,
-                              asSingleFile: Boolean,
-                              disableFastConcat: Boolean,
-                              optHeaderPath: Option[String] = None) {
-    if (asSingleFile) {
-
-      // write rdd to disk
-      val tailPath = "%s_tail".format(outputPath)
-      rdd.saveAsTextFile(tailPath)
-
-      // get the filesystem impl
-      val fs = FileSystem.get(rdd.context.hadoopConfiguration)
-
-      // and then merge
-      FileMerger.mergeFiles(rdd.context,
-        fs,
-        new Path(outputPath),
-        new Path(tailPath),
-        disableFastConcat = disableFastConcat,
-        optHeaderPath = optHeaderPath.map(p => new Path(p)))
-    } else {
-      assert(optHeaderPath.isEmpty)
-      rdd.saveAsTextFile(outputPath)
-    }
-  }
-
-  /**
    * Save this FeatureRDD in GTF format.
    *
    * @param fileName The path to save GTF formatted text file(s) to.

--- a/adam-core/src/test/scala/org/bdgenomics/adam/rdd/contig/NucleotideContigFragmentRDDSuite.scala
+++ b/adam-core/src/test/scala/org/bdgenomics/adam/rdd/contig/NucleotideContigFragmentRDDSuite.scala
@@ -56,6 +56,14 @@ class NucleotideContigFragmentRDDSuite extends ADAMFunSuite {
     assert(fragments3.dataset.count === 8L)
   }
 
+  sparkTest("save fasta back as a single file") {
+    val origFasta = testFile("artificial.fa")
+    val tmpFasta = tmpFile("test.fa")
+    sc.loadFasta(origFasta)
+      .saveAsFasta(tmpFasta, asSingleFile = true, lineWidth = 70)
+    checkFiles(origFasta, tmpFasta)
+  }
+
   sparkTest("generate sequence dict from fasta") {
 
     val contig1 = Contig.newBuilder


### PR DESCRIPTION
Resolves #1438. To support saving FASTA as a single file, moved the private `writeTextRdd` method from the `FeatureRDD` to `GenomicRDD`, and opened protections to `protected`.