### PR TITLE
[ADAM-1599] Add explicit functions for updating GenomicRDD metadata.

### DIFF
--- a/adam-core/src/main/scala/org/bdgenomics/adam/models/RecordGroupDictionary.scala
+++ b/adam-core/src/main/scala/org/bdgenomics/adam/models/RecordGroupDictionary.scala
@@ -51,7 +51,7 @@ object RecordGroupDictionary {
  * This dictionary provides numerical IDs for each group; these IDs are only
  * consistent when referencing a single dictionary.
  *
- * @param recordGroups A seq of record groups to popualate the dictionary.
+ * @param recordGroups A seq of record groups to populate the dictionary.
  *
  * @throws IllegalArgumentError Throws an assertion error if there are multiple record
  *   groups with the same name.

--- a/adam-core/src/main/scala/org/bdgenomics/adam/rdd/contig/NucleotideContigFragmentRDD.scala
+++ b/adam-core/src/main/scala/org/bdgenomics/adam/rdd/contig/NucleotideContigFragmentRDD.scala
@@ -123,6 +123,11 @@ case class ParquetUnboundNucleotideContigFragmentRDD private[rdd] (
     import sqlContext.implicits._
     sqlContext.read.parquet(parquetFilename).as[NucleotideContigFragmentProduct]
   }
+
+  def replaceSequences(
+    newSequences: SequenceDictionary): NucleotideContigFragmentRDD = {
+    copy(sequences = newSequences)
+  }
 }
 
 case class DatasetBoundNucleotideContigFragmentRDD private[rdd] (
@@ -146,6 +151,11 @@ case class DatasetBoundNucleotideContigFragmentRDD private[rdd] (
       .save(filePath)
     saveMetadata(filePath)
   }
+
+  def replaceSequences(
+    newSequences: SequenceDictionary): NucleotideContigFragmentRDD = {
+    copy(sequences = newSequences)
+  }
 }
 
 /**
@@ -166,6 +176,11 @@ case class RDDBoundNucleotideContigFragmentRDD private[rdd] (
     val sqlContext = SQLContext.getOrCreate(rdd.context)
     import sqlContext.implicits._
     sqlContext.createDataset(rdd.map(NucleotideContigFragmentProduct.fromAvro))
+  }
+
+  def replaceSequences(
+    newSequences: SequenceDictionary): NucleotideContigFragmentRDD = {
+    copy(sequences = newSequences)
   }
 }
 

--- a/adam-core/src/main/scala/org/bdgenomics/adam/rdd/feature/CoverageRDD.scala
+++ b/adam-core/src/main/scala/org/bdgenomics/adam/rdd/feature/CoverageRDD.scala
@@ -86,6 +86,11 @@ case class ParquetUnboundCoverageRDD private[rdd] (
   def toFeatureRDD(): FeatureRDD = {
     ParquetUnboundFeatureRDD(sc, parquetFilename, sequences)
   }
+
+  def replaceSequences(
+    newSequences: SequenceDictionary): CoverageRDD = {
+    copy(sequences = newSequences)
+  }
 }
 
 /**
@@ -108,6 +113,11 @@ case class DatasetBoundCoverageRDD private[rdd] (
   def toFeatureRDD(): FeatureRDD = {
     import dataset.sqlContext.implicits._
     DatasetBoundFeatureRDD(dataset.map(_.toSqlFeature), sequences)
+  }
+
+  def replaceSequences(
+    newSequences: SequenceDictionary): CoverageRDD = {
+    copy(sequences = newSequences)
   }
 }
 
@@ -132,6 +142,11 @@ case class RDDBoundCoverageRDD private[rdd] (
   def toFeatureRDD(): FeatureRDD = {
     val featureRdd = rdd.map(_.toFeature)
     new RDDBoundFeatureRDD(featureRdd, sequences, optPartitionMap = optPartitionMap)
+  }
+
+  def replaceSequences(
+    newSequences: SequenceDictionary): CoverageRDD = {
+    copy(sequences = newSequences)
   }
 }
 

--- a/adam-core/src/main/scala/org/bdgenomics/adam/rdd/feature/FeatureRDD.scala
+++ b/adam-core/src/main/scala/org/bdgenomics/adam/rdd/feature/FeatureRDD.scala
@@ -572,12 +572,4 @@ sealed abstract class FeatureRDD extends AvroGenomicRDD[Feature, FeatureProduct,
 
     replaceRdd(rdd.sortBy(f => f, ascending, numPartitions))
   }
-
-  /**
-   * Replaces the sequence dictionary attached to a FeatureRDD.
-   *
-   * @param newSequences The sequence dictionary to add.
-   * @return Returns a new FeatureRDD with sequence dictionary attached.
-   */
-  def replaceSequences(newSequences: SequenceDictionary): FeatureRDD
 }

