### PR TITLE
[ADAM-1795] Map -DskipTests=true to exec.skip for Python and R tests.

### DIFF
--- a/adam-python/pom.xml
+++ b/adam-python/pom.xml
@@ -46,6 +46,7 @@
               <arguments>
                 <argument>test</argument>
               </arguments>
+              <skip>${skipTests}</skip>
             </configuration>
           </execution>
         </executions>

--- a/adam-r/pom.xml
+++ b/adam-r/pom.xml
@@ -65,6 +65,7 @@
                 <argument>check</argument>
                 <argument>bdgenomics.adam/</argument>
               </arguments>
+              <skip>${skipTests}</skip>
             </configuration>
           </execution>
         </executions>


### PR DESCRIPTION
Fixes #1795.