### PR TITLE
[ADAM-1614] Add VariantContextRDD to R and Python APIs.

### DIFF
--- a/adam-python/src/bdgenomics/adam/test/genotypeRdd_test.py
+++ b/adam-python/src/bdgenomics/adam/test/genotypeRdd_test.py
@@ -32,7 +32,7 @@ class GenotypeRDDTest(SparkTestCase):
         genotypes = ac.loadGenotypes(testFile)
 
         tmpPath = self.tmpFile() + ".vcf"
-        genotypes.save(tmpPath)
+        genotypes.toVariantContextRDD().saveAsVcf(tmpPath)
 
         savedGenotypes = ac.loadGenotypes(testFile)
 
@@ -48,9 +48,8 @@ class GenotypeRDDTest(SparkTestCase):
         genotypes = ac.loadGenotypes(testFile)
 
         tmpPath = self.tmpFile() + ".vcf"
-        genotypes.saveAsVcf(tmpPath,
-                            asSingleFile=True,
-                            sortOnSave=True)
+        genotypes.toVariantContextRDD().sort().saveAsVcf(tmpPath,
+                                                         asSingleFile=True)
 
         self.checkFiles(tmpPath, self.resourceFile("sorted.vcf"))
 
@@ -63,8 +62,7 @@ class GenotypeRDDTest(SparkTestCase):
         genotypes = ac.loadGenotypes(testFile)
 
         tmpPath = self.tmpFile() + ".vcf"
-        genotypes.saveAsVcf(tmpPath,
-                            asSingleFile=True,
-                            sortOnSave="lexicographically")
+        genotypes.toVariantContextRDD().sortLexicographically().saveAsVcf(tmpPath,
+                                                                          asSingleFile=True)
 
         self.checkFiles(tmpPath, self.resourceFile("sorted.lex.vcf"))

--- a/adam-python/src/bdgenomics/adam/test/variantRdd_test.py
+++ b/adam-python/src/bdgenomics/adam/test/variantRdd_test.py
@@ -32,7 +32,7 @@ class VariantRDDTest(SparkTestCase):
         variants = ac.loadVariants(testFile)
 
         tmpPath = self.tmpFile() + ".vcf"
-        variants.save(tmpPath)
+        variants.toVariantContextRDD().saveAsVcf(tmpPath)
 
         savedVariants = ac.loadVariants(testFile)
 

--- a/adam-r/bdg.adam/R/generics.R
+++ b/adam-r/bdg.adam/R/generics.R
@@ -73,6 +73,16 @@ setGeneric("replaceRdd",
 setGeneric("save",
            function(ardd, filePath, ...) { standardGeneric("save") })
 
+# @rdname GenomicRDD
+# @export
+setGeneric("sort",
+           function(ardd) { standardGeneric("sort") })
+
+# @rdname GenomicRDD
+# @export
+setGeneric("sortLexicographically",
+           function(ardd) { standardGeneric("sortLexicographically") })
+
 #### AlignmentRecord operations ####
 
 # @rdname AlignmentRecordRDD
@@ -160,8 +170,13 @@ setGeneric("toReads",
 
 # @rdname GenotypeRDD
 # @export
-setGeneric("saveAsVcf",
-           function(ardd, filePath, ...) { standardGeneric("saveAsVcf") })
+setGeneric("toVariantContextRDD",
+           function(ardd) { standardGeneric("toVariantContextRDD") })
+
+# @rdname GenotypeRDD
+# @export
+setGeneric("saveAsParquet",
+           function(ardd, filePath) { standardGeneric("saveAsParquet") })
 
 #### NucleotideContigFragment operations ####
 
@@ -175,6 +190,16 @@ setGeneric("flankAdjacentFragments",
 #### Variant operations ####
 
 # @rdname VariantRDD
+# @export
+setGeneric("toVariantContextRDD",
+           function(ardd) { standardGeneric("toVariantContextRDD") })
+
+# @rdname VariantRDD
+# @export
+setGeneric("saveAsParquet",
+           function(ardd, filePath) { standardGeneric("saveAsParquet") })
+
+# @rdname VariantContextRDD
 # @export
 setGeneric("saveAsVcf",
            function(ardd, filePath, ...) { standardGeneric("saveAsVcf") })

--- a/adam-r/bdg.adam/tests/testthat/test_genotypeRdd.R
+++ b/adam-r/bdg.adam/tests/testthat/test_genotypeRdd.R
@@ -26,7 +26,7 @@ test_that("round trip vcf", {
     testFile <- resourceFile("small.vcf")
     genotypes <- loadGenotypes(ac, testFile)
     tmpPath <- tempfile(fileext = ".vcf")
-    save(genotypes, tmpPath)
+    saveAsVcf(toVariantContextRDD(genotypes), tmpPath)
 
     expect_equal(count(toDF(genotypes)), count(toDF(loadGenotypes(ac, tmpPath))))
 })
@@ -36,7 +36,7 @@ test_that("save sorted vcf", {
     testFile <- resourceFile("random.vcf")
     genotypes <- loadGenotypes(ac, testFile)
     tmpPath <- tempfile(fileext = ".vcf")
-    saveAsVcf(genotypes, tmpPath, asSingleFile = TRUE, sortOnSave = TRUE)
+    saveAsVcf(sort(toVariantContextRDD(genotypes)), tmpPath, asSingleFile = TRUE)
 
     truthFile <- resourceFile("sorted.vcf")
     expect_files_match(tmpPath, truthFile)
@@ -47,7 +47,9 @@ test_that("save lex sorted vcf", {
     testFile <- resourceFile("random.vcf")
     genotypes <- loadGenotypes(ac, testFile)
     tmpPath <- tempfile(fileext = ".vcf")
-    saveAsVcf(genotypes, tmpPath, asSingleFile = TRUE, sortOnSave = "lexicographically")
+    saveAsVcf(sortLexicographically(toVariantContextRDD(genotypes)),
+              tmpPath,
+              asSingleFile = TRUE)
 
     truthFile <- resourceFile("sorted.lex.vcf")
     expect_files_match(tmpPath, truthFile)

--- a/adam-r/bdg.adam/tests/testthat/test_variantRdd.R
+++ b/adam-r/bdg.adam/tests/testthat/test_variantRdd.R
@@ -26,7 +26,7 @@ test_that("round trip vcf", {
     testFile <- resourceFile("small.vcf")
     variants <- loadVariants(ac, testFile)
     tmpPath <- tempfile(fileext = ".vcf")
-    save(variants, tmpPath)
+    saveAsVcf(toVariantContextRDD(variants), tmpPath)
 
     expect_equal(count(toDF(variants)), count(toDF(loadVariants(ac, tmpPath))))
 })


### PR DESCRIPTION
Resolves #1614. Restructures both R and Python APIs to add `GenomicDataset` class, which inherits from `GenomicRDD`, as in adam-core. Moves all implementing classes onto `GenomicDataset`, and adds `VariantContextRDD` which is the lone class that extends `GenomicRDD`. Deletes `saveAsVcf` from `GenotypeRDD` and `VariantRDD`, and moves this functionality into `toVariantContextRDD` functions and `VariantContextRDD.saveAsVcf`. Additionally, adds `sort` and `sortLexicographically` to the R API, and fixes `sortLexicographically` in the Python API (it was calling `sort` previously).