### PR TITLE
[ADAM-1635] Eliminate passing FASTQ splittable status via config.

### DIFF
--- a/adam-core/src/main/java/org/bdgenomics/adam/io/FastqInputFormat.java
+++ b/adam-core/src/main/java/org/bdgenomics/adam/io/FastqInputFormat.java
@@ -34,8 +34,6 @@ public abstract class FastqInputFormat extends FileInputFormat<Void, Text> {
 
     protected boolean splittable;
 
-    static final String FILE_SPLITTABLE = "org.bdgenomics.adam.io.FastqInputFormat.fileIsSplittable";
-    
     /**
      * Checks to see if the file we are looking at is splittable.
      *
@@ -84,11 +82,6 @@ public abstract class FastqInputFormat extends FileInputFormat<Void, Text> {
         } else {
             splittable = false;
         }
-
-        // the behavior of the record reader depends on whether the underlying
-        // stream is splittable. the only reliable way to pass this to the
-        // record reader is through the hadoop configuration.
-        conf.setBoolean(FILE_SPLITTABLE, splittable);
 
         return splittable;
     }


### PR DESCRIPTION
Resolves #1635. Instead of passing whether a FASTQ was splittable via config, checks to see if the compression codec is splittable. This is more reliable. In the case of a .gz file, the BGZFEnhancedGZipCodec properly handles this edge case by checking the stream type; this coupled with us explicitly checking the stream when split picking ensures that we don't try to create an invalid GZIP split. Additionally, I identified and fixed an error in the old FASTQ code that did a seek on the uncompressed input stream to backtrack if seeing a line of quality scores that began with @ when identifying the position of the first valid record in a split. Instead, we check for two successive lines that start with an @, which indicates that the first line contains quality scores, while the second line contains read names.