### PR TITLE
[ADAM-1715] Support validation stringency in Python/R.

### DIFF
--- a/adam-apis/src/main/scala/org/bdgenomics/adam/api/java/JavaADAMContext.scala
+++ b/adam-apis/src/main/scala/org/bdgenomics/adam/api/java/JavaADAMContext.scala
@@ -17,6 +17,7 @@
  */
 package org.bdgenomics.adam.api.java
 
+import htsjdk.samtools.ValidationStringency
 import org.apache.spark.api.java.JavaSparkContext
 import org.bdgenomics.adam.rdd.ADAMContext
 import org.bdgenomics.adam.rdd.contig.NucleotideContigFragmentRDD
@@ -76,6 +77,38 @@ class JavaADAMContext(val ac: ADAMContext) extends Serializable {
   }
 
   /**
+   * Load alignment records into an AlignmentRecordRDD (java-friendly method).
+   *
+   * Loads path names ending in:
+   * * .bam/.cram/.sam as BAM/CRAM/SAM format,
+   * * .fa/.fasta as FASTA format,
+   * * .fq/.fastq as FASTQ format, and
+   * * .ifq as interleaved FASTQ format.
+   *
+   * If none of these match, fall back to Parquet + Avro.
+   *
+   * For FASTA, FASTQ, and interleaved FASTQ formats, compressed files are supported
+   * through compression codecs configured in Hadoop, which by default include .gz and .bz2,
+   * but can include more.
+   *
+   * @see ADAMContext#loadAlignments
+   *
+   * @param pathName The path name to load alignment records from.
+   *   Globs/directories are supported, although file extension must be present
+   *   for BAM/CRAM/SAM, FASTA, and FASTQ formats.
+   * @param stringency The validation stringency to use when validating
+   *   BAM/CRAM/SAM or FASTQ formats.
+   * @return Returns an AlignmentRecordRDD which wraps the RDD of alignment records,
+   *   sequence dictionary representing contigs the alignment records may be aligned to,
+   *   and the record group dictionary for the alignment records if one is available.
+   */
+  def loadAlignments(pathName: java.lang.String,
+                     stringency: ValidationStringency): AlignmentRecordRDD = {
+    ac.loadAlignments(pathName,
+      stringency = stringency)
+  }
+
+  /**
    * Load nucleotide contig fragments into a NucleotideContigFragmentRDD (java-friendly method).
    *
    * If the path name has a .fa/.fasta extension, load as FASTA format.
@@ -119,6 +152,31 @@ class JavaADAMContext(val ac: ADAMContext) extends Serializable {
   }
 
   /**
+   * Load fragments into a FragmentRDD (java-friendly method).
+   *
+   * Loads path names ending in:
+   * * .bam/.cram/.sam as BAM/CRAM/SAM format and
+   * * .ifq as interleaved FASTQ format.
+   *
+   * If none of these match, fall back to Parquet + Avro.
+   *
+   * For interleaved FASTQ format, compressed files are supported through compression codecs
+   * configured in Hadoop, which by default include .gz and .bz2, but can include more.
+   *
+   * @see ADAMContext#loadFragments
+   *
+   * @param pathName The path name to load fragments from.
+   *   Globs/directories are supported, although file extension must be present
+   *   for BAM/CRAM/SAM and FASTQ formats.
+   * @param stringency The validation stringency to use when validating BAM/CRAM/SAM or FASTQ formats.
+   * @return Returns a FragmentRDD.
+   */
+  def loadFragments(pathName: java.lang.String,
+                    stringency: ValidationStringency): FragmentRDD = {
+    ac.loadFragments(pathName, stringency = stringency)
+  }
+
+  /**
    * Load features into a FeatureRDD (java-friendly method).
    *
    * Loads path names ending in:
@@ -143,6 +201,36 @@ class JavaADAMContext(val ac: ADAMContext) extends Serializable {
    */
   def loadFeatures(pathName: java.lang.String): FeatureRDD = {
     ac.loadFeatures(pathName)
+  }
+
+  /**
+   * Load features into a FeatureRDD (java-friendly method).
+   *
+   * Loads path names ending in:
+   * * .bed as BED6/12 format,
+   * * .gff3 as GFF3 format,
+   * * .gtf/.gff as GTF/GFF2 format,
+   * * .narrow[pP]eak as NarrowPeak format, and
+   * * .interval_list as IntervalList format.
+   *
+   * If none of these match, fall back to Parquet + Avro.
+   *
+   * For BED6/12, GFF3, GTF/GFF2, NarrowPeak, and IntervalList formats, compressed files
+   * are supported through compression codecs configured in Hadoop, which by default include
+   * .gz and .bz2, but can include more.
+   *
+   * @see ADAMContext#loadFeatures
+   *
+   * @param pathName The path name to load features from.
+   *   Globs/directories are supported, although file extension must be present
+   *   for BED6/12, GFF3, GTF/GFF2, NarrowPeak, or IntervalList formats.
+   * @param stringency The validation stringency to use when validating BED6/12, GFF3,
+   *   GTF/GFF2, NarrowPeak, or IntervalList formats.
+   * @return Returns a FeatureRDD.
+   */
+  def loadFeatures(pathName: java.lang.String,
+                   stringency: ValidationStringency): FeatureRDD = {
+    ac.loadFeatures(pathName, stringency = stringency)
   }
 
   /**
@@ -174,6 +262,38 @@ class JavaADAMContext(val ac: ADAMContext) extends Serializable {
   }
 
   /**
+   * Load features into a FeatureRDD and convert to a CoverageRDD (java-friendly method).
+   * Coverage is stored in the score field of Feature.
+   *
+   * Loads path names ending in:
+   * * .bed as BED6/12 format,
+   * * .gff3 as GFF3 format,
+   * * .gtf/.gff as GTF/GFF2 format,
+   * * .narrow[pP]eak as NarrowPeak format, and
+   * * .interval_list as IntervalList format.
+   *
+   * If none of these match, fall back to Parquet + Avro.
+   *
+   * For BED6/12, GFF3, GTF/GFF2, NarrowPeak, and IntervalList formats, compressed files
+   * are supported through compression codecs configured in Hadoop, which by default include
+   * .gz and .bz2, but can include more.
+   *
+   * @see ADAMContext#loadCoverage
+   *
+   * @param pathName The path name to load features from.
+   *   Globs/directories are supported, although file extension must be present
+   *   for BED6/12, GFF3, GTF/GFF2, NarrowPeak, or IntervalList formats.
+   * @param stringency The validation stringency to use when validating BED6/12, GFF3,
+   *   GTF/GFF2, NarrowPeak, or IntervalList formats.
+   * @return Returns a FeatureRDD converted to a CoverageRDD.
+   */
+  def loadCoverage(pathName: java.lang.String,
+                   stringency: ValidationStringency): CoverageRDD = {
+    ac.loadCoverage(pathName,
+      stringency = stringency)
+  }
+
+  /**
    * Load genotypes into a GenotypeRDD (java-friendly method).
    *
    * If the path name has a .vcf/.vcf.gz/.vcf.bgzf/.vcf.bgz extension, load as VCF format.
@@ -191,6 +311,26 @@ class JavaADAMContext(val ac: ADAMContext) extends Serializable {
   }
 
   /**
+   * Load genotypes into a GenotypeRDD (java-friendly method).
+   *
+   * If the path name has a .vcf/.vcf.gz/.vcf.bgzf/.vcf.bgz extension, load as VCF format.
+   * Else, fall back to Parquet + Avro.
+   *
+   * @see ADAMContext#loadGenotypes
+   *
+   * @param pathName The path name to load genotypes from.
+   *   Globs/directories are supported, although file extension must be present
+   *   for VCF format.
+   * @param stringency The validation stringency to use when validating VCF format.
+   * @return Returns a GenotypeRDD.
+   */
+  def loadGenotypes(pathName: java.lang.String,
+                    stringency: ValidationStringency): GenotypeRDD = {
+    ac.loadGenotypes(pathName,
+      stringency = stringency)
+  }
+
+  /**
    * Load variants into a VariantRDD (java-friendly method).
    *
    * If the path name has a .vcf/.vcf.gz/.vcf.bgzf/.vcf.bgz extension, load as VCF format.
@@ -204,6 +344,24 @@ class JavaADAMContext(val ac: ADAMContext) extends Serializable {
    */
   def loadVariants(pathName: java.lang.String): VariantRDD = {
     ac.loadVariants(pathName)
+  }
+
+  /**
+   * Load variants into a VariantRDD (java-friendly method).
+   *
+   * If the path name has a .vcf/.vcf.gz/.vcf.bgzf/.vcf.bgz extension, load as VCF format.
+   * Else, fall back to Parquet + Avro.
+   *
+   * @see ADAMContext#loadVariants
+   *
+   * @param pathName The path name to load variants from.
+   *   Globs/directories are supported, although file extension must be present for VCF format.
+   * @param stringency The validation stringency to use when validating VCF format.
+   * @return Returns a VariantRDD.
+   */
+  def loadVariants(pathName: java.lang.String,
+                   stringency: ValidationStringency): VariantRDD = {
+    ac.loadVariants(pathName, stringency = stringency)
   }
 
   /**

--- a/adam-python/bdgenomics/adam/adamContext.py
+++ b/adam-python/bdgenomics/adam/adamContext.py
@@ -23,7 +23,8 @@ from bdgenomics.adam.rdd import AlignmentRecordRDD, \
     GenotypeRDD, \
     NucleotideContigFragmentRDD, \
     VariantRDD
-    
+from bdgenomics.adam.stringency import STRICT, _toJava
+
 
 class ADAMContext(object):
     """
@@ -46,7 +47,7 @@ class ADAMContext(object):
         self.__jac = self._jvm.org.bdgenomics.adam.api.java.JavaADAMContext(c)
 
 
-    def loadAlignments(self, filePath):
+    def loadAlignments(self, filePath, stringency=STRICT):
         """
         Load alignment records into an AlignmentRecordRDD.
 
@@ -63,16 +64,19 @@ class ADAMContext(object):
         but can include more.
 
         :param str filePath: The path to load the file from.
+        :param stringency: The validation stringency to apply. Defaults to STRICT.
         :return: Returns an RDD containing reads.
         :rtype: bdgenomics.adam.rdd.AlignmentRecordRDD
         """
 
-        adamRdd = self.__jac.loadAlignments(filePath)
+        adamRdd = self.__jac.loadAlignments(filePath,
+                                            _toJava(stringency, self._jvm))
 
         return AlignmentRecordRDD(adamRdd, self._sc)
 
 
-    def loadCoverage(self, filePath):
+    def loadCoverage(self, filePath,
+                     stringency=STRICT):
         """
         Load features into a FeatureRDD and convert to a CoverageRDD.
         Coverage is stored in the score field of Feature.
@@ -91,11 +95,13 @@ class ADAMContext(object):
         .gz and .bz2, but can include more.
 
         :param str filePath: The path to load coverage data from.
+        :param stringency: The validation stringency to apply. Defaults to STRICT.
         :return: Returns an RDD containing coverage.
         :rtype: bdgenomics.adam.rdd.CoverageRDD
         """
 
-        adamRdd = self.__jac.loadCoverage(filePath)
+        adamRdd = self.__jac.loadCoverage(filePath,
+                                          _toJava(stringency, self._jvm))
 
         return CoverageRDD(adamRdd, self._sc)
         
@@ -120,7 +126,7 @@ class ADAMContext(object):
         return NucleotideContigFragmentRDD(adamRdd, self._sc)
 
 
-    def loadFragments(self, filePath):
+    def loadFragments(self, filePath, stringency=STRICT):
         """
         Load fragments into a FragmentRDD.
 
@@ -133,16 +139,17 @@ class ADAMContext(object):
         configured in Hadoop, which by default include .gz and .bz2, but can include more.
 
         :param str filePath: The path to load the file from.
+        :param stringency: The validation stringency to apply. Defaults to STRICT.
         :return: Returns an RDD containing sequenced fragments.
         :rtype: bdgenomics.adam.rdd.FragmentRDD
         """
 
-        adamRdd = self.__jac.loadFragments(filePath)
+        adamRdd = self.__jac.loadFragments(filePath, stringency)
 
         return FragmentRDD(adamRdd, self._sc)
 
 
-    def loadFeatures(self, filePath):
+    def loadFeatures(self, filePath, stringency=STRICT):
         """
         Load features into a FeatureRDD.
 
@@ -160,16 +167,18 @@ class ADAMContext(object):
         .gz and .bz2, but can include more.
 
         :param str filePath: The path to load the file from.
+        :param stringency: The validation stringency to apply. Defaults to STRICT.
         :return: Returns an RDD containing features.
         :rtype: bdgenomics.adam.rdd.FeatureRDD
         """
 
-        adamRdd = self.__jac.loadFeatures(filePath)
+        adamRdd = self.__jac.loadFeatures(filePath,
+                                          _toJava(stringency, self._jvm))
 
         return FeatureRDD(adamRdd, self._sc)
 
 
-    def loadGenotypes(self, filePath):
+    def loadGenotypes(self, filePath, stringency=STRICT):
         """
         Load genotypes into a GenotypeRDD.
 
@@ -177,16 +186,18 @@ class ADAMContext(object):
         Else, fall back to Parquet + Avro.
 
         :param str filePath: The path to load the file from.
+        :param stringency: The validation stringency to apply. Defaults to STRICT.
         :return: Returns an RDD containing genotypes.
         :rtype: bdgenomics.adam.rdd.GenotypeRDD
         """
 
-        adamRdd = self.__jac.loadGenotypes(filePath)
+        adamRdd = self.__jac.loadGenotypes(filePath,
+                                           _toJava(stringency, self._jvm))
 
         return GenotypeRDD(adamRdd, self._sc)
 
 
-    def loadVariants(self, filePath):
+    def loadVariants(self, filePath, stringency=STRICT):
         """
         Load variants into a VariantRDD.
 
@@ -194,10 +205,12 @@ class ADAMContext(object):
         Else, fall back to Parquet + Avro.
 
         :param str filePath: The path to load the file from.
+        :param stringency: The validation stringency to apply. Defaults to STRICT.
         :return: Returns an RDD containing variants.
         :rtype: bdgenomics.adam.rdd.VariantRDD
         """
 
-        adamRdd = self.__jac.loadVariants(filePath)
+        adamRdd = self.__jac.loadVariants(filePath,
+                                          _toJava(stringency, self._jvm))
 
         return VariantRDD(adamRdd, self._sc)

--- a/adam-r/bdg.adam/R/adam-context.R
+++ b/adam-r/bdg.adam/R/adam-context.R
@@ -36,6 +36,13 @@ ADAMContext <- function(ss) {
     new("ADAMContext", jac = jac)
 }
 
+javaStringency <- function(stringency) {
+    stringency <- sparkR.callJStatic("htsjdk.samtools.ValidationStringency",
+                                     "valueOf",
+                                     stringency)
+}
+
+
 #' Load alignment records into an AlignmentRecordRDD.
 #'
 #' Loads path names ending in:
@@ -52,13 +59,17 @@ ADAMContext <- function(ss) {
 #'
 #' @param ac The ADAMContext.
 #' @param filePath The path to load the file from.
+#' @param stringency The validation stringency to apply. Defaults to STRICT.
 #' @return Returns an RDD containing reads.
 #'
 #' @export
 setMethod("loadAlignments",
           signature(ac = "ADAMContext", filePath = "character"),
-          function(ac, filePath) {
-              jrdd <- sparkR.callJMethod(ac@jac, "loadAlignments", filePath)
+          function(ac, filePath, stringency = "STRICT") {
+              jStringency <- javaStringency(stringency)
+              jrdd <- sparkR.callJMethod(ac@jac,
+                                         "loadAlignments",
+                                         filePath, jStringency)
               AlignmentRecordRDD(jrdd)
           })
 
@@ -95,13 +106,18 @@ setMethod("loadContigFragments",
 #'
 #' @param ac The ADAMContext.
 #' @param filePath The path to load the file from.
+#' @param stringency The validation stringency to apply. Defaults to STRICT.
 #' @return Returns an RDD containing sequence fragments.
 #'
 #' @export
 setMethod("loadFragments",
           signature(ac = "ADAMContext", filePath = "character"),
-          function(ac, filePath) {
-              jrdd <- sparkR.callJMethod(ac@jac, "loadFragments", filePath)
+          function(ac, filePath, stringency) {
+              jStringency <- javaStringency(stringency)
+              jrdd <- sparkR.callJMethod(ac@jac,
+                                         "loadFragments",
+                                         filePath,
+                                         jStringency)
               FragmentRDD(jrdd)
           })
 
@@ -122,13 +138,18 @@ setMethod("loadFragments",
 #'
 #' @param ac The ADAMContext.
 #' @param filePath The path to load the file from.
+#' @param stringency The validation stringency to apply. Defaults to STRICT.
 #' @return Returns an RDD containing features.
 #'
 #' @export
 setMethod("loadFeatures",
           signature(ac = "ADAMContext", filePath = "character"),
-          function(ac, filePath) {
-              jrdd <- sparkR.callJMethod(ac@jac, "loadFeatures", filePath)
+          function(ac, filePath, stringency = "STRICT") {
+              jStringency <- javaStringency(stringency)
+              jrdd <- sparkR.callJMethod(ac@jac,
+                                         "loadFeatures",
+                                         filePath,
+                                         jStringency)
               FeatureRDD(jrdd)
           })
 
@@ -150,13 +171,18 @@ setMethod("loadFeatures",
 #'
 #' @param ac The ADAMContext.
 #' @param filePath The path to load the file from.
+#' @param stringency The validation stringency to apply. Defaults to STRICT.
 #' @return Returns an RDD containing coverage.
 #'
 #' @export
 setMethod("loadCoverage",
           signature(ac = "ADAMContext", filePath = "character"),
-          function(ac, filePath) {
-              jrdd <- sparkR.callJMethod(ac@jac, "loadCoverage", filePath)
+          function(ac, filePath, stringency = "STRICT") {
+              jStringency <- javaStringency(stringency)
+              jrdd <- sparkR.callJMethod(ac@jac,
+                                         "loadCoverage",
+                                         filePath,
+                                         jStringency)
               CoverageRDD(jrdd)
           })
 
@@ -167,13 +193,18 @@ setMethod("loadCoverage",
 #'
 #' @param ac The ADAMContext.
 #' @param filePath The path to load the file from.
+#' @param stringency The validation stringency to apply. Defaults to STRICT.
 #' @return Returns an RDD containing genotypes.
 #'
 #' @export
 setMethod("loadGenotypes",
           signature(ac = "ADAMContext", filePath = "character"),
-          function(ac, filePath) {
-              jrdd <- sparkR.callJMethod(ac@jac, "loadGenotypes", filePath)
+          function(ac, filePath, stringency = "STRICT") {
+              jStringency <- javaStringency(stringency)
+              jrdd <- sparkR.callJMethod(ac@jac,
+                                         "loadGenotypes",
+                                         filePath,
+                                         jStringency)
               GenotypeRDD(jrdd)
           })
 
@@ -184,12 +215,17 @@ setMethod("loadGenotypes",
 #'
 #' @param ac The ADAMContext.
 #' @param filePath The path to load the file from.
+#' @param stringency The validation stringency to apply. Defaults to STRICT.
 #' @return Returns an RDD containing variants.
 #'
 #' @export
 setMethod("loadVariants",
           signature(ac = "ADAMContext", filePath = "character"),
-          function(ac, filePath) {
-              jrdd <- sparkR.callJMethod(ac@jac, "loadVariants", filePath)
+          function(ac, filePath, stringency = "STRICT") {
+              jStringency <- javaStringency(stringency)
+              jrdd <- sparkR.callJMethod(ac@jac,
+                                         "loadVariants",
+                                         filePath,
+                                         jStringency)
               VariantRDD(jrdd)
           })

--- a/adam-r/bdg.adam/R/generics.R
+++ b/adam-r/bdg.adam/R/generics.R
@@ -21,7 +21,7 @@
 # @rdname ADAMContext
 # @export
 setGeneric("loadAlignments",
-           function(ac, filePath) { standardGeneric("loadAlignments") })
+           function(ac, filePath, ...) { standardGeneric("loadAlignments") })
 
 # @rdname ADAMContext
 # @export
@@ -31,27 +31,27 @@ setGeneric("loadContigFragments",
 # @rdname ADAMContext
 # @export
 setGeneric("loadFragments",
-           function(ac, filePath) { standardGeneric("loadFragments") })
+           function(ac, filePath, ...) { standardGeneric("loadFragments") })
 
 # @rdname ADAMContext
 # @export
 setGeneric("loadFeatures",
-           function(ac, filePath) { standardGeneric("loadFeatures") })
+           function(ac, filePath, ...) { standardGeneric("loadFeatures") })
 
 # @rdname ADAMContext
 # @export
 setGeneric("loadCoverage",
-           function(ac, filePath) { standardGeneric("loadCoverage") })
+           function(ac, filePath, ...) { standardGeneric("loadCoverage") })
 
 # @rdname ADAMContext
 # @export
 setGeneric("loadGenotypes",
-           function(ac, filePath) { standardGeneric("loadGenotypes") })
+           function(ac, filePath, ...) { standardGeneric("loadGenotypes") })
 
 # @rdname ADAMContext
 # @export
 setGeneric("loadVariants",
-           function(ac, filePath) { standardGeneric("loadVariants") })
+           function(ac, filePath, ...) { standardGeneric("loadVariants") })
 
 #### RDD operations ####
 


### PR DESCRIPTION
Resolves #1715. Also adds support for validation stringency when loading fragments.