### PR TITLE
[ADAM-1663] Enable read groups with repeated names when unioning.

### DIFF
--- a/adam-core/src/main/scala/org/bdgenomics/adam/models/RecordGroupDictionary.scala
+++ b/adam-core/src/main/scala/org/bdgenomics/adam/models/RecordGroupDictionary.scala
@@ -94,7 +94,7 @@ case class RecordGroupDictionary(recordGroups: Seq[RecordGroup]) {
    * @return The merged record group dictionary.
    */
   def ++(that: RecordGroupDictionary): RecordGroupDictionary = {
-    new RecordGroupDictionary(recordGroups ++ that.recordGroups)
+    new RecordGroupDictionary((recordGroups ++ that.recordGroups).distinct)
   }
 
   /**

--- a/adam-core/src/test/scala/org/bdgenomics/adam/models/RecordGroupDictionarySuite.scala
+++ b/adam-core/src/test/scala/org/bdgenomics/adam/models/RecordGroupDictionarySuite.scala
@@ -84,4 +84,11 @@ class RecordGroupDictionarySuite extends FunSuite {
     assert(emptyRgd.isEmpty)
     assert(emptyRgd.recordGroups.size === 0)
   }
+
+  test("merging a dictionary with itself should work") {
+    val rgd = RecordGroupDictionary(Seq(RecordGroup("sample1", "rg1")))
+
+    val mergedRgd = rgd ++ rgd
+    assert(rgd === mergedRgd)
+  }
 }


### PR DESCRIPTION
Resolves #1663. When unioning two read groups together, calls distinct after appending the two RecordGroupDictionaries.