### PR TITLE
[ADAM-1693] Add adam-shell friendly VariantContextRDD.saveAsVcf method.

### DIFF
--- a/adam-core/src/main/scala/org/bdgenomics/adam/instrumentation/Timers.scala
+++ b/adam-core/src/main/scala/org/bdgenomics/adam/instrumentation/Timers.scala
@@ -114,6 +114,7 @@ object Timers extends Metrics {
   val ConvertToSAM = timer("Convert To SAM")
   val ConvertToSAMRecord = timer("Convert To SAM Record")
   val SaveAsADAM = timer("Save File In ADAM Format")
+  val SaveAsVcf = timer("Save File In VCF Format")
   val WriteADAMRecord = timer("Write ADAM Record")
   val WriteBAMRecord = timer("Write BAM Record")
   val WriteSAMRecord = timer("Write SAM Record")

--- a/adam-core/src/main/scala/org/bdgenomics/adam/rdd/variant/VariantContextRDD.scala
+++ b/adam-core/src/main/scala/org/bdgenomics/adam/rdd/variant/VariantContextRDD.scala
@@ -29,6 +29,7 @@ import org.bdgenomics.adam.converters.{
   DefaultHeaderLines,
   VariantContextConverter
 }
+import org.bdgenomics.adam.instrumentation.Timers.SaveAsVcf
 import org.bdgenomics.adam.models.{
   ReferenceRegion,
   ReferenceRegionSerializer,
@@ -201,6 +202,8 @@ case class VariantContextRDD(rdd: RDD[VariantContext],
    * Converts an RDD of ADAM VariantContexts to HTSJDK VariantContexts
    * and saves to disk as VCF.
    *
+   * File paths that end in .gz or .bgz will be saved as block GZIP compressed VCFs.
+   *
    * @param args Arguments defining where to save the file.
    * @param stringency The validation stringency to use when writing the VCF.
    *   Defaults to LENIENT.
@@ -217,15 +220,33 @@ case class VariantContextRDD(rdd: RDD[VariantContext],
 
   /**
    * Converts an RDD of ADAM VariantContexts to HTSJDK VariantContexts
+   * and saves as a single file to disk as VCF. Uses lenient validation
+   * stringency.
+   *
+   * File paths that end in .gz or .bgz will be saved as block GZIP compressed VCFs.
+   *
+   * @param filePath The file path to save to.
+   */
+  def saveAsVcf(filePath: String): Unit = {
+    saveAsVcf(
+      filePath,
+      asSingleFile = true,
+      deferMerging = false,
+      disableFastConcat = false,
+      stringency = ValidationStringency.LENIENT)
+  }
+
+  /**
+   * Converts an RDD of ADAM VariantContexts to HTSJDK VariantContexts
    * and saves to disk as VCF.
    *
-   * Files that end in .gz or .bgz will be saved as block GZIP compressed VCFs.
+   * File paths that end in .gz or .bgz will be saved as block GZIP compressed VCFs.
    *
-   * @param filePath The filepath to save to.
+   * @param filePath The file path to save to.
    * @param asSingleFile If true, saves the output as a single file by merging
    *   the sharded output after completing the write to HDFS. If false, the
    *   output of this call will be written as shards, where each shard has a
-   *   valid VCF header. Default is false.
+   *   valid VCF header.
    * @param deferMerging If true and asSingleFile is true, we will save the
    *   output shards as a headerless file, but we will not merge the shards.
    * @param disableFastConcat If asSingleFile is true and deferMerging is false,
@@ -236,7 +257,7 @@ case class VariantContextRDD(rdd: RDD[VariantContext],
                 asSingleFile: Boolean,
                 deferMerging: Boolean,
                 disableFastConcat: Boolean,
-                stringency: ValidationStringency) {
+                stringency: ValidationStringency): Unit = SaveAsVcf.time {
 
     // TODO: Add BCF support
     val vcfFormat = VCFFormat.VCF

--- a/adam-core/src/test/scala/org/bdgenomics/adam/rdd/variant/VariantContextRDDSuite.scala
+++ b/adam-core/src/test/scala/org/bdgenomics/adam/rdd/variant/VariantContextRDDSuite.scala
@@ -105,7 +105,17 @@ class VariantContextRDDSuite extends ADAMFunSuite {
     assert(vcRdd.sequences.records(0).name === "chr11")
   }
 
-  sparkTest("can write as a single file, then read in .vcf file") {
+  sparkTest("can write as a single file via simple saveAsVcf method, then read in .vcf file") {
+    val path = new File(tempDir, "test_single.vcf")
+    variants.saveAsVcf(path.getAbsolutePath)
+    assert(path.exists)
+    val vcRdd = sc.loadVcf("%s/test_single.vcf".format(tempDir))
+    assert(vcRdd.rdd.count === 1)
+    assert(vcRdd.sequences.records.size === 1)
+    assert(vcRdd.sequences.records(0).name === "chr11")
+  }
+
+  sparkTest("can write as a single file via full saveAsVcf method, then read in .vcf file") {
     val path = new File(tempDir, "test_single.vcf")
     variants.saveAsVcf(path.getAbsolutePath,
       asSingleFile = true,


### PR DESCRIPTION
Fixes #1693 