### PR TITLE
[ADAM-1444] Ignore failed push to Coveralls.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -681,11 +681,12 @@
           <plugin>
             <groupId>org.eluder.coveralls</groupId>
             <artifactId>coveralls-maven-plugin</artifactId>
-            <version>3.0.1</version>
+            <version>4.3.0</version>
             <configuration>
               <coberturaReports>
                 <param>${project.build.directory}/cobertura.xml</param>
               </coberturaReports>
+              <failOnServiceError>false</failOnServiceError>
               <sourceDirectories>
                 <param>adam-core/src/main/scala</param>
                 <param>adam-core/src/main/java</param>


### PR DESCRIPTION
Resolves #1444. Bumps to latest version of coveralls plugin and sets `failOnServiceError`, which ignores internal errors in Coveralls when pushing.