### PR TITLE
[ADAM-1688] Add bdg-formats exclusion to org.hammerlab:genomic-loci dependency.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -408,6 +408,12 @@
         <groupId>org.hammerlab</groupId>
         <artifactId>genomic-loci_${scala.version.prefix}</artifactId>
         <version>1.4.4</version>
+        <exclusions>
+          <exclusion>
+            <groupId>org.bdgenomics.bdg-formats</groupId>
+            <artifactId>*</artifactId>
+          </exclusion>
+        </exclusions>
       </dependency>
       <dependency>
         <groupId>org.bdgenomics.utils</groupId>


### PR DESCRIPTION
Fixes #1688