### PR TITLE
[ADAM-1789] Move scala-lang to provided scope.

### DIFF
--- a/adam-apis/pom.xml
+++ b/adam-apis/pom.xml
@@ -93,7 +93,7 @@
     <dependency>
       <groupId>org.scala-lang</groupId>
       <artifactId>scala-library</artifactId>
-      <scope>compile</scope>
+      <scope>provided</scope>
     </dependency>
     <dependency>
       <groupId>org.apache.hadoop</groupId>

--- a/adam-cli/pom.xml
+++ b/adam-cli/pom.xml
@@ -171,7 +171,7 @@
     <dependency>
       <groupId>org.scala-lang</groupId>
       <artifactId>scala-library</artifactId>
-      <scope>compile</scope>
+      <scope>provided</scope>
     </dependency>
     <dependency>
       <groupId>org.slf4j</groupId>

--- a/adam-core/pom.xml
+++ b/adam-core/pom.xml
@@ -165,6 +165,11 @@
     </dependency>
     <dependency>
       <groupId>org.bdgenomics.utils</groupId>
+      <artifactId>utils-misc_${scala.version.prefix}</artifactId>
+      <scope>compile</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.bdgenomics.utils</groupId>
       <artifactId>utils-metrics_${scala.version.prefix}</artifactId>
       <scope>compile</scope>
     </dependency>
@@ -206,7 +211,7 @@
     <dependency>
       <groupId>org.scala-lang</groupId>
       <artifactId>scala-library</artifactId>
-      <scope>compile</scope>
+      <scope>provided</scope>
     </dependency>
     <dependency>
       <groupId>org.apache.hadoop</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -347,6 +347,7 @@
         <groupId>org.scala-lang</groupId>
         <artifactId>scala-library</artifactId>
         <version>${scala.version}</version>
+        <scope>provided</scope>
       </dependency>
       <dependency>
         <groupId>org.bdgenomics.adam</groupId>


### PR DESCRIPTION
Resolves #1789. Also includes utils-misc in adam-core. Previously, utils-misc was specified as just being test scoped in adam-core.