### PR TITLE
[ADAM-1666] SQLContext creation fix for Spark 2.x

### DIFF
--- a/adam-core/src/main/scala/org/bdgenomics/adam/rdd/ADAMContext.scala
+++ b/adam-core/src/main/scala/org/bdgenomics/adam/rdd/ADAMContext.scala
@@ -42,7 +42,7 @@ import org.apache.parquet.hadoop.util.ContextUtil
 import org.apache.spark.SparkContext
 import org.apache.spark.rdd.MetricsContext._
 import org.apache.spark.rdd.RDD
-import org.apache.spark.sql.Dataset
+import org.apache.spark.sql.{ SparkSession, Dataset }
 import org.bdgenomics.adam.converters._
 import org.bdgenomics.adam.instrumentation.Timers._
 import org.bdgenomics.adam.io._
@@ -998,6 +998,17 @@ object ADAMContext {
 
   // Add ADAM Spark context methods
   implicit def sparkContextToADAMContext(sc: SparkContext): ADAMContext = new ADAMContext(sc)
+
+  /**
+   * Creates an ADAMContext from a SparkSession. Sets active session, including SQLContext, to input session.
+   *
+   * @param ss SparkSession
+   * @return ADAMContext
+   */
+  def ADAMContextFromSession(ss: SparkSession): ADAMContext = {
+    SparkSession.setActiveSession(ss)
+    new ADAMContext(ss.sparkContext)
+  }
 
   // Add generic RDD methods for all types of ADAM RDDs
   implicit def rddToADAMRDD[T](rdd: RDD[T])(implicit ev1: T => IndexedRecord, ev2: Manifest[T]): ConcreteADAMRDDFunctions[T] = new ConcreteADAMRDDFunctions(rdd)

--- a/adam-python/bdgenomics/adam/adamContext.py
+++ b/adam-python/bdgenomics/adam/adamContext.py
@@ -33,7 +33,7 @@ class ADAMContext(object):
     """
 
 
-    def __init__(self, sc):
+    def __init__(self, ss):
         """
         Initializes an ADAMContext using a SparkContext.
 
@@ -41,9 +41,9 @@ class ADAMContext(object):
         SparkContext.
         """
 
-        self._sc = sc
-        self._jvm = sc._jvm
-        c = self._jvm.org.bdgenomics.adam.rdd.ADAMContext(sc._jsc.sc())
+        self._sc = ss.sparkContext
+        self._jvm = self._sc._jvm
+        c = self._jvm.org.bdgenomics.adam.rdd.ADAMContext.ADAMContextFromSession(ss._jsparkSession)
         self.__jac = self._jvm.org.bdgenomics.adam.api.java.JavaADAMContext(c)
 
 

--- a/adam-python/bdgenomics/adam/test/__init__.py
+++ b/adam-python/bdgenomics/adam/test/__init__.py
@@ -22,8 +22,7 @@ import sys
 import tempfile
 import unittest
 
-
-from pyspark.context import SparkContext
+from pyspark.sql import SparkSession
 
 class SparkTestCase(unittest.TestCase):
 
@@ -58,7 +57,8 @@ class SparkTestCase(unittest.TestCase):
     def setUp(self):
         self._old_sys_path = list(sys.path)
         class_name = self.__class__.__name__
-        self.sc = SparkContext('local[4]', class_name)
+        self.ss = SparkSession.builder.master('local[4]').appName(class_name).getOrCreate()
+        self.sc = self.ss.sparkContext
 
         
     def tearDown(self):

--- a/adam-python/bdgenomics/adam/test/adamContext_test.py
+++ b/adam-python/bdgenomics/adam/test/adamContext_test.py
@@ -28,7 +28,7 @@ class ADAMContextTest(SparkTestCase):
     def test_load_alignments(self):
         
         testFile = self.resourceFile("small.sam")
-        ac = ADAMContext(self.sc)
+        ac = ADAMContext(self.ss)
         
         reads = ac.loadAlignments(testFile)
 
@@ -51,7 +51,7 @@ class ADAMContextTest(SparkTestCase):
     def test_load_gtf(self):
 
         testFile = self.resourceFile("Homo_sapiens.GRCh37.75.trun20.gtf")
-        ac = ADAMContext(self.sc)
+        ac = ADAMContext(self.ss)
         
         reads = ac.loadFeatures(testFile)
 
@@ -62,7 +62,7 @@ class ADAMContextTest(SparkTestCase):
     def test_load_bed(self):
 
         testFile = self.resourceFile("gencode.v7.annotation.trunc10.bed")
-        ac = ADAMContext(self.sc)
+        ac = ADAMContext(self.ss)
         
         reads = ac.loadFeatures(testFile)
 
@@ -74,7 +74,7 @@ class ADAMContextTest(SparkTestCase):
 
         
         testFile = self.resourceFile("wgEncodeOpenChromDnaseGm19238Pk.trunc10.narrowPeak")
-        ac = ADAMContext(self.sc)
+        ac = ADAMContext(self.ss)
         
         reads = ac.loadFeatures(testFile)
 
@@ -84,9 +84,8 @@ class ADAMContextTest(SparkTestCase):
 
     def test_load_interval_list(self):
 
-
         testFile = self.resourceFile("SeqCap_EZ_Exome_v3.hg19.interval_list")
-        ac = ADAMContext(self.sc)
+        ac = ADAMContext(self.ss)
         
         reads = ac.loadFeatures(testFile)
 
@@ -98,7 +97,7 @@ class ADAMContextTest(SparkTestCase):
 
 
         testFile = self.resourceFile("sample_coverage.bed")
-        ac = ADAMContext(self.sc)
+        ac = ADAMContext(self.ss)
 
         coverage = ac.loadCoverage(testFile)
 
@@ -109,7 +108,7 @@ class ADAMContextTest(SparkTestCase):
 
         
         testFile = self.resourceFile("small.vcf")
-        ac = ADAMContext(self.sc)
+        ac = ADAMContext(self.ss)
         
         reads = ac.loadGenotypes(testFile)
 
@@ -121,7 +120,7 @@ class ADAMContextTest(SparkTestCase):
 
         
         testFile = self.resourceFile("small.vcf")
-        ac = ADAMContext(self.sc)
+        ac = ADAMContext(self.ss)
         
         reads = ac.loadVariants(testFile)
 
@@ -133,7 +132,7 @@ class ADAMContextTest(SparkTestCase):
 
 
         testFile = self.resourceFile("HLA_DQB1_05_01_01_02.fa")
-        ac = ADAMContext(self.sc)
+        ac = ADAMContext(self.ss)
         
         reads = ac.loadContigFragments(testFile)
 

--- a/adam-python/bdgenomics/adam/test/alignmentRecordRdd_test.py
+++ b/adam-python/bdgenomics/adam/test/alignmentRecordRdd_test.py
@@ -30,7 +30,7 @@ class AlignmentRecordRDDTest(SparkTestCase):
     def test_save_sorted_sam(self):
 
         testFile = self.resourceFile("sorted.sam")
-        ac = ADAMContext(self.sc)
+        ac = ADAMContext(self.ss)
         
         reads = ac.loadAlignments(testFile)
         tmpPath = self.tmpFile() + ".sam"
@@ -45,7 +45,7 @@ class AlignmentRecordRDDTest(SparkTestCase):
     def test_save_unordered_sam(self):
 
         testFile = self.resourceFile("unordered.sam")
-        ac = ADAMContext(self.sc)
+        ac = ADAMContext(self.ss)
         
         reads = ac.loadAlignments(testFile)
         tmpPath = self.tmpFile() + ".sam"
@@ -59,7 +59,7 @@ class AlignmentRecordRDDTest(SparkTestCase):
 
         testFile1 = self.resourceFile("sorted.sam")
         testFile2 = self.resourceFile("unordered.sam")
-        ac = ADAMContext(self.sc)
+        ac = ADAMContext(self.ss)
 
         reads1 = ac.loadAlignments(testFile1)
         reads2 = ac.loadAlignments(testFile2)
@@ -72,7 +72,7 @@ class AlignmentRecordRDDTest(SparkTestCase):
     def test_save_as_bam(self):
 
         testFile = self.resourceFile("sorted.sam")
-        ac = ADAMContext(self.sc)
+        ac = ADAMContext(self.ss)
         
         reads = ac.loadAlignments(testFile)
         tmpPath = self.tmpFile() + ".bam"
@@ -89,7 +89,7 @@ class AlignmentRecordRDDTest(SparkTestCase):
     def test_count_kmers(self):
 
         testFile = self.resourceFile("small.sam")
-        ac = ADAMContext(self.sc)
+        ac = ADAMContext(self.ss)
         
         reads = ac.loadAlignments(testFile)
         kmers = reads.countKmers(6)
@@ -100,7 +100,7 @@ class AlignmentRecordRDDTest(SparkTestCase):
     def test_pipe_as_sam(self):
 
         reads12Path = self.resourceFile("reads12.sam")
-        ac = ADAMContext(self.sc)
+        ac = ADAMContext(self.ss)
 
         reads = ac.loadAlignments(reads12Path)
 
@@ -115,7 +115,7 @@ class AlignmentRecordRDDTest(SparkTestCase):
     def test_transform(self):
 
         readsPath = self.resourceFile("unsorted.sam")
-        ac = ADAMContext(self.sc)
+        ac = ADAMContext(self.ss)
 
         reads = ac.loadAlignments(readsPath)
 
@@ -127,7 +127,7 @@ class AlignmentRecordRDDTest(SparkTestCase):
     def test_transmute_to_coverage(self):
 
         readsPath = self.resourceFile("unsorted.sam")
-        ac = ADAMContext(self.sc)
+        ac = ADAMContext(self.ss)
 
         reads = ac.loadAlignments(readsPath)
 
@@ -144,7 +144,7 @@ class AlignmentRecordRDDTest(SparkTestCase):
     def test_to_coverage(self):
 
         readsPath = self.resourceFile("unsorted.sam")
-        ac = ADAMContext(self.sc)
+        ac = ADAMContext(self.ss)
 
         reads = ac.loadAlignments(readsPath)
 
@@ -158,7 +158,7 @@ class AlignmentRecordRDDTest(SparkTestCase):
     def test_to_fragments(self):
 
         readsPath = self.resourceFile("unsorted.sam")
-        ac = ADAMContext(self.sc)
+        ac = ADAMContext(self.ss)
 
         reads = ac.loadAlignments(readsPath)
 

--- a/adam-python/bdgenomics/adam/test/featureRdd_test.py
+++ b/adam-python/bdgenomics/adam/test/featureRdd_test.py
@@ -27,7 +27,7 @@ class FeatureRDDTest(SparkTestCase):
     def test_round_trip_gtf(self):
 
         testFile = self.resourceFile("Homo_sapiens.GRCh37.75.trun20.gtf")
-        ac = ADAMContext(self.sc)
+        ac = ADAMContext(self.ss)
         
         features = ac.loadFeatures(testFile)
         tmpPath = self.tmpFile() + ".gtf"
@@ -43,7 +43,7 @@ class FeatureRDDTest(SparkTestCase):
     def test_round_trip_bed(self):
 
         testFile = self.resourceFile("gencode.v7.annotation.trunc10.bed")
-        ac = ADAMContext(self.sc)
+        ac = ADAMContext(self.ss)
         
         features = ac.loadFeatures(testFile)
         tmpPath = self.tmpFile() + ".bed"
@@ -59,7 +59,7 @@ class FeatureRDDTest(SparkTestCase):
     def test_round_trip_narrowPeak(self):
 
         testFile = self.resourceFile("wgEncodeOpenChromDnaseGm19238Pk.trunc10.narrowPeak")
-        ac = ADAMContext(self.sc)
+        ac = ADAMContext(self.ss)
         
         features = ac.loadFeatures(testFile)
         tmpPath = self.tmpFile() + ".narrowPeak"
@@ -75,7 +75,7 @@ class FeatureRDDTest(SparkTestCase):
     def test_round_trip_interval_list(self):
 
         testFile = self.resourceFile("SeqCap_EZ_Exome_v3.hg19.interval_list")
-        ac = ADAMContext(self.sc)
+        ac = ADAMContext(self.ss)
         
         features = ac.loadFeatures(testFile)
         tmpPath = self.tmpFile() + ".interval_list"
@@ -91,7 +91,7 @@ class FeatureRDDTest(SparkTestCase):
     def test_transform(self):
 
         featurePath = self.resourceFile("gencode.v7.annotation.trunc10.bed")
-        ac = ADAMContext(self.sc)
+        ac = ADAMContext(self.ss)
 
         features = ac.loadFeatures(featurePath)
 

--- a/adam-python/bdgenomics/adam/test/genotypeRdd_test.py
+++ b/adam-python/bdgenomics/adam/test/genotypeRdd_test.py
@@ -27,7 +27,7 @@ class GenotypeRDDTest(SparkTestCase):
     def test_vcf_round_trip(self):
         
         testFile = self.resourceFile("small.vcf")
-        ac = ADAMContext(self.sc)
+        ac = ADAMContext(self.ss)
         
         genotypes = ac.loadGenotypes(testFile)
 
@@ -43,7 +43,7 @@ class GenotypeRDDTest(SparkTestCase):
     def test_vcf_sort(self):
     
         testFile = self.resourceFile("random.vcf")
-        ac = ADAMContext(self.sc)
+        ac = ADAMContext(self.ss)
         
         genotypes = ac.loadGenotypes(testFile)
 
@@ -57,7 +57,7 @@ class GenotypeRDDTest(SparkTestCase):
     def test_vcf_sort_lex(self):
     
         testFile = self.resourceFile("random.vcf")
-        ac = ADAMContext(self.sc)
+        ac = ADAMContext(self.ss)
         
         genotypes = ac.loadGenotypes(testFile)
 
@@ -70,7 +70,7 @@ class GenotypeRDDTest(SparkTestCase):
 
     def test_transform(self):
         testFile = self.resourceFile("random.vcf")
-        ac = ADAMContext(self.sc)
+        ac = ADAMContext(self.ss)
 
         genotypes = ac.loadGenotypes(testFile)
 

--- a/adam-python/bdgenomics/adam/test/variantRdd_test.py
+++ b/adam-python/bdgenomics/adam/test/variantRdd_test.py
@@ -27,7 +27,7 @@ class VariantRDDTest(SparkTestCase):
     def test_vcf_round_trip(self):
         
         testFile = self.resourceFile("small.vcf")
-        ac = ADAMContext(self.sc)
+        ac = ADAMContext(self.ss)
         
         variants = ac.loadVariants(testFile)
 
@@ -43,7 +43,7 @@ class VariantRDDTest(SparkTestCase):
     def test_transform(self):
 
         variantPath = self.resourceFile("small.vcf")
-        ac = ADAMContext(self.sc)
+        ac = ADAMContext(self.ss)
 
         variants = ac.loadVariants(variantPath)
 

--- a/scripts/jenkins-test-pyadam.py
+++ b/scripts/jenkins-test-pyadam.py
@@ -18,10 +18,10 @@
 
 from bdgenomics.adam.adamContext import ADAMContext
 
-from pyspark.context import SparkContext
+from pyspark.sql import SparkSession
 
-sc = SparkContext('local')
-ac = ADAMContext(sc)
+ss = SparkSession.builder.master('local').getOrCreate()
+ac = ADAMContext(ss)
 
 reads = ac.loadAlignments("adam-core/src/test/resources/small.sam").toDF().count()
 


### PR DESCRIPTION
Fixes https://github.com/bigdatagenomics/adam/issues/1666

Only for Spark 2.x. However, this breaks for Spark 1.x because SparkSession does not exist. Any ideas?