--- a/adam-core/src/main/scala/org/bdgenomics/adam/rdd/fragment/FragmentRDD.scala
+++ b/adam-core/src/main/scala/org/bdgenomics/adam/rdd/fragment/FragmentRDD.scala
@@ -30,7 +30,7 @@ import org.bdgenomics.adam.models.{
   SequenceDictionary
 }
 import org.bdgenomics.adam.rdd.ADAMContext._
-import org.bdgenomics.adam.rdd.{ AvroReadGroupGenomicRDD, JavaSaveArgs }
+import org.bdgenomics.adam.rdd.{ AvroRecordGroupGenomicRDD, JavaSaveArgs }
 import org.bdgenomics.adam.rdd.read.{
   AlignmentRecordRDD,
   BinQualities,
@@ -225,7 +225,7 @@ case class RDDBoundFragmentRDD private[rdd] (
   }
 }
 
-sealed abstract class FragmentRDD extends AvroReadGroupGenomicRDD[Fragment, FragmentProduct, FragmentRDD] {
+sealed abstract class FragmentRDD extends AvroRecordGroupGenomicRDD[Fragment, FragmentProduct, FragmentRDD] {
 
   protected def buildTree(rdd: RDD[(ReferenceRegion, Fragment)])(
     implicit tTag: ClassTag[Fragment]): IntervalArray[ReferenceRegion, Fragment] = {

--- a/adam-core/src/main/scala/org/bdgenomics/adam/rdd/fragment/FragmentRDD.scala
+++ b/adam-core/src/main/scala/org/bdgenomics/adam/rdd/fragment/FragmentRDD.scala
@@ -148,6 +148,16 @@ case class ParquetUnboundFragmentRDD private[rdd] (
     import sqlContext.implicits._
     sqlContext.read.parquet(parquetFilename).as[FragmentProduct]
   }
+
+  def replaceSequences(
+    newSequences: SequenceDictionary): FragmentRDD = {
+    copy(sequences = newSequences)
+  }
+
+  def replaceRecordGroups(
+    newRecordGroups: RecordGroupDictionary): FragmentRDD = {
+    copy(recordGroups = newRecordGroups)
+  }
 }
 
 case class DatasetBoundFragmentRDD private[rdd] (
@@ -177,6 +187,16 @@ case class DatasetBoundFragmentRDD private[rdd] (
     tFn: Dataset[FragmentProduct] => Dataset[FragmentProduct]): FragmentRDD = {
     copy(dataset = tFn(dataset))
   }
+
+  def replaceSequences(
+    newSequences: SequenceDictionary): FragmentRDD = {
+    copy(sequences = newSequences)
+  }
+
+  def replaceRecordGroups(
+    newRecordGroups: RecordGroupDictionary): FragmentRDD = {
+    copy(recordGroups = newRecordGroups)
+  }
 }
 
 case class RDDBoundFragmentRDD private[rdd] (
@@ -192,6 +212,16 @@ case class RDDBoundFragmentRDD private[rdd] (
     val sqlContext = SQLContext.getOrCreate(rdd.context)
     import sqlContext.implicits._
     sqlContext.createDataset(rdd.map(FragmentProduct.fromAvro))
+  }
+
+  def replaceSequences(
+    newSequences: SequenceDictionary): FragmentRDD = {
+    copy(sequences = newSequences)
+  }
+
+  def replaceRecordGroups(
+    newRecordGroups: RecordGroupDictionary): FragmentRDD = {
+    copy(recordGroups = newRecordGroups)
   }
 }
 

--- a/adam-core/src/main/scala/org/bdgenomics/adam/rdd/read/AlignmentRecordRDD.scala
+++ b/adam-core/src/main/scala/org/bdgenomics/adam/rdd/read/AlignmentRecordRDD.scala
@@ -42,7 +42,7 @@ import org.bdgenomics.adam.instrumentation.Timers._
 import org.bdgenomics.adam.models._
 import org.bdgenomics.adam.rdd.ADAMContext._
 import org.bdgenomics.adam.rdd.{
-  AvroReadGroupGenomicRDD,
+  AvroRecordGroupGenomicRDD,
   ADAMSaveAnyArgs,
   FileMerger,
   JavaSaveArgs,
@@ -279,7 +279,7 @@ case class RDDBoundAlignmentRecordRDD private[rdd] (
 private case class AlignmentWindow(contigName: String, start: Long, end: Long) {
 }
 
-sealed abstract class AlignmentRecordRDD extends AvroReadGroupGenomicRDD[AlignmentRecord, AlignmentRecordProduct, AlignmentRecordRDD] {
+sealed abstract class AlignmentRecordRDD extends AvroRecordGroupGenomicRDD[AlignmentRecord, AlignmentRecordProduct, AlignmentRecordRDD] {
 
   /**
    * Applies a function that transforms the underlying RDD into a new RDD using

--- a/adam-core/src/main/scala/org/bdgenomics/adam/rdd/read/AlignmentRecordRDD.scala
+++ b/adam-core/src/main/scala/org/bdgenomics/adam/rdd/read/AlignmentRecordRDD.scala
@@ -177,6 +177,16 @@ case class ParquetUnboundAlignmentRecordRDD private[rdd] (
     import sqlContext.implicits._
     sqlContext.read.parquet(parquetFilename).as[AlignmentRecordProduct]
   }
+
+  def replaceSequences(
+    newSequences: SequenceDictionary): AlignmentRecordRDD = {
+    copy(sequences = newSequences)
+  }
+
+  def replaceRecordGroups(
+    newRecordGroups: RecordGroupDictionary): AlignmentRecordRDD = {
+    copy(recordGroups = newRecordGroups)
+  }
 }
 
 case class DatasetBoundAlignmentRecordRDD private[rdd] (
@@ -205,6 +215,16 @@ case class DatasetBoundAlignmentRecordRDD private[rdd] (
   override def transformDataset(
     tFn: Dataset[AlignmentRecordProduct] => Dataset[AlignmentRecordProduct]): AlignmentRecordRDD = {
     copy(dataset = tFn(dataset))
+  }
+
+  def replaceSequences(
+    newSequences: SequenceDictionary): AlignmentRecordRDD = {
+    copy(sequences = newSequences)
+  }
+
+  def replaceRecordGroups(
+    newRecordGroups: RecordGroupDictionary): AlignmentRecordRDD = {
+    copy(recordGroups = newRecordGroups)
   }
 }
 
@@ -243,6 +263,16 @@ case class RDDBoundAlignmentRecordRDD private[rdd] (
         .map(r => Coverage(r._1, r._2.toDouble))
 
     RDDBoundCoverageRDD(covCounts, sequences, None)
+  }
+
+  def replaceSequences(
+    newSequences: SequenceDictionary): AlignmentRecordRDD = {
+    copy(sequences = newSequences)
+  }
+
+  def replaceRecordGroups(
+    newRecordGroups: RecordGroupDictionary): AlignmentRecordRDD = {
+    copy(recordGroups = newRecordGroups)
   }
 }
 

--- a/adam-core/src/main/scala/org/bdgenomics/adam/rdd/variant/GenotypeRDD.scala
+++ b/adam-core/src/main/scala/org/bdgenomics/adam/rdd/variant/GenotypeRDD.scala
@@ -82,9 +82,9 @@ object GenotypeRDD extends Serializable {
    */
   def apply(rdd: RDD[Genotype],
             sequences: SequenceDictionary,
-            samples: Seq[Sample],
+            samples: Iterable[Sample],
             headerLines: Seq[VCFHeaderLine] = DefaultHeaderLines.allHeaderLines): GenotypeRDD = {
-    RDDBoundGenotypeRDD(rdd, sequences, samples, headerLines, None)
+    RDDBoundGenotypeRDD(rdd, sequences, samples.toSeq, headerLines, None)
   }
 
   /**
@@ -99,9 +99,9 @@ object GenotypeRDD extends Serializable {
    */
   def apply(ds: Dataset[GenotypeProduct],
             sequences: SequenceDictionary,
-            samples: Seq[Sample],
+            samples: Iterable[Sample],
             headerLines: Seq[VCFHeaderLine]): GenotypeRDD = {
-    DatasetBoundGenotypeRDD(ds, sequences, samples, headerLines)
+    DatasetBoundGenotypeRDD(ds, sequences, samples.toSeq, headerLines)
   }
 }
 
@@ -122,6 +122,19 @@ case class ParquetUnboundGenotypeRDD private[rdd] (
     val sqlContext = SQLContext.getOrCreate(sc)
     import sqlContext.implicits._
     sqlContext.read.parquet(parquetFilename).as[GenotypeProduct]
+  }
+
+  def replaceSequences(
+    newSequences: SequenceDictionary): GenotypeRDD = {
+    copy(sequences = newSequences)
+  }
+
+  def replaceHeaderLines(newHeaderLines: Seq[VCFHeaderLine]): GenotypeRDD = {
+    copy(headerLines = newHeaderLines)
+  }
+
+  def replaceSamples(newSamples: Iterable[Sample]): GenotypeRDD = {
+    copy(samples = newSamples.toSeq)
   }
 }
 
@@ -153,6 +166,19 @@ case class DatasetBoundGenotypeRDD private[rdd] (
     tFn: Dataset[GenotypeProduct] => Dataset[GenotypeProduct]): GenotypeRDD = {
     copy(dataset = tFn(dataset))
   }
+
+  def replaceSequences(
+    newSequences: SequenceDictionary): GenotypeRDD = {
+    copy(sequences = newSequences)
+  }
+
+  def replaceHeaderLines(newHeaderLines: Seq[VCFHeaderLine]): GenotypeRDD = {
+    copy(headerLines = newHeaderLines)
+  }
+
+  def replaceSamples(newSamples: Iterable[Sample]): GenotypeRDD = {
+    copy(samples = newSamples.toSeq)
+  }
 }
 
 case class RDDBoundGenotypeRDD private[rdd] (
@@ -169,6 +195,19 @@ case class RDDBoundGenotypeRDD private[rdd] (
     val sqlContext = SQLContext.getOrCreate(rdd.context)
     import sqlContext.implicits._
     sqlContext.createDataset(rdd.map(GenotypeProduct.fromAvro))
+  }
+
+  def replaceSequences(
+    newSequences: SequenceDictionary): GenotypeRDD = {
+    copy(sequences = newSequences)
+  }
+
+  def replaceHeaderLines(newHeaderLines: Seq[VCFHeaderLine]): GenotypeRDD = {
+    copy(headerLines = newHeaderLines)
+  }
+
+  def replaceSamples(newSamples: Iterable[Sample]): GenotypeRDD = {
+    copy(samples = newSamples.toSeq)
   }
 }
 

--- a/adam-core/src/main/scala/org/bdgenomics/adam/rdd/variant/VariantContextRDD.scala
+++ b/adam-core/src/main/scala/org/bdgenomics/adam/rdd/variant/VariantContextRDD.scala
@@ -87,15 +87,15 @@ object VariantContextRDD extends Serializable {
    */
   def apply(rdd: RDD[VariantContext],
             sequences: SequenceDictionary,
-            samples: Seq[Sample],
+            samples: Iterable[Sample],
             headerLines: Seq[VCFHeaderLine]): VariantContextRDD = {
-    VariantContextRDD(rdd, sequences, samples, headerLines, None)
+    VariantContextRDD(rdd, sequences, samples.toSeq, headerLines, None)
   }
 
   def apply(rdd: RDD[VariantContext],
             sequences: SequenceDictionary,
-            samples: Seq[Sample]): VariantContextRDD = {
-    VariantContextRDD(rdd, sequences, samples, null)
+            samples: Iterable[Sample]): VariantContextRDD = {
+    VariantContextRDD(rdd, sequences, samples.toSeq, null)
   }
 }
 
@@ -114,6 +114,45 @@ case class VariantContextRDD(rdd: RDD[VariantContext],
                              @transient headerLines: Seq[VCFHeaderLine],
                              optPartitionMap: Option[Array[Option[(ReferenceRegion, ReferenceRegion)]]]) extends MultisampleGenomicRDD[VariantContext, VariantContextRDD]
     with Logging {
+
+  def replaceSequences(
+    newSequences: SequenceDictionary): VariantContextRDD = {
+    copy(sequences = newSequences)
+  }
+
+  /**
+   * Replaces the header lines attached to this RDD.
+   *
+   * @param newHeaderLines The new header lines to attach to this RDD.
+   * @return A new RDD with the header lines replaced.
+   */
+  def replaceHeaderLines(newHeaderLines: Seq[VCFHeaderLine]): VariantContextRDD = {
+    copy(headerLines = newHeaderLines)
+  }
+
+  /**
+   * Appends new header lines to the existing lines.
+   *
+   * @param headerLinesToAdd Zero or more header lines to add.
+   * @return A new RDD with the new header lines added.
+   */
+  def addHeaderLines(headerLinesToAdd: Seq[VCFHeaderLine]): VariantContextRDD = {
+    replaceHeaderLines(headerLines ++ headerLinesToAdd)
+  }
+
+  /**
+   * Appends a new header line to the existing lines.
+   *
+   * @param headerLineToAdd A header line to add.
+   * @return A new RDD with the new header line added.
+   */
+  def addHeaderLine(headerLineToAdd: VCFHeaderLine): VariantContextRDD = {
+    addHeaderLines(Seq(headerLineToAdd))
+  }
+
+  def replaceSamples(newSamples: Iterable[Sample]): VariantContextRDD = {
+    copy(samples = newSamples.toSeq)
+  }
 
   protected def buildTree(rdd: RDD[(ReferenceRegion, VariantContext)])(
     implicit tTag: ClassTag[VariantContext]): IntervalArray[ReferenceRegion, VariantContext] = {

--- a/adam-core/src/test/scala/org/bdgenomics/adam/rdd/contig/NucleotideContigFragmentRDDSuite.scala
+++ b/adam-core/src/test/scala/org/bdgenomics/adam/rdd/contig/NucleotideContigFragmentRDDSuite.scala
@@ -37,20 +37,31 @@ class NucleotideContigFragmentRDDSuite extends ADAMFunSuite {
   }
 
   sparkTest("round trip a ncf to parquet") {
+    def testMetadata(fRdd: NucleotideContigFragmentRDD) {
+      val sequenceRdd = fRdd.addSequence(SequenceRecord("aSequence", 1000L))
+      assert(sequenceRdd.sequences.containsRefName("aSequence"))
+    }
+
     val fragments1 = sc.loadFasta(testFile("HLA_DQB1_05_01_01_02.fa"), 1000L)
     assert(fragments1.rdd.count === 8L)
     assert(fragments1.dataset.count === 8L)
+    testMetadata(fragments1)
 
     // save using dataset path
     val output1 = tmpFile("ctg.adam")
-    fragments1.transformDataset(ds => ds).saveAsParquet(output1)
+    val dsBound = fragments1.transformDataset(ds => ds)
+    testMetadata(dsBound)
+    dsBound.saveAsParquet(output1)
     val fragments2 = sc.loadContigFragments(output1)
+    testMetadata(fragments2)
     assert(fragments2.rdd.count === 8L)
     assert(fragments2.dataset.count === 8L)
 
     // save using rdd path
     val output2 = tmpFile("ctg.adam")
-    fragments2.transform(rdd => rdd).saveAsParquet(output2)
+    val rddBound = fragments2.transform(rdd => rdd)
+    testMetadata(rddBound)
+    rddBound.saveAsParquet(output2)
     val fragments3 = sc.loadContigFragments(output2)
     assert(fragments3.rdd.count === 8L)
     assert(fragments3.dataset.count === 8L)


### PR DESCRIPTION
Resolves #1599. Adds functions that replaces or appends to the sequence dictionary/record groups/header lines/sample metadata that is attached to a GenomicRDD. This is necessary as a59b8ed948db1bbf50260a61ed404b8325df0563 eliminated the `copy` methods that were attached to all implementations of `GenomicRDD` by making the exposed implementations abstract classes instead of case classes.

~One TODO:~
- [x] ~Extend to Python API~ Punted to #1604