### PR TITLE
[ADAM-1672] Use working directory for R devtools::document().

### DIFF
--- a/adam-r/pom.xml
+++ b/adam-r/pom.xml
@@ -30,9 +30,10 @@
             </goals>
             <configuration>
               <executable>R</executable>
+              <workingDirectory>bdgenomics.adam</workingDirectory>
               <arguments>
                 <argument>-e</argument>
-                <argument>"library(devtools);devtools::document()"</argument>
+                <argument>library(devtools);devtools::document()</argument>
               </arguments>
             </configuration>
           </execution>


### PR DESCRIPTION
Fixes #1672.