### PR TITLE
[ADAM-1676] Add more finely grained validation for INFO/FORMAT fields.

### DIFF
--- a/adam-core/src/test/scala/org/bdgenomics/adam/converters/VariantContextConverterSuite.scala
+++ b/adam-core/src/test/scala/org/bdgenomics/adam/converters/VariantContextConverterSuite.scala
@@ -306,7 +306,10 @@ class VariantContextConverterSuite extends ADAMFunSuite {
 
     val optHtsjdkVC = converter.convert(ADAMVariantContext(variant, Seq(genotype)))
 
-    assert(optHtsjdkVC.isEmpty)
+    assert(optHtsjdkVC.isDefined)
+    optHtsjdkVC.foreach(vc => {
+      assert(!vc.getGenotype("NA12878").hasAnyAttribute("SB"))
+    })
   }
 
   test("Convert htsjdk multi-allelic sites-only SNVs to ADAM") {

--- a/adam-core/src/test/scala/org/bdgenomics/adam/rdd/variant/VariantContextRDDSuite.scala
+++ b/adam-core/src/test/scala/org/bdgenomics/adam/rdd/variant/VariantContextRDDSuite.scala
@@ -132,13 +132,14 @@ class VariantContextRDDSuite extends ADAMFunSuite {
   sparkTest("transform a vcf file with bad header") {
     val path = testFile("invalid/truth_small_variants.vcf")
     val before = sc.loadVcf(path, ValidationStringency.SILENT)
-    assert(before.rdd.count == 1)
+    assert(before.rdd.count === 7)
+    assert(before.toGenotypeRDD().rdd.filter(_.getPhaseSetId == null).count === 7)
 
     val tempPath = tmpLocation(".adam")
     before.toVariantRDD().saveAsParquet(tempPath)
 
     val after = sc.loadVariants(tempPath).toVariantContextRDD()
-    assert(after.rdd.count == 1)
+    assert(after.rdd.count === 7)
   }
 
   sparkTest("don't lose any variants when piping as VCF") {


### PR DESCRIPTION
Resolves #1676. Pushes validation checking down to the single field conversion level, which keeps a variant/genotype record around even if a bad INFO/FORMAT field was attached to that record.

WIP, needs more testing, not ready for merge.