### PR TITLE
[ADAM-1709] Add ability to left normalize reads containing INDELs.

### DIFF
--- a/adam-core/src/main/scala/org/bdgenomics/adam/algorithms/consensus/NormalizationUtils.scala
+++ b/adam-core/src/main/scala/org/bdgenomics/adam/algorithms/consensus/NormalizationUtils.scala
@@ -27,7 +27,7 @@ import scala.collection.JavaConversions._
 /**
  * Utility for left normalizing INDELs in alignments.
  */
-private[consensus] object NormalizationUtils {
+private[adam] object NormalizationUtils {
 
   /**
    * Given a cigar, returns the cigar with the position of the cigar shifted left.


### PR DESCRIPTION
Resolves #1709. Opens protection on main method in NormalizationUtils to be package-private to org.bdgenomics.adam. Adds code to AlignmentRecordRDD exposing INDEL normalization as a transformation.