### PR TITLE
[ADAM-1615] Add transform and transmute APIs to Java, R, and Python

### DIFF
--- a/adam-apis/src/main/scala/org/bdgenomics/adam/api/java/GenomicDatasetConverters.scala
+++ b/adam-apis/src/main/scala/org/bdgenomics/adam/api/java/GenomicDatasetConverters.scala
@@ -1,0 +1,365 @@
+/**
+ * Licensed to Big Data Genomics (BDG) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The BDG licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.bdgenomics.adam.api.java
+
+import org.apache.spark.sql.Dataset
+import org.bdgenomics.adam.models.Coverage
+import org.bdgenomics.adam.rdd.{
+  ADAMContext,
+  GenomicDataset,
+  GenomicDatasetConversion
+}
+import org.bdgenomics.adam.rdd.contig.NucleotideContigFragmentRDD
+import org.bdgenomics.adam.rdd.feature.{ CoverageRDD, FeatureRDD }
+import org.bdgenomics.adam.rdd.fragment.FragmentRDD
+import org.bdgenomics.adam.rdd.read.AlignmentRecordRDD
+import org.bdgenomics.adam.rdd.variant.{
+  VariantRDD,
+  GenotypeRDD
+}
+import org.bdgenomics.adam.sql._
+import scala.reflect.runtime.universe._
+
+trait ToContigDatasetConversion[T <: Product, U <: GenomicDataset[_, T, U]] extends GenomicDatasetConversion[T, U, NucleotideContigFragment, NucleotideContigFragmentRDD] {
+
+  val xTag: TypeTag[NucleotideContigFragment] = typeTag[NucleotideContigFragment]
+}
+
+trait ToCoverageDatasetConversion[T <: Product, U <: GenomicDataset[_, T, U]] extends GenomicDatasetConversion[T, U, Coverage, CoverageRDD] {
+
+  val xTag: TypeTag[Coverage] = typeTag[Coverage]
+}
+
+trait ToFeatureDatasetConversion[T <: Product, U <: GenomicDataset[_, T, U]] extends GenomicDatasetConversion[T, U, Feature, FeatureRDD] {
+
+  val xTag: TypeTag[Feature] = typeTag[Feature]
+}
+
+trait ToFragmentDatasetConversion[T <: Product, U <: GenomicDataset[_, T, U]] extends GenomicDatasetConversion[T, U, Fragment, FragmentRDD] {
+
+  val xTag: TypeTag[Fragment] = typeTag[Fragment]
+}
+
+trait ToAlignmentRecordDatasetConversion[T <: Product, U <: GenomicDataset[_, T, U]] extends GenomicDatasetConversion[T, U, AlignmentRecord, AlignmentRecordRDD] {
+
+  val xTag: TypeTag[AlignmentRecord] = typeTag[AlignmentRecord]
+}
+
+trait ToGenotypeDatasetConversion[T <: Product, U <: GenomicDataset[_, T, U]] extends GenomicDatasetConversion[T, U, Genotype, GenotypeRDD] {
+
+  val xTag: TypeTag[Genotype] = typeTag[Genotype]
+}
+
+trait ToVariantDatasetConversion[T <: Product, U <: GenomicDataset[_, T, U]] extends GenomicDatasetConversion[T, U, Variant, VariantRDD] {
+
+  val xTag: TypeTag[Variant] = typeTag[Variant]
+}
+
+final class ContigsToCoverageDatasetConverter extends ToCoverageDatasetConversion[NucleotideContigFragment, NucleotideContigFragmentRDD] {
+
+  def call(v1: NucleotideContigFragmentRDD, v2: Dataset[Coverage]): CoverageRDD = {
+    ADAMContext.contigsToCoverageDatasetConversionFn(v1, v2)
+  }
+}
+
+final class ContigsToFeaturesDatasetConverter extends ToFeatureDatasetConversion[NucleotideContigFragment, NucleotideContigFragmentRDD] {
+
+  def call(v1: NucleotideContigFragmentRDD, v2: Dataset[Feature]): FeatureRDD = {
+    ADAMContext.contigsToFeaturesDatasetConversionFn(v1, v2)
+  }
+}
+
+final class ContigsToFragmentsDatasetConverter extends ToFragmentDatasetConversion[NucleotideContigFragment, NucleotideContigFragmentRDD] {
+
+  def call(v1: NucleotideContigFragmentRDD, v2: Dataset[Fragment]): FragmentRDD = {
+    ADAMContext.contigsToFragmentsDatasetConversionFn(v1, v2)
+  }
+}
+
+final class ContigsToAlignmentRecordsDatasetConverter extends ToAlignmentRecordDatasetConversion[NucleotideContigFragment, NucleotideContigFragmentRDD] {
+
+  def call(v1: NucleotideContigFragmentRDD, v2: Dataset[AlignmentRecord]): AlignmentRecordRDD = {
+    ADAMContext.contigsToAlignmentRecordsDatasetConversionFn(v1, v2)
+  }
+}
+
+final class ContigsToGenotypesDatasetConverter extends ToGenotypeDatasetConversion[NucleotideContigFragment, NucleotideContigFragmentRDD] {
+
+  def call(v1: NucleotideContigFragmentRDD, v2: Dataset[Genotype]): GenotypeRDD = {
+    ADAMContext.contigsToGenotypesDatasetConversionFn(v1, v2)
+  }
+}
+
+final class ContigsToVariantsDatasetConverter extends ToVariantDatasetConversion[NucleotideContigFragment, NucleotideContigFragmentRDD] {
+
+  def call(v1: NucleotideContigFragmentRDD, v2: Dataset[Variant]): VariantRDD = {
+    ADAMContext.contigsToVariantsDatasetConversionFn(v1, v2)
+  }
+}
+
+final class CoverageToContigsDatasetConverter extends ToContigDatasetConversion[Coverage, CoverageRDD] {
+
+  def call(v1: CoverageRDD, v2: Dataset[NucleotideContigFragment]): NucleotideContigFragmentRDD = {
+    ADAMContext.coverageToContigsDatasetConversionFn(v1, v2)
+  }
+}
+
+final class CoverageToFeaturesDatasetConverter extends ToFeatureDatasetConversion[Coverage, CoverageRDD] {
+
+  def call(v1: CoverageRDD, v2: Dataset[Feature]): FeatureRDD = {
+    ADAMContext.coverageToFeaturesDatasetConversionFn(v1, v2)
+  }
+}
+
+final class CoverageToFragmentsDatasetConverter extends ToFragmentDatasetConversion[Coverage, CoverageRDD] {
+
+  def call(v1: CoverageRDD, v2: Dataset[Fragment]): FragmentRDD = {
+    ADAMContext.coverageToFragmentsDatasetConversionFn(v1, v2)
+  }
+}
+
+final class CoverageToAlignmentRecordsDatasetConverter extends ToAlignmentRecordDatasetConversion[Coverage, CoverageRDD] {
+
+  def call(v1: CoverageRDD, v2: Dataset[AlignmentRecord]): AlignmentRecordRDD = {
+    ADAMContext.coverageToAlignmentRecordsDatasetConversionFn(v1, v2)
+  }
+}
+
+final class CoverageToGenotypesDatasetConverter extends ToGenotypeDatasetConversion[Coverage, CoverageRDD] {
+
+  def call(v1: CoverageRDD, v2: Dataset[Genotype]): GenotypeRDD = {
+    ADAMContext.coverageToGenotypesDatasetConversionFn(v1, v2)
+  }
+}
+
+final class CoverageToVariantsDatasetConverter extends ToVariantDatasetConversion[Coverage, CoverageRDD] {
+
+  def call(v1: CoverageRDD, v2: Dataset[Variant]): VariantRDD = {
+    ADAMContext.coverageToVariantsDatasetConversionFn(v1, v2)
+  }
+}
+
+final class FeaturesToContigsDatasetConverter extends ToContigDatasetConversion[Feature, FeatureRDD] {
+
+  def call(v1: FeatureRDD, v2: Dataset[NucleotideContigFragment]): NucleotideContigFragmentRDD = {
+    ADAMContext.featuresToContigsDatasetConversionFn(v1, v2)
+  }
+}
+
+final class FeaturesToCoverageDatasetConverter extends ToCoverageDatasetConversion[Feature, FeatureRDD] {
+
+  def call(v1: FeatureRDD, v2: Dataset[Coverage]): CoverageRDD = {
+    ADAMContext.featuresToCoverageDatasetConversionFn(v1, v2)
+  }
+}
+
+final class FeaturesToFragmentsDatasetConverter extends ToFragmentDatasetConversion[Feature, FeatureRDD] {
+
+  def call(v1: FeatureRDD, v2: Dataset[Fragment]): FragmentRDD = {
+    ADAMContext.featuresToFragmentsDatasetConversionFn(v1, v2)
+  }
+}
+
+final class FeaturesToAlignmentRecordsDatasetConverter extends ToAlignmentRecordDatasetConversion[Feature, FeatureRDD] {
+
+  def call(v1: FeatureRDD, v2: Dataset[AlignmentRecord]): AlignmentRecordRDD = {
+    ADAMContext.featuresToAlignmentRecordsDatasetConversionFn(v1, v2)
+  }
+}
+
+final class FeaturesToGenotypesDatasetConverter extends ToGenotypeDatasetConversion[Feature, FeatureRDD] {
+
+  def call(v1: FeatureRDD, v2: Dataset[Genotype]): GenotypeRDD = {
+    ADAMContext.featuresToGenotypesDatasetConversionFn(v1, v2)
+  }
+}
+
+final class FeaturesToVariantsDatasetConverter extends ToVariantDatasetConversion[Feature, FeatureRDD] {
+
+  def call(v1: FeatureRDD, v2: Dataset[Variant]): VariantRDD = {
+    ADAMContext.featuresToVariantsDatasetConversionFn(v1, v2)
+  }
+}
+
+final class FragmentsToContigsDatasetConverter extends ToContigDatasetConversion[Fragment, FragmentRDD] {
+
+  def call(v1: FragmentRDD, v2: Dataset[NucleotideContigFragment]): NucleotideContigFragmentRDD = {
+    ADAMContext.fragmentsToContigsDatasetConversionFn(v1, v2)
+  }
+}
+
+final class FragmentsToCoverageDatasetConverter extends ToCoverageDatasetConversion[Fragment, FragmentRDD] {
+
+  def call(v1: FragmentRDD, v2: Dataset[Coverage]): CoverageRDD = {
+    ADAMContext.fragmentsToCoverageDatasetConversionFn(v1, v2)
+  }
+}
+
+final class FragmentsToFeaturesDatasetConverter extends ToFeatureDatasetConversion[Fragment, FragmentRDD] {
+
+  def call(v1: FragmentRDD, v2: Dataset[Feature]): FeatureRDD = {
+    ADAMContext.fragmentsToFeaturesDatasetConversionFn(v1, v2)
+  }
+}
+
+final class FragmentsToAlignmentRecordsDatasetConverter extends ToAlignmentRecordDatasetConversion[Fragment, FragmentRDD] {
+
+  def call(v1: FragmentRDD, v2: Dataset[AlignmentRecord]): AlignmentRecordRDD = {
+    ADAMContext.fragmentsToAlignmentRecordsDatasetConversionFn(v1, v2)
+  }
+}
+
+final class FragmentsToGenotypesDatasetConverter extends ToGenotypeDatasetConversion[Fragment, FragmentRDD] {
+
+  def call(v1: FragmentRDD, v2: Dataset[Genotype]): GenotypeRDD = {
+    ADAMContext.fragmentsToGenotypesDatasetConversionFn(v1, v2)
+  }
+}
+
+final class FragmentsToVariantsDatasetConverter extends ToVariantDatasetConversion[Fragment, FragmentRDD] {
+
+  def call(v1: FragmentRDD, v2: Dataset[Variant]): VariantRDD = {
+    ADAMContext.fragmentsToVariantsDatasetConversionFn(v1, v2)
+  }
+}
+
+final class AlignmentRecordsToContigsDatasetConverter extends ToContigDatasetConversion[AlignmentRecord, AlignmentRecordRDD] {
+
+  def call(v1: AlignmentRecordRDD, v2: Dataset[NucleotideContigFragment]): NucleotideContigFragmentRDD = {
+    ADAMContext.alignmentRecordsToContigsDatasetConversionFn(v1, v2)
+  }
+}
+
+final class AlignmentRecordsToCoverageDatasetConverter extends ToCoverageDatasetConversion[AlignmentRecord, AlignmentRecordRDD] {
+
+  def call(v1: AlignmentRecordRDD, v2: Dataset[Coverage]): CoverageRDD = {
+    ADAMContext.alignmentRecordsToCoverageDatasetConversionFn(v1, v2)
+  }
+}
+
+final class AlignmentRecordsToFeaturesDatasetConverter extends ToFeatureDatasetConversion[AlignmentRecord, AlignmentRecordRDD] {
+
+  def call(v1: AlignmentRecordRDD, v2: Dataset[Feature]): FeatureRDD = {
+    ADAMContext.alignmentRecordsToFeaturesDatasetConversionFn(v1, v2)
+  }
+}
+
+final class AlignmentRecordsToFragmentsDatasetConverter extends ToFragmentDatasetConversion[AlignmentRecord, AlignmentRecordRDD] {
+
+  def call(v1: AlignmentRecordRDD, v2: Dataset[Fragment]): FragmentRDD = {
+    ADAMContext.alignmentRecordsToFragmentsDatasetConversionFn(v1, v2)
+  }
+}
+
+final class AlignmentRecordsToGenotypesDatasetConverter extends ToGenotypeDatasetConversion[AlignmentRecord, AlignmentRecordRDD] {
+
+  def call(v1: AlignmentRecordRDD, v2: Dataset[Genotype]): GenotypeRDD = {
+    ADAMContext.alignmentRecordsToGenotypesDatasetConversionFn(v1, v2)
+  }
+}
+
+final class AlignmentRecordsToVariantsDatasetConverter extends ToVariantDatasetConversion[AlignmentRecord, AlignmentRecordRDD] {
+
+  def call(v1: AlignmentRecordRDD, v2: Dataset[Variant]): VariantRDD = {
+    ADAMContext.alignmentRecordsToVariantsDatasetConversionFn(v1, v2)
+  }
+}
+
+final class GenotypesToContigsDatasetConverter extends ToContigDatasetConversion[Genotype, GenotypeRDD] {
+
+  def call(v1: GenotypeRDD, v2: Dataset[NucleotideContigFragment]): NucleotideContigFragmentRDD = {
+    ADAMContext.genotypesToContigsDatasetConversionFn(v1, v2)
+  }
+}
+
+final class GenotypesToCoverageDatasetConverter extends ToCoverageDatasetConversion[Genotype, GenotypeRDD] {
+
+  def call(v1: GenotypeRDD, v2: Dataset[Coverage]): CoverageRDD = {
+    ADAMContext.genotypesToCoverageDatasetConversionFn(v1, v2)
+  }
+}
+
+final class GenotypesToFeaturesDatasetConverter extends ToFeatureDatasetConversion[Genotype, GenotypeRDD] {
+
+  def call(v1: GenotypeRDD, v2: Dataset[Feature]): FeatureRDD = {
+    ADAMContext.genotypesToFeaturesDatasetConversionFn(v1, v2)
+  }
+}
+
+final class GenotypesToFragmentsDatasetConverter extends ToFragmentDatasetConversion[Genotype, GenotypeRDD] {
+
+  def call(v1: GenotypeRDD, v2: Dataset[Fragment]): FragmentRDD = {
+    ADAMContext.genotypesToFragmentsDatasetConversionFn(v1, v2)
+  }
+}
+
+final class GenotypesToAlignmentRecordsDatasetConverter extends ToAlignmentRecordDatasetConversion[Genotype, GenotypeRDD] {
+
+  def call(v1: GenotypeRDD, v2: Dataset[AlignmentRecord]): AlignmentRecordRDD = {
+    ADAMContext.genotypesToAlignmentRecordsDatasetConversionFn(v1, v2)
+  }
+}
+
+final class GenotypesToVariantsDatasetConverter extends ToVariantDatasetConversion[Genotype, GenotypeRDD] {
+
+  def call(v1: GenotypeRDD, v2: Dataset[Variant]): VariantRDD = {
+    ADAMContext.genotypesToVariantsDatasetConversionFn(v1, v2)
+  }
+}
+
+final class VariantsToContigsDatasetConverter extends ToContigDatasetConversion[Variant, VariantRDD] {
+
+  def call(v1: VariantRDD, v2: Dataset[NucleotideContigFragment]): NucleotideContigFragmentRDD = {
+    ADAMContext.variantsToContigsDatasetConversionFn(v1, v2)
+  }
+}
+
+final class VariantsToCoverageDatasetConverter extends ToCoverageDatasetConversion[Variant, VariantRDD] {
+
+  def call(v1: VariantRDD, v2: Dataset[Coverage]): CoverageRDD = {
+    ADAMContext.variantsToCoverageDatasetConversionFn(v1, v2)
+  }
+}
+
+final class VariantsToFeaturesDatasetConverter extends ToFeatureDatasetConversion[Variant, VariantRDD] {
+
+  def call(v1: VariantRDD, v2: Dataset[Feature]): FeatureRDD = {
+    ADAMContext.variantsToFeaturesDatasetConversionFn(v1, v2)
+  }
+}
+
+final class VariantsToFragmentsDatasetConverter extends ToFragmentDatasetConversion[Variant, VariantRDD] {
+
+  def call(v1: VariantRDD, v2: Dataset[Fragment]): FragmentRDD = {
+    ADAMContext.variantsToFragmentsDatasetConversionFn(v1, v2)
+  }
+}
+
+final class VariantsToAlignmentRecordsDatasetConverter extends ToAlignmentRecordDatasetConversion[Variant, VariantRDD] {
+
+  def call(v1: VariantRDD, v2: Dataset[AlignmentRecord]): AlignmentRecordRDD = {
+    ADAMContext.variantsToAlignmentRecordsDatasetConversionFn(v1, v2)
+  }
+}
+
+final class VariantsToGenotypesDatasetConverter extends ToGenotypeDatasetConversion[Variant, VariantRDD] {
+
+  def call(v1: VariantRDD, v2: Dataset[Genotype]): GenotypeRDD = {
+    ADAMContext.variantsToGenotypesDatasetConversionFn(v1, v2)
+  }
+}

--- a/adam-apis/src/main/scala/org/bdgenomics/adam/api/python/DataFrameConversionWrapper.scala
+++ b/adam-apis/src/main/scala/org/bdgenomics/adam/api/python/DataFrameConversionWrapper.scala
@@ -1,0 +1,29 @@
+/**
+ * Licensed to Big Data Genomics (BDG) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The BDG licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.bdgenomics.adam.api.python
+
+import org.apache.spark.api.java.function.{ Function => JFunction }
+import org.apache.spark.sql.DataFrame
+
+class DataFrameConversionWrapper(
+    newDf: DataFrame) extends JFunction[DataFrame, DataFrame] {
+
+  def call(v1: DataFrame): DataFrame = {
+    newDf
+  }
+}

--- a/adam-core/src/main/scala/org/bdgenomics/adam/rdd/GenomicDatasetConversion.scala
+++ b/adam-core/src/main/scala/org/bdgenomics/adam/rdd/GenomicDatasetConversion.scala
@@ -1,0 +1,29 @@
+/**
+ * Licensed to Big Data Genomics (BDG) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The BDG licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.bdgenomics.adam.rdd
+
+import org.apache.spark.api.java.function.Function2
+import org.apache.spark.sql.Dataset
+import scala.reflect.runtime.universe.TypeTag
+
+trait GenomicDatasetConversion[T <: Product, U <: GenomicDataset[_, T, U], X <: Product, Y <: GenomicDataset[_, X, Y]] extends Function2[U, Dataset[X], Y] {
+
+  val xTag: TypeTag[X]
+
+  def call(v1: U, v2: Dataset[X]): Y
+}

--- a/adam-core/src/main/scala/org/bdgenomics/adam/rdd/contig/NucleotideContigFragmentRDD.scala
+++ b/adam-core/src/main/scala/org/bdgenomics/adam/rdd/contig/NucleotideContigFragmentRDD.scala
@@ -42,6 +42,7 @@ import org.bdgenomics.utils.interval.array.{
 import scala.collection.JavaConversions._
 import scala.math.max
 import scala.reflect.ClassTag
+import scala.reflect.runtime.universe._
 
 private[adam] case class NucleotideContigFragmentArray(
     array: Array[(ReferenceRegion, NucleotideContigFragment)],
@@ -185,6 +186,8 @@ case class RDDBoundNucleotideContigFragmentRDD private[rdd] (
 }
 
 sealed abstract class NucleotideContigFragmentRDD extends AvroGenomicRDD[NucleotideContigFragment, NucleotideContigFragmentProduct, NucleotideContigFragmentRDD] {
+
+  @transient val uTag: TypeTag[NucleotideContigFragmentProduct] = typeTag[NucleotideContigFragmentProduct]
 
   protected def buildTree(rdd: RDD[(ReferenceRegion, NucleotideContigFragment)])(
     implicit tTag: ClassTag[NucleotideContigFragment]): IntervalArray[ReferenceRegion, NucleotideContigFragment] = {

--- a/adam-core/src/main/scala/org/bdgenomics/adam/rdd/feature/CoverageRDD.scala
+++ b/adam-core/src/main/scala/org/bdgenomics/adam/rdd/feature/CoverageRDD.scala
@@ -36,6 +36,7 @@ import org.bdgenomics.utils.interval.array.{
 }
 import scala.annotation.tailrec
 import scala.reflect.ClassTag
+import scala.reflect.runtime.universe._
 
 private[adam] case class CoverageArray(
     array: Array[(ReferenceRegion, Coverage)],
@@ -151,6 +152,8 @@ case class RDDBoundCoverageRDD private[rdd] (
 }
 
 abstract class CoverageRDD extends GenomicDataset[Coverage, Coverage, CoverageRDD] {
+
+  @transient val uTag: TypeTag[Coverage] = typeTag[Coverage]
 
   protected def buildTree(rdd: RDD[(ReferenceRegion, Coverage)])(
     implicit tTag: ClassTag[Coverage]): IntervalArray[ReferenceRegion, Coverage] = {

--- a/adam-core/src/main/scala/org/bdgenomics/adam/rdd/feature/FeatureRDD.scala
+++ b/adam-core/src/main/scala/org/bdgenomics/adam/rdd/feature/FeatureRDD.scala
@@ -43,6 +43,7 @@ import org.bdgenomics.utils.interval.array.{
 import scala.collection.JavaConversions._
 import scala.math.max
 import scala.reflect.ClassTag
+import scala.reflect.runtime.universe._
 
 private[adam] case class FeatureArray(
     array: Array[(ReferenceRegion, Feature)],
@@ -336,6 +337,8 @@ case class RDDBoundFeatureRDD private[rdd] (
 }
 
 sealed abstract class FeatureRDD extends AvroGenomicRDD[Feature, FeatureProduct, FeatureRDD] {
+
+  @transient val uTag: TypeTag[FeatureProduct] = typeTag[FeatureProduct]
 
   protected def buildTree(rdd: RDD[(ReferenceRegion, Feature)])(
     implicit tTag: ClassTag[Feature]): IntervalArray[ReferenceRegion, Feature] = {

--- a/adam-core/src/main/scala/org/bdgenomics/adam/rdd/fragment/FragmentRDD.scala
+++ b/adam-core/src/main/scala/org/bdgenomics/adam/rdd/fragment/FragmentRDD.scala
@@ -47,6 +47,7 @@ import org.bdgenomics.utils.interval.array.{
 import org.bdgenomics.utils.misc.Logging
 import scala.collection.JavaConversions._
 import scala.reflect.ClassTag
+import scala.reflect.runtime.universe._
 
 private[adam] case class FragmentArray(
     array: Array[(ReferenceRegion, Fragment)],
@@ -256,6 +257,8 @@ case class RDDBoundFragmentRDD private[rdd] (
 }
 
 sealed abstract class FragmentRDD extends AvroRecordGroupGenomicRDD[Fragment, FragmentProduct, FragmentRDD] {
+
+  @transient val uTag: TypeTag[FragmentProduct] = typeTag[FragmentProduct]
 
   protected def buildTree(rdd: RDD[(ReferenceRegion, Fragment)])(
     implicit tTag: ClassTag[Fragment]): IntervalArray[ReferenceRegion, Fragment] = {

--- a/adam-core/src/main/scala/org/bdgenomics/adam/rdd/read/AlignmentRecordRDD.scala
+++ b/adam-core/src/main/scala/org/bdgenomics/adam/rdd/read/AlignmentRecordRDD.scala
@@ -70,6 +70,7 @@ import scala.collection.JavaConversions._
 import scala.language.implicitConversions
 import scala.math.{ abs, min }
 import scala.reflect.ClassTag
+import scala.reflect.runtime.universe._
 
 private[adam] case class AlignmentRecordArray(
     array: Array[(ReferenceRegion, AlignmentRecord)],
@@ -326,6 +327,8 @@ private case class AlignmentWindow(contigName: String, start: Long, end: Long) {
 }
 
 sealed abstract class AlignmentRecordRDD extends AvroRecordGroupGenomicRDD[AlignmentRecord, AlignmentRecordProduct, AlignmentRecordRDD] {
+
+  @transient val uTag: TypeTag[AlignmentRecordProduct] = typeTag[AlignmentRecordProduct]
 
   /**
    * Applies a function that transforms the underlying RDD into a new RDD using

--- a/adam-core/src/main/scala/org/bdgenomics/adam/rdd/variant/GenotypeRDD.scala
+++ b/adam-core/src/main/scala/org/bdgenomics/adam/rdd/variant/GenotypeRDD.scala
@@ -40,6 +40,7 @@ import org.bdgenomics.utils.interval.array.{ IntervalArray, IntervalArraySeriali
 import org.bdgenomics.formats.avro.{ Genotype, Sample }
 import scala.collection.JavaConversions._
 import scala.reflect.ClassTag
+import scala.reflect.runtime.universe._
 
 private[adam] case class GenotypeArray(
     array: Array[(ReferenceRegion, Genotype)],
@@ -210,6 +211,8 @@ case class RDDBoundGenotypeRDD private[rdd] (
 }
 
 sealed abstract class GenotypeRDD extends MultisampleAvroGenomicRDD[Genotype, GenotypeProduct, GenotypeRDD] {
+
+  @transient val uTag: TypeTag[GenotypeProduct] = typeTag[GenotypeProduct]
 
   val headerLines: Seq[VCFHeaderLine]
 

--- a/adam-core/src/main/scala/org/bdgenomics/adam/rdd/variant/VariantRDD.scala
+++ b/adam-core/src/main/scala/org/bdgenomics/adam/rdd/variant/VariantRDD.scala
@@ -44,6 +44,7 @@ import org.bdgenomics.utils.interval.array.{
 }
 import scala.collection.JavaConversions._
 import scala.reflect.ClassTag
+import scala.reflect.runtime.universe._
 
 private[adam] case class VariantArray(
     array: Array[(ReferenceRegion, Variant)],
@@ -194,6 +195,8 @@ case class RDDBoundVariantRDD private[rdd] (
 }
 
 sealed abstract class VariantRDD extends AvroGenomicRDD[Variant, VariantProduct, VariantRDD] {
+
+  @transient val uTag: TypeTag[VariantProduct] = typeTag[VariantProduct]
 
   val headerLines: Seq[VCFHeaderLine]
 

--- a/adam-r/bdg.adam/R/generics.R
+++ b/adam-r/bdg.adam/R/generics.R
@@ -68,6 +68,25 @@ setGeneric("toDF",
 setGeneric("replaceRdd",
            function(ardd, rdd) { standardGeneric("replaceRdd") })
 
+setGeneric("wrapTransformation",
+           function(ardd, tFn) { standardGeneric("wrapTransformation") })
+
+# @rdname GenomicRDD
+# @export
+setGeneric("transform",
+           function(ardd, tFn) { standardGeneric("transform") })
+
+setGeneric("inferConversionFn",
+           function(ardd, destClass) { standardGeneric("inferConversionFn") })
+
+setGeneric("destClassSuffix",
+           function(destClass) { standardGeneric("destClassSuffix") })
+
+# @rdname GenomicRDD
+# @export
+setGeneric("transmute",
+           function(ardd, tFn, destClass, ...) { standardGeneric("transmute") })
+
 # @rdname GenomicRDD
 # @export
 setGeneric("save",

--- a/adam-r/bdg.adam/R/generics.R
+++ b/adam-r/bdg.adam/R/generics.R
@@ -160,6 +160,11 @@ setGeneric("realignIndels",
 
 # @rdname CoverageRDD
 # @export
+setGeneric("collapse",
+           function(ardd, ...) { standardGeneric("collapse") })
+
+# @rdname CoverageRDD
+# @export
 setGeneric("toFeatureRDD",
            function(ardd) { standardGeneric("toFeatureRDD") })
 

--- a/adam-r/bdg.adam/R/rdd.R
+++ b/adam-r/bdg.adam/R/rdd.R
@@ -574,7 +574,7 @@ setMethod("save",
 #' @return An RDD with merged tuples of adjacent sites with same coverage.
 #'
 #' @export
-setMethod("save", signature(ardd = "CoverageRDD"),
+setMethod("collapse", signature(ardd = "CoverageRDD"),
           function(ardd) {
               CoverageRDD(sparkR.callJMethod(ardd@jrdd, "collapse"))
           })

--- a/adam-r/bdg.adam/tests/testthat/test_alignmentRecordRdd.R
+++ b/adam-r/bdg.adam/tests/testthat/test_alignmentRecordRdd.R
@@ -82,3 +82,27 @@ test_that("pipe as sam", {
     expect_equal(count(toDF(reads)),
                  count(toDF(pipedRdd)))
 })
+
+test_that("transform dataframe of reads", {
+
+    readsPath <- resourceFile("unsorted.sam")
+    reads <- loadAlignments(ac, readsPath)
+
+    transformedReads = transform(reads, function(df) {
+        filter(df, df$contigName == "1")
+    })
+
+    expect_equal(count(toDF(transformedReads)), 1)
+})
+
+test_that("transmute to coverage", {
+    readsPath <- resourceFile("unsorted.sam")
+    reads <- loadAlignments(ac, readsPath)
+
+    readsAsCoverage = transmute(reads, function(df) {
+        select(df, df$contigName, df$start, df$end, alias(cast(df$mapq, "double"), "count"))
+    }, "CoverageRDD")
+
+    expect_true(is(readsAsCoverage, "CoverageRDD"))
+    expect_equal(count(toDF(readsAsCoverage)), 5)
+})


### PR DESCRIPTION
Resolves #1615. Adds `GenomicDatasetConversion` class to adam-core API, along with accompanying implementations in `org.bdgenomics.adam.api.java` package. Adds `transformDataFrame` and `transmuteDataFrame` to `GenomicRDD` API. To enable use from Python and R, we provide a `DataFrameConversionWrapper` that wraps the product of an R/Python function in a Spark Java API `Function`.

- [ ] When this moves on top of #1628, need to make sure the functions move on top of `GenomicDataset`.