### PR TITLE
[ADAM-1607] Update distribution assembly task to attach assembly überjar

### DIFF
--- a/distribution/src/main/assembly/assembly.xml
+++ b/distribution/src/main/assembly/assembly.xml
@@ -47,7 +47,7 @@
     <fileSet>
       <directory>../adam-assembly/target</directory>
       <includes>
-        <include>adam_*.jar</include>
+        <include>adam-assembly*.jar</include>
       </includes>
       <outputDirectory>repo</outputDirectory>
       <directoryMode>0755</directoryMode>

--- a/scripts/jenkins-test
+++ b/scripts/jenkins-test
@@ -133,6 +133,13 @@ mvn -U \
     -Dspark.version=${SPARK_VERSION} \
     -DargLine=${ADAM_MVN_TMP_DIR}
 
+# make sure that the distribution package contains an assembly jar
+# if no assembly jar is found, this will exit with code 1 and fail the build
+tar tzvf distribution/target/adam-distribution*-bin.tar.gz | \
+    grep adam-assembly | \
+    grep jar | \
+    grep -v -e sources -e javadoc 
+
 # we are done with maven, so clean up the maven temp dir
 find ${ADAM_MVN_TMP_DIR}
 rm -rf ${ADAM_MVN_TMP_DIR}


### PR DESCRIPTION
Resolves #1607. 3ea4f18e2275bdbed7609403098aa4194b03003a renamed the überjar generated by the adam-assembly package from `adam_<version>.jar` to `adam-assembly_<version>.jar`, but did not update the distribution assembly task. This commit updates that task, and adds code to `jenkins-test` to ensure that the assembly jar is packaged in the distribution.