### PR TITLE
[ADAM-1611] Extend pipe APIs to Java, Python, and R.

### DIFF
--- a/adam-apis/src/main/scala/org/bdgenomics/adam/api/java/GenomicRDDConverters.scala
+++ b/adam-apis/src/main/scala/org/bdgenomics/adam/api/java/GenomicRDDConverters.scala
@@ -1,0 +1,459 @@
+/**
+ * Licensed to Big Data Genomics (BDG) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The BDG licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.bdgenomics.adam.api.java
+
+import org.apache.spark.api.java.function.Function2
+import org.apache.spark.rdd.RDD
+import org.bdgenomics.adam.models.{
+  Coverage,
+  VariantContext
+}
+import org.bdgenomics.adam.rdd.{ ADAMContext, GenomicRDD }
+import org.bdgenomics.adam.rdd.contig.NucleotideContigFragmentRDD
+import org.bdgenomics.adam.rdd.feature.{ CoverageRDD, FeatureRDD }
+import org.bdgenomics.adam.rdd.fragment.FragmentRDD
+import org.bdgenomics.adam.rdd.read.AlignmentRecordRDD
+import org.bdgenomics.adam.rdd.variant.{
+  VariantRDD,
+  GenotypeRDD,
+  VariantContextRDD
+}
+import org.bdgenomics.formats.avro._
+
+sealed trait SameTypeConversion[T, U <: GenomicRDD[T, U]] extends Function2[U, RDD[T], U] {
+
+  def call(v1: U, v2: RDD[T]): U = {
+    ADAMContext.sameTypeConversionFn(v1, v2)
+  }
+}
+
+final class ContigsToContigsConverter extends SameTypeConversion[NucleotideContigFragment, NucleotideContigFragmentRDD] {
+}
+
+final class ContigsToCoverageConverter extends Function2[NucleotideContigFragmentRDD, RDD[Coverage], CoverageRDD] {
+
+  def call(v1: NucleotideContigFragmentRDD, v2: RDD[Coverage]): CoverageRDD = {
+    ADAMContext.contigsToCoverageConversionFn(v1, v2)
+  }
+}
+
+final class ContigsToFeaturesConverter extends Function2[NucleotideContigFragmentRDD, RDD[Feature], FeatureRDD] {
+
+  def call(v1: NucleotideContigFragmentRDD, v2: RDD[Feature]): FeatureRDD = {
+    ADAMContext.contigsToFeaturesConversionFn(v1, v2)
+  }
+}
+
+final class ContigsToFragmentsConverter extends Function2[NucleotideContigFragmentRDD, RDD[Fragment], FragmentRDD] {
+
+  def call(v1: NucleotideContigFragmentRDD, v2: RDD[Fragment]): FragmentRDD = {
+    ADAMContext.contigsToFragmentsConversionFn(v1, v2)
+  }
+}
+
+final class ContigsToAlignmentRecordsConverter extends Function2[NucleotideContigFragmentRDD, RDD[AlignmentRecord], AlignmentRecordRDD] {
+
+  def call(v1: NucleotideContigFragmentRDD, v2: RDD[AlignmentRecord]): AlignmentRecordRDD = {
+    ADAMContext.contigsToAlignmentRecordsConversionFn(v1, v2)
+  }
+}
+
+final class ContigsToGenotypesConverter extends Function2[NucleotideContigFragmentRDD, RDD[Genotype], GenotypeRDD] {
+
+  def call(v1: NucleotideContigFragmentRDD, v2: RDD[Genotype]): GenotypeRDD = {
+    ADAMContext.contigsToGenotypesConversionFn(v1, v2)
+  }
+}
+
+final class ContigsToVariantsConverter extends Function2[NucleotideContigFragmentRDD, RDD[Variant], VariantRDD] {
+
+  def call(v1: NucleotideContigFragmentRDD, v2: RDD[Variant]): VariantRDD = {
+    ADAMContext.contigsToVariantsConversionFn(v1, v2)
+  }
+}
+
+final class ContigsToVariantContextsConverter extends Function2[NucleotideContigFragmentRDD, RDD[VariantContext], VariantContextRDD] {
+
+  def call(v1: NucleotideContigFragmentRDD, v2: RDD[VariantContext]): VariantContextRDD = {
+    ADAMContext.contigsToVariantContextConversionFn(v1, v2)
+  }
+}
+
+final class CoverageToContigsConverter extends Function2[CoverageRDD, RDD[NucleotideContigFragment], NucleotideContigFragmentRDD] {
+
+  def call(v1: CoverageRDD, v2: RDD[NucleotideContigFragment]): NucleotideContigFragmentRDD = {
+    ADAMContext.coverageToContigsConversionFn(v1, v2)
+  }
+}
+
+final class CoverageToCoverageConverter extends SameTypeConversion[Coverage, CoverageRDD] {
+}
+
+final class CoverageToFeaturesConverter extends Function2[CoverageRDD, RDD[Feature], FeatureRDD] {
+
+  def call(v1: CoverageRDD, v2: RDD[Feature]): FeatureRDD = {
+    ADAMContext.coverageToFeaturesConversionFn(v1, v2)
+  }
+}
+
+final class CoverageToFragmentsConverter extends Function2[CoverageRDD, RDD[Fragment], FragmentRDD] {
+
+  def call(v1: CoverageRDD, v2: RDD[Fragment]): FragmentRDD = {
+    ADAMContext.coverageToFragmentsConversionFn(v1, v2)
+  }
+}
+
+final class CoverageToAlignmentRecordsConverter extends Function2[CoverageRDD, RDD[AlignmentRecord], AlignmentRecordRDD] {
+
+  def call(v1: CoverageRDD, v2: RDD[AlignmentRecord]): AlignmentRecordRDD = {
+    ADAMContext.coverageToAlignmentRecordsConversionFn(v1, v2)
+  }
+}
+
+final class CoverageToGenotypesConverter extends Function2[CoverageRDD, RDD[Genotype], GenotypeRDD] {
+
+  def call(v1: CoverageRDD, v2: RDD[Genotype]): GenotypeRDD = {
+    ADAMContext.coverageToGenotypesConversionFn(v1, v2)
+  }
+}
+
+final class CoverageToVariantsConverter extends Function2[CoverageRDD, RDD[Variant], VariantRDD] {
+
+  def call(v1: CoverageRDD, v2: RDD[Variant]): VariantRDD = {
+    ADAMContext.coverageToVariantsConversionFn(v1, v2)
+  }
+}
+
+final class CoverageToVariantContextConverter extends Function2[CoverageRDD, RDD[VariantContext], VariantContextRDD] {
+
+  def call(v1: CoverageRDD, v2: RDD[VariantContext]): VariantContextRDD = {
+    ADAMContext.coverageToVariantContextConversionFn(v1, v2)
+  }
+}
+
+final class FeaturesToContigsConverter extends Function2[FeatureRDD, RDD[NucleotideContigFragment], NucleotideContigFragmentRDD] {
+
+  def call(v1: FeatureRDD, v2: RDD[NucleotideContigFragment]): NucleotideContigFragmentRDD = {
+    ADAMContext.featuresToContigsConversionFn(v1, v2)
+  }
+}
+
+final class FeaturesToCoverageConverter extends Function2[FeatureRDD, RDD[Coverage], CoverageRDD] {
+
+  def call(v1: FeatureRDD, v2: RDD[Coverage]): CoverageRDD = {
+    ADAMContext.featuresToCoverageConversionFn(v1, v2)
+  }
+}
+
+final class FeaturesToFeatureConverter extends SameTypeConversion[Feature, FeatureRDD] {
+}
+
+final class FeaturesToFragmentsConverter extends Function2[FeatureRDD, RDD[Fragment], FragmentRDD] {
+
+  def call(v1: FeatureRDD, v2: RDD[Fragment]): FragmentRDD = {
+    ADAMContext.featuresToFragmentsConversionFn(v1, v2)
+  }
+}
+
+final class FeaturesToAlignmentRecordsConverter extends Function2[FeatureRDD, RDD[AlignmentRecord], AlignmentRecordRDD] {
+
+  def call(v1: FeatureRDD, v2: RDD[AlignmentRecord]): AlignmentRecordRDD = {
+    ADAMContext.featuresToAlignmentRecordsConversionFn(v1, v2)
+  }
+}
+
+final class FeaturesToGenotypesConverter extends Function2[FeatureRDD, RDD[Genotype], GenotypeRDD] {
+
+  def call(v1: FeatureRDD, v2: RDD[Genotype]): GenotypeRDD = {
+    ADAMContext.featuresToGenotypesConversionFn(v1, v2)
+  }
+}
+
+final class FeaturesToVariantsConverter extends Function2[FeatureRDD, RDD[Variant], VariantRDD] {
+
+  def call(v1: FeatureRDD, v2: RDD[Variant]): VariantRDD = {
+    ADAMContext.featuresToVariantsConversionFn(v1, v2)
+  }
+}
+
+final class FeaturesToVariantContextConverter extends Function2[FeatureRDD, RDD[VariantContext], VariantContextRDD] {
+
+  def call(v1: FeatureRDD, v2: RDD[VariantContext]): VariantContextRDD = {
+    ADAMContext.featuresToVariantContextConversionFn(v1, v2)
+  }
+}
+
+final class FragmentsToContigsConverter extends Function2[FragmentRDD, RDD[NucleotideContigFragment], NucleotideContigFragmentRDD] {
+
+  def call(v1: FragmentRDD, v2: RDD[NucleotideContigFragment]): NucleotideContigFragmentRDD = {
+    ADAMContext.fragmentsToContigsConversionFn(v1, v2)
+  }
+}
+
+final class FragmentsToCoverageConverter extends Function2[FragmentRDD, RDD[Coverage], CoverageRDD] {
+
+  def call(v1: FragmentRDD, v2: RDD[Coverage]): CoverageRDD = {
+    ADAMContext.fragmentsToCoverageConversionFn(v1, v2)
+  }
+}
+
+final class FragmentsToFeaturesConverter extends Function2[FragmentRDD, RDD[Feature], FeatureRDD] {
+
+  def call(v1: FragmentRDD, v2: RDD[Feature]): FeatureRDD = {
+    ADAMContext.fragmentsToFeaturesConversionFn(v1, v2)
+  }
+}
+
+final class FragmentsToFragmentConverter extends SameTypeConversion[Fragment, FragmentRDD] {
+}
+
+final class FragmentsToAlignmentRecordsConverter extends Function2[FragmentRDD, RDD[AlignmentRecord], AlignmentRecordRDD] {
+
+  def call(v1: FragmentRDD, v2: RDD[AlignmentRecord]): AlignmentRecordRDD = {
+    ADAMContext.fragmentsToAlignmentRecordsConversionFn(v1, v2)
+  }
+}
+
+final class FragmentsToGenotypesConverter extends Function2[FragmentRDD, RDD[Genotype], GenotypeRDD] {
+
+  def call(v1: FragmentRDD, v2: RDD[Genotype]): GenotypeRDD = {
+    ADAMContext.fragmentsToGenotypesConversionFn(v1, v2)
+  }
+}
+
+final class FragmentsToVariantsConverter extends Function2[FragmentRDD, RDD[Variant], VariantRDD] {
+
+  def call(v1: FragmentRDD, v2: RDD[Variant]): VariantRDD = {
+    ADAMContext.fragmentsToVariantsConversionFn(v1, v2)
+  }
+}
+
+final class FragmentsToVariantContextConverter extends Function2[FragmentRDD, RDD[VariantContext], VariantContextRDD] {
+
+  def call(v1: FragmentRDD, v2: RDD[VariantContext]): VariantContextRDD = {
+    ADAMContext.fragmentsToVariantContextConversionFn(v1, v2)
+  }
+}
+
+final class AlignmentRecordsToContigsConverter extends Function2[AlignmentRecordRDD, RDD[NucleotideContigFragment], NucleotideContigFragmentRDD] {
+
+  def call(v1: AlignmentRecordRDD, v2: RDD[NucleotideContigFragment]): NucleotideContigFragmentRDD = {
+    ADAMContext.alignmentRecordsToContigsConversionFn(v1, v2)
+  }
+}
+
+final class AlignmentRecordsToCoverageConverter extends Function2[AlignmentRecordRDD, RDD[Coverage], CoverageRDD] {
+
+  def call(v1: AlignmentRecordRDD, v2: RDD[Coverage]): CoverageRDD = {
+    ADAMContext.alignmentRecordsToCoverageConversionFn(v1, v2)
+  }
+}
+
+final class AlignmentRecordsToFeaturesConverter extends Function2[AlignmentRecordRDD, RDD[Feature], FeatureRDD] {
+
+  def call(v1: AlignmentRecordRDD, v2: RDD[Feature]): FeatureRDD = {
+    ADAMContext.alignmentRecordsToFeaturesConversionFn(v1, v2)
+  }
+}
+
+final class AlignmentRecordsToFragmentsConverter extends Function2[AlignmentRecordRDD, RDD[Fragment], FragmentRDD] {
+
+  def call(v1: AlignmentRecordRDD, v2: RDD[Fragment]): FragmentRDD = {
+    ADAMContext.alignmentRecordsToFragmentsConversionFn(v1, v2)
+  }
+}
+
+final class AlignmentRecordsToAlignmentRecordsConverter extends SameTypeConversion[AlignmentRecord, AlignmentRecordRDD] {
+}
+
+final class AlignmentRecordsToGenotypesConverter extends Function2[AlignmentRecordRDD, RDD[Genotype], GenotypeRDD] {
+
+  def call(v1: AlignmentRecordRDD, v2: RDD[Genotype]): GenotypeRDD = {
+    ADAMContext.alignmentRecordsToGenotypesConversionFn(v1, v2)
+  }
+}
+
+final class AlignmentRecordsToVariantsConverter extends Function2[AlignmentRecordRDD, RDD[Variant], VariantRDD] {
+
+  def call(v1: AlignmentRecordRDD, v2: RDD[Variant]): VariantRDD = {
+    ADAMContext.alignmentRecordsToVariantsConversionFn(v1, v2)
+  }
+}
+
+final class AlignmentRecordsToVariantContextConverter extends Function2[AlignmentRecordRDD, RDD[VariantContext], VariantContextRDD] {
+
+  def call(v1: AlignmentRecordRDD, v2: RDD[VariantContext]): VariantContextRDD = {
+    ADAMContext.alignmentRecordsToVariantContextConversionFn(v1, v2)
+  }
+}
+
+final class GenotypesToContigsConverter extends Function2[GenotypeRDD, RDD[NucleotideContigFragment], NucleotideContigFragmentRDD] {
+
+  def call(v1: GenotypeRDD, v2: RDD[NucleotideContigFragment]): NucleotideContigFragmentRDD = {
+    ADAMContext.genotypesToContigsConversionFn(v1, v2)
+  }
+}
+
+final class GenotypesToCoverageConverter extends Function2[GenotypeRDD, RDD[Coverage], CoverageRDD] {
+
+  def call(v1: GenotypeRDD, v2: RDD[Coverage]): CoverageRDD = {
+    ADAMContext.genotypesToCoverageConversionFn(v1, v2)
+  }
+}
+
+final class GenotypesToFeaturesConverter extends Function2[GenotypeRDD, RDD[Feature], FeatureRDD] {
+
+  def call(v1: GenotypeRDD, v2: RDD[Feature]): FeatureRDD = {
+    ADAMContext.genotypesToFeaturesConversionFn(v1, v2)
+  }
+}
+
+final class GenotypesToFragmentsConverter extends Function2[GenotypeRDD, RDD[Fragment], FragmentRDD] {
+
+  def call(v1: GenotypeRDD, v2: RDD[Fragment]): FragmentRDD = {
+    ADAMContext.genotypesToFragmentsConversionFn(v1, v2)
+  }
+}
+
+final class GenotypesToAlignmentRecordsConverter extends Function2[GenotypeRDD, RDD[AlignmentRecord], AlignmentRecordRDD] {
+
+  def call(v1: GenotypeRDD, v2: RDD[AlignmentRecord]): AlignmentRecordRDD = {
+    ADAMContext.genotypesToAlignmentRecordsConversionFn(v1, v2)
+  }
+}
+
+final class GenotypesToGenotypesConverter extends SameTypeConversion[Genotype, GenotypeRDD] {
+}
+
+final class GenotypesToVariantsConverter extends Function2[GenotypeRDD, RDD[Variant], VariantRDD] {
+
+  def call(v1: GenotypeRDD, v2: RDD[Variant]): VariantRDD = {
+    ADAMContext.genotypesToVariantsConversionFn(v1, v2)
+  }
+}
+
+final class GenotypesToVariantContextConverter extends Function2[GenotypeRDD, RDD[VariantContext], VariantContextRDD] {
+
+  def call(v1: GenotypeRDD, v2: RDD[VariantContext]): VariantContextRDD = {
+    ADAMContext.genotypesToVariantContextConversionFn(v1, v2)
+  }
+}
+
+final class VariantsToContigsConverter extends Function2[VariantRDD, RDD[NucleotideContigFragment], NucleotideContigFragmentRDD] {
+
+  def call(v1: VariantRDD, v2: RDD[NucleotideContigFragment]): NucleotideContigFragmentRDD = {
+    ADAMContext.variantsToContigsConversionFn(v1, v2)
+  }
+}
+
+final class VariantsToCoverageConverter extends Function2[VariantRDD, RDD[Coverage], CoverageRDD] {
+
+  def call(v1: VariantRDD, v2: RDD[Coverage]): CoverageRDD = {
+    ADAMContext.variantsToCoverageConversionFn(v1, v2)
+  }
+}
+
+final class VariantsToFeaturesConverter extends Function2[VariantRDD, RDD[Feature], FeatureRDD] {
+
+  def call(v1: VariantRDD, v2: RDD[Feature]): FeatureRDD = {
+    ADAMContext.variantsToFeaturesConversionFn(v1, v2)
+  }
+}
+
+final class VariantsToFragmentsConverter extends Function2[VariantRDD, RDD[Fragment], FragmentRDD] {
+
+  def call(v1: VariantRDD, v2: RDD[Fragment]): FragmentRDD = {
+    ADAMContext.variantsToFragmentsConversionFn(v1, v2)
+  }
+}
+
+final class VariantsToAlignmentRecordsConverter extends Function2[VariantRDD, RDD[AlignmentRecord], AlignmentRecordRDD] {
+
+  def call(v1: VariantRDD, v2: RDD[AlignmentRecord]): AlignmentRecordRDD = {
+    ADAMContext.variantsToAlignmentRecordsConversionFn(v1, v2)
+  }
+}
+
+final class VariantsToGenotypesConverter extends Function2[VariantRDD, RDD[Genotype], GenotypeRDD] {
+
+  def call(v1: VariantRDD, v2: RDD[Genotype]): GenotypeRDD = {
+    ADAMContext.variantsToGenotypesConversionFn(v1, v2)
+  }
+}
+
+final class VariantsToVariantsConverter extends SameTypeConversion[Variant, VariantRDD] {
+}
+
+final class VariantsToVariantContextConverter extends Function2[VariantRDD, RDD[VariantContext], VariantContextRDD] {
+
+  def call(v1: VariantRDD, v2: RDD[VariantContext]): VariantContextRDD = {
+    ADAMContext.variantsToVariantContextConversionFn(v1, v2)
+  }
+}
+
+final class VariantContextsToContigsConverter extends Function2[VariantContextRDD, RDD[NucleotideContigFragment], NucleotideContigFragmentRDD] {
+
+  def call(v1: VariantContextRDD, v2: RDD[NucleotideContigFragment]): NucleotideContigFragmentRDD = {
+    ADAMContext.variantContextsToContigsConversionFn(v1, v2)
+  }
+}
+
+final class VariantContextsToCoverageConverter extends Function2[VariantContextRDD, RDD[Coverage], CoverageRDD] {
+
+  def call(v1: VariantContextRDD, v2: RDD[Coverage]): CoverageRDD = {
+    ADAMContext.variantContextsToCoverageConversionFn(v1, v2)
+  }
+}
+
+final class VariantContextsToFeaturesConverter extends Function2[VariantContextRDD, RDD[Feature], FeatureRDD] {
+
+  def call(v1: VariantContextRDD, v2: RDD[Feature]): FeatureRDD = {
+    ADAMContext.variantContextsToFeaturesConversionFn(v1, v2)
+  }
+}
+
+final class VariantContextsToFragmentsConverter extends Function2[VariantContextRDD, RDD[Fragment], FragmentRDD] {
+
+  def call(v1: VariantContextRDD, v2: RDD[Fragment]): FragmentRDD = {
+    ADAMContext.variantContextsToFragmentsConversionFn(v1, v2)
+  }
+}
+
+final class VariantContextsToAlignmentRecordsConverter extends Function2[VariantContextRDD, RDD[AlignmentRecord], AlignmentRecordRDD] {
+
+  def call(v1: VariantContextRDD, v2: RDD[AlignmentRecord]): AlignmentRecordRDD = {
+    ADAMContext.variantContextsToAlignmentRecordsConversionFn(v1, v2)
+  }
+}
+
+final class VariantContextsToGenotypesConverter extends Function2[VariantContextRDD, RDD[Genotype], GenotypeRDD] {
+
+  def call(v1: VariantContextRDD, v2: RDD[Genotype]): GenotypeRDD = {
+    ADAMContext.variantContextsToGenotypesConversionFn(v1, v2)
+  }
+}
+
+final class VariantContextsToVariantsConverter extends Function2[VariantContextRDD, RDD[Variant], VariantRDD] {
+
+  def call(v1: VariantContextRDD, v2: RDD[Variant]): VariantRDD = {
+    ADAMContext.variantContextsToVariantsConversionFn(v1, v2)
+  }
+}
+
+final class VariantContextsToVariantContextConverter extends SameTypeConversion[VariantContext, VariantContextRDD] {
+}

--- a/adam-core/src/main/scala/org/bdgenomics/adam/rdd/ADAMContext.scala
+++ b/adam-core/src/main/scala/org/bdgenomics/adam/rdd/ADAMContext.scala
@@ -506,7 +506,7 @@ object ADAMContext {
     new DatasetBoundFeatureRDD(ds, gRdd.sequences)
   }
 
-  implicit def fragmentsToFragmentsConversionFn(
+  implicit def fragmentsToAlignmentRecordsConversionFn(
     gRdd: FragmentRDD,
     rdd: RDD[AlignmentRecord]): AlignmentRecordRDD = {
     new RDDBoundAlignmentRecordRDD(rdd,
@@ -761,13 +761,13 @@ object ADAMContext {
     new DatasetBoundCoverageRDD(ds, gRdd.sequences)
   }
 
-  implicit def genotypesToFeatureConversionFn(
+  implicit def genotypesToFeaturesConversionFn(
     gRdd: GenotypeRDD,
     rdd: RDD[Feature]): FeatureRDD = {
     new RDDBoundFeatureRDD(rdd, gRdd.sequences, None)
   }
 
-  implicit def genotypesToFeatureDatasetConversionFn(
+  implicit def genotypesToFeaturesDatasetConversionFn(
     gRdd: GenotypeRDD,
     ds: Dataset[FeatureProduct]): FeatureRDD = {
     new DatasetBoundFeatureRDD(ds, gRdd.sequences)
@@ -861,13 +861,13 @@ object ADAMContext {
     new DatasetBoundCoverageRDD(ds, gRdd.sequences)
   }
 
-  implicit def variantsToFeatureConversionFn(
+  implicit def variantsToFeaturesConversionFn(
     gRdd: VariantRDD,
     rdd: RDD[Feature]): FeatureRDD = {
     new RDDBoundFeatureRDD(rdd, gRdd.sequences, None)
   }
 
-  implicit def variantsToFeatureDatasetConversionFn(
+  implicit def variantsToFeaturesDatasetConversionFn(
     gRdd: VariantRDD,
     ds: Dataset[FeatureProduct]): FeatureRDD = {
     new DatasetBoundFeatureRDD(ds, gRdd.sequences)
@@ -951,7 +951,7 @@ object ADAMContext {
     new RDDBoundCoverageRDD(rdd, gRdd.sequences, None)
   }
 
-  implicit def variantContextsToFeatureConversionFn(
+  implicit def variantContextsToFeaturesConversionFn(
     gRdd: VariantContextRDD,
     rdd: RDD[Feature]): FeatureRDD = {
     new RDDBoundFeatureRDD(rdd, gRdd.sequences, None)
@@ -987,7 +987,7 @@ object ADAMContext {
       None)
   }
 
-  implicit def variantContextsToVariantConversionFn(
+  implicit def variantContextsToVariantsConversionFn(
     gRdd: VariantContextRDD,
     rdd: RDD[Variant]): VariantRDD = {
     new RDDBoundVariantRDD(rdd,

--- a/adam-core/src/main/scala/org/bdgenomics/adam/rdd/read/SAMInFormatter.scala
+++ b/adam-core/src/main/scala/org/bdgenomics/adam/rdd/read/SAMInFormatter.scala
@@ -45,6 +45,10 @@ case class SAMInFormatter private (
     recordGroups: RecordGroupDictionary,
     converter: AlignmentRecordConverter) extends AnySAMInFormatter[SAMInFormatter] {
 
+  def this() = {
+    this(null, null, null)
+  }
+
   protected val companion = SAMInFormatter
 
   protected def makeWriter(os: OutputStream): SAMFileWriter = {

--- a/adam-python/src/bdgenomics/adam/test/alignmentRecordRdd_test.py
+++ b/adam-python/src/bdgenomics/adam/test/alignmentRecordRdd_test.py
@@ -92,3 +92,20 @@ class AlignmentRecordRDDTest(SparkTestCase):
         kmers = reads.countKmers(6)
 
         self.assertEquals(kmers.count(), 1040)
+
+
+    def test_pipe_as_sam(self):
+
+        reads12Path = self.resourceFile("reads12.sam")
+        ac = ADAMContext(self.sc)
+
+        reads = ac.loadAlignments(reads12Path)
+
+        pipedRdd = reads.pipe("tee /dev/null",
+                              "org.bdgenomics.adam.rdd.read.SAMInFormatter",
+                              "org.bdgenomics.adam.rdd.read.AnySAMOutFormatter",
+                              "org.bdgenomics.adam.api.java.AlignmentRecordsToAlignmentRecordsConverter")
+
+        self.assertEquals(reads.toDF().count(), pipedRdd.toDF().count())
+
+        

--- a/adam-r/bdg.adam/R/generics.R
+++ b/adam-r/bdg.adam/R/generics.R
@@ -57,8 +57,16 @@ setGeneric("loadVariants",
 
 # @rdname GenomicRDD
 # @export
+setGeneric("pipe",
+           function(ardd, cmd, tFormatter, xFormatter, convFn, ...) { standardGeneric("pipe") })
+
+# @rdname GenomicRDD
+# @export
 setGeneric("toDF",
            function(ardd) { standardGeneric("toDF") })
+
+setGeneric("replaceRdd",
+           function(ardd, rdd) { standardGeneric("replaceRdd") })
 
 # @rdname GenomicRDD
 # @export

--- a/adam-r/bdg.adam/R/rdd.R
+++ b/adam-r/bdg.adam/R/rdd.R
@@ -174,7 +174,7 @@ setMethod("pipe",
 #'
 #' @export
 setMethod("toDF",
-          signature(ardd = "AlignmentRecordRDD"),
+          signature(ardd = "GenomicRDD"),
           function(ardd) {
               sdf = sparkR.callJMethod(ardd@jrdd, "toDF")
               new("SparkDataFrame", sdf, FALSE)
@@ -400,18 +400,6 @@ setMethod("realignIndels",
                                                     maxTargetSize))
           })
 
-#' Converts this GenomicRDD into a dataframe.
-#'
-#' @param ardd The RDD to convert into a dataframe.
-#' @return Returns a dataframe representing this RDD.
-#'
-#' @export
-setMethod("toDF",
-          signature(ardd = "CoverageRDD"),
-          function(ardd) {
-              new("SparkDataFrame", sparkR.callJMethod(ardd@jrdd, "toDF"), FALSE)
-          })
-
 setMethod("replaceRdd",
           signature(ardd = "CoverageRDD",
                     rdd = "jobj"),
@@ -505,18 +493,6 @@ setMethod("replaceRdd",
               FeatureRDD(rdd)
           })
 
-#' Converts this GenomicRDD into a dataframe.
-#'
-#' @param ardd The RDD to convert into a dataframe.
-#' @return Returns a dataframe representing this RDD.
-#'
-#' @export
-setMethod("toDF",
-          signature(ardd = "FeatureRDD"),
-          function(ardd) {
-              new("SparkDataFrame", sparkR.callJMethod(ardd@jrdd, "toDF"), FALSE)
-          })
-
 #' Saves coverage, autodetecting the file type from the extension.
 #'
 #' Writes files ending in .bed as BED6/12, .gff3 as GFF3, .gtf/.gff as GTF/GFF2,
@@ -555,18 +531,6 @@ setMethod("replaceRdd",
               FragmentRDD(rdd)
           })
 
-#' Converts this GenomicRDD into a dataframe.
-#'
-#' @param ardd The RDD to convert into a dataframe.
-#' @return Returns a dataframe representing this RDD.
-#'
-#' @export
-setMethod("toDF",
-          signature(ardd = "FragmentRDD"),
-          function(ardd) {
-              new("SparkDataFrame", sparkR.callJMethod(ardd@jrdd, "toDF"), FALSE)
-          })
-
 #' Splits up the reads in a Fragment, and creates a new RDD.
 #'
 #' @return Returns this RDD converted back to reads.
@@ -603,18 +567,6 @@ setMethod("replaceRdd",
                     rdd = "jobj"),
           function(ardd, rdd) {
               GenotypeRDD(rdd)
-          })
-
-#' Converts this GenomicRDD into a dataframe.
-#'
-#' @param ardd The RDD to convert into a dataframe.
-#' @return Returns a dataframe representing this RDD.
-#'
-#' @export
-setMethod("toDF",
-          signature(ardd = "GenotypeRDD"),
-          function(ardd) {
-              new("SparkDataFrame", sparkR.callJMethod(ardd@jrdd, "toDF"), FALSE)
           })
 
 #' Saves this RDD of genotypes to disk.
@@ -684,18 +636,6 @@ setMethod("replaceRdd",
               NucleotideContigFragmentRDD(rdd)
           })
 
-#' Converts this GenomicRDD into a dataframe.
-#'
-#' @param ardd The RDD to convert into a dataframe.
-#' @return Returns a dataframe representing this RDD.
-#'
-#' @export
-setMethod("toDF",
-          signature(ardd = "NucleotideContigFragmentRDD"),
-          function(ardd) {
-              new("SparkDataFrame", sparkR.callJMethod(ardd@jrdd, "toDF"), FALSE)
-          })
-
 #' Save nucleotide contig fragments as Parquet or FASTA.
 #'
 #' If filename ends in .fa or .fasta, saves as Fasta. If not, saves fragments to
@@ -730,18 +670,6 @@ setMethod("replaceRdd",
                     rdd = "jobj"),
           function(ardd, rdd) {
               VariantRDD(rdd)
-          })
-
-#' Converts this GenomicRDD into a dataframe.
-#'
-#' @param ardd The RDD to convert into a dataframe.
-#' @return Returns a dataframe representing this RDD.
-#'
-#' @export
-setMethod("toDF",
-          signature(ardd = "VariantRDD"),
-          function(ardd) {
-              new("SparkDataFrame", sparkR.callJMethod(ardd@jrdd, "toDF"), FALSE)
           })
 
 #' Saves this RDD of variants to disk.

--- a/adam-r/bdg.adam/tests/testthat/test_alignmentRecordRdd.R
+++ b/adam-r/bdg.adam/tests/testthat/test_alignmentRecordRdd.R
@@ -67,3 +67,18 @@ test_that("count k-mers", {
 
     expect_equal(count(kmers), 1040)
 })
+
+test_that("pipe as sam", {
+
+    reads12Path <- resourceFile("reads12.sam")
+    reads <- loadAlignments(ac, reads12Path)
+
+    pipedRdd <- pipe(reads,
+                     "tee /dev/null",
+                     "org.bdgenomics.adam.rdd.read.SAMInFormatter",
+                     "org.bdgenomics.adam.rdd.read.AnySAMOutFormatter",
+                     "org.bdgenomics.adam.api.java.AlignmentRecordsToAlignmentRecordsConverter")
+
+    expect_equal(count(toDF(reads)),
+                 count(toDF(pipedRdd)))
+})


### PR DESCRIPTION
Resolves #1611. Depends on #1397. Adds a Java-friendly pipe method onto `GenomicRDD`, and     conversion functions in the `org.bdgenomics.adam.api.java` package. Simultaneously, we add a `GenomicRDD` base type in the R bindings. With these additions, we then add the pipe method to the `GenomicRDD` class that exists in both Python and R. The language bindings use reflection     to construct the in/out-formatters and conversion functions.

While I was at it, I also made the `toDF` implementation in R generic.