### PR TITLE
[ADAM-1610] Mark non-serializable field in TwoBitFile as transient.

### DIFF
--- a/adam-core/src/main/scala/org/bdgenomics/adam/util/TwoBitFile.scala
+++ b/adam-core/src/main/scala/org/bdgenomics/adam/util/TwoBitFile.scala
@@ -59,7 +59,7 @@ private object TwoBitFile {
 class TwoBitFile(byteAccess: ByteAccess) extends ReferenceFile {
 
   // load file into memory
-  private[util] val bytes = ByteBuffer.wrap(byteAccess.readFully(0, byteAccess.length().toInt))
+  @transient private[util] val bytes = ByteBuffer.wrap(byteAccess.readFully(0, byteAccess.length().toInt))
   private[util] val numSeq = readHeader()
   // hold current byte position of start of current index record
   var indexRecordStart = TwoBitFile.FILE_INDEX_OFFSET


### PR DESCRIPTION
Resolves #1610.