### PR TITLE
[ADAM-1554] Support saving BGZF VCF output.

### DIFF
--- a/adam-core/src/main/scala/org/bdgenomics/adam/rdd/ADAMContext.scala
+++ b/adam-core/src/main/scala/org/bdgenomics/adam/rdd/ADAMContext.scala
@@ -177,6 +177,25 @@ private class FileFilter(private val name: String) extends PathFilter {
 }
 
 /**
+ * A filter to run on globs/directories that finds all files that do not start
+ * with a given string.
+ *
+ * @param prefix The prefix to search for. Files that contain this prefix are
+ *   discarded.
+ */
+private class NoPrefixFileFilter(private val prefix: String) extends PathFilter {
+
+  /**
+   * @param path Path to evaluate.
+   * @return Returns true if the pathName of the path does not match the prefix passed
+   *   to the constructor.
+   */
+  def accept(path: Path): Boolean = {
+    !path.getName.startsWith(prefix)
+  }
+}
+
+/**
  * The ADAMContext provides functions on top of a SparkContext for loading genomic data.
  *
  * @param sc The SparkContext to wrap.
@@ -207,7 +226,7 @@ class ADAMContext(@transient val sc: SparkContext) extends Serializable with Log
    */
   private[rdd] def loadVcfMetadata(pathName: String): (SequenceDictionary, Seq[Sample], Seq[VCFHeaderLine]) = {
     // get the paths to all vcfs
-    val files = getFsAndFiles(new Path(pathName))
+    val files = getFsAndFilesWithFilter(pathName, new NoPrefixFileFilter("_"))
 
     // load yonder the metadata
     files.map(p => loadSingleVcfMetadata(p.toString)).reduce((p1, p2) => {

--- a/adam-core/src/main/scala/org/bdgenomics/adam/rdd/variant/ADAMVCFOutputFormat.scala
+++ b/adam-core/src/main/scala/org/bdgenomics/adam/rdd/variant/ADAMVCFOutputFormat.scala
@@ -45,33 +45,6 @@ class ADAMVCFOutputFormat[K] extends KeyIgnoringVCFOutputFormat[K](VCFFormat.VCF
     readHeaderFrom(path, FileSystem.get(conf))
 
     // return record writer
-    return new KeyIgnoringVCFRecordWriter[K](getDefaultWorkFile(context, ""),
-      header,
-      true,
-      context);
-  }
-}
-
-/**
- * Wrapper for Hadoop-BAM to work around requirement for no-args constructor.
- *
- * @tparam K The key type. Keys are not written.
- */
-class ADAMHeaderlessVCFOutputFormat[K] extends KeyIgnoringVCFOutputFormat[K](VCFFormat.VCF) with Serializable {
-
-  override def getRecordWriter(context: TaskAttemptContext): RecordWriter[K, VariantContextWritable] = {
-    val conf = context.getConfiguration()
-
-    // where is our header file?
-    val path = new Path(conf.get("org.bdgenomics.adam.rdd.variant.vcf_header_path"))
-
-    // read the header file
-    readHeaderFrom(path, FileSystem.get(conf))
-
-    // return record writer
-    return new KeyIgnoringVCFRecordWriter[K](getDefaultWorkFile(context, ""),
-      header,
-      false,
-      context);
+    super.getRecordWriter(context)
   }
 }

--- a/adam-core/src/main/scala/org/bdgenomics/adam/rdd/variant/GenotypeRDD.scala
+++ b/adam-core/src/main/scala/org/bdgenomics/adam/rdd/variant/GenotypeRDD.scala
@@ -250,7 +250,9 @@ sealed abstract class GenotypeRDD extends MultisampleAvroGenomicRDD[Genotype, Ge
     // write vcf headers to file
     VCFHeaderUtils.write(new VCFHeader(headerLines.toSet),
       new Path("%s/_header".format(filePath)),
-      rdd.context.hadoopConfiguration)
+      rdd.context.hadoopConfiguration,
+      false,
+      false)
   }
 
   override protected def saveMetadata(filePath: String): Unit = {

--- a/adam-core/src/main/scala/org/bdgenomics/adam/rdd/variant/VariantRDD.scala
+++ b/adam-core/src/main/scala/org/bdgenomics/adam/rdd/variant/VariantRDD.scala
@@ -234,7 +234,9 @@ sealed abstract class VariantRDD extends AvroGenomicRDD[Variant, VariantProduct,
     // write vcf headers to file
     VCFHeaderUtils.write(new VCFHeader(headerLines.toSet),
       new Path("%s/_header".format(filePath)),
-      rdd.context.hadoopConfiguration)
+      rdd.context.hadoopConfiguration,
+      false,
+      false)
   }
 
   override protected def saveMetadata(filePath: String): Unit = {

--- a/adam-core/src/main/scala/org/bdgenomics/adam/util/FileExtensions.scala
+++ b/adam-core/src/main/scala/org/bdgenomics/adam/util/FileExtensions.scala
@@ -115,8 +115,16 @@ private[adam] object FileExtensions {
   def isVcfExt(pathName: String): Boolean = {
     pathName.endsWith(".vcf") ||
       pathName.endsWith(".vcf.gz") ||
-      pathName.endsWith(".vcf.bgzf") ||
       pathName.endsWith(".vcf.bgz")
+  }
+
+  /**
+   * @param pathName The path name to match.
+   * @return Returns true if the path name matches a GZIP format file extension.
+   */
+  def isGzip(pathName: String): Boolean = {
+    pathName.endsWith(".gz") ||
+      pathName.endsWith(".bgz")
   }
 
   /**

--- a/adam-core/src/test/scala/org/bdgenomics/adam/util/FileExtensionsSuite.scala
+++ b/adam-core/src/test/scala/org/bdgenomics/adam/util/FileExtensionsSuite.scala
@@ -1,0 +1,39 @@
+/**
+ * Licensed to Big Data Genomics (BDG) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The BDG licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.bdgenomics.adam.util
+
+import org.scalatest.FunSuite
+
+class FileExtensionsSuite extends FunSuite {
+
+  test("ends in gzip extension") {
+    assert(FileExtensions.isGzip("file.vcf.gz"))
+    assert(FileExtensions.isGzip("file.fastq.bgz"))
+    assert(!FileExtensions.isGzip("file.fastq.bgzf"))
+    assert(!FileExtensions.isGzip("file.vcf"))
+    assert(!FileExtensions.isGzip("file.fastq"))
+  }
+
+  test("is a vcf extension") {
+    assert(FileExtensions.isVcfExt("file.vcf"))
+    assert(FileExtensions.isVcfExt("file.vcf.bgz"))
+    assert(!FileExtensions.isVcfExt("file.bcf"))
+    assert(FileExtensions.isVcfExt("file.vcf.gz"))
+    assert(!FileExtensions.isVcfExt("file.vcf.bgzf"))
+  }
+}


### PR DESCRIPTION
Resolves #1554. Additionally:

* Moves VCF file extension logic into ADAM, since Hadoop-BAM does not recognize .bgzf as a valid BGZF extension
* Refactored VCF output formats to remove need for ADAMHeaderlessVCFOutputFormat

This isn't completely done... Specifically, it produces output that bcftools thinks is good:

```
$ bcftools stats bqsr1.vcf.bgz 
# This file was produced by bcftools stats (1.3.1+htslib-1.3.1) and can be plotted using plot-vcfstats.
# The command line was:	bcftools stats  bqsr1.vcf.bgz
#
# Definition of sets:
# ID	[2]id	[3]tab-separated file names
ID	0	bqsr1.vcf.bgz
# SN, Summary numbers:
# SN	[2]id	[3]key	[4]value
SN	0	number of samples:	0
SN	0	number of records:	681
SN	0	number of no-ALTs:	0
SN	0	number of SNPs:	681
SN	0	number of MNPs:	0
SN	0	number of indels:	0
SN	0	number of others:	0
SN	0	number of multiallelic sites:	0
SN	0	number of multiallelic SNP sites:	0
```

But, that fails to load in properly when read back from ADAM:

```
scala> sc.loadVcf("bqsr1.vcf.bgz").rdd.count
res1: Long = 0
```

I'm still debugging this, but was wondering if anyone else had thoughts?