### PR TITLE
Adding loadPairedFastqAsFragments method

### DIFF
--- a/adam-core/src/main/scala/org/bdgenomics/adam/instrumentation/Timers.scala
+++ b/adam-core/src/main/scala/org/bdgenomics/adam/instrumentation/Timers.scala
@@ -46,6 +46,7 @@ object Timers extends Metrics {
   val LoadIndexedVcf = timer("Load indexed VCF format")
   val LoadInterleavedFastq = timer("Load interleaved FASTQ format")
   val LoadInterleavedFastqFragments = timer("Load interleaved FASTQ format as Fragments")
+  val LoadPairedFastqFragments = timer("Load paired FASTQ format as Fragments")
   val LoadIntervalList = timer("Load IntervalList format")
   val LoadNarrowPeak = timer("Load NarrowPeak format")
   val LoadPairedFastq = timer("Load paired FASTQ format")

--- a/adam-core/src/main/scala/org/bdgenomics/adam/rdd/ADAMContext.scala
+++ b/adam-core/src/main/scala/org/bdgenomics/adam/rdd/ADAMContext.scala
@@ -2357,8 +2357,8 @@ class ADAMContext(@transient val sc: SparkContext) extends Serializable with Log
           val r2Fragment = fastqRecordConverter.convertFragment(r2)
           stringency match {
             case ValidationStringency.STRICT | ValidationStringency.LENIENT =>
-              val r1Name = r1Fragment.getReadName.split(" ").head.stripSuffix("/1")
-              val r2Name = r2Fragment.getReadName.split(" ").head.stripSuffix("/2")
+              val r1Name = r1Fragment.getReadName.takeWhile(_ != ' ').stripSuffix("/1")
+              val r2Name = r2Fragment.getReadName.takeWhile(_ != ' ').stripSuffix("/2")
               if (r1Name != r2Name) {
                 val msg = s"Fastq 1 ($pathNameR1) and fastq 2 ($pathNameR2) are not in sync, order of the reads should be the same"
                 if (stringency == ValidationStringency.STRICT)

--- a/adam-core/src/main/scala/org/bdgenomics/adam/rdd/ADAMContext.scala
+++ b/adam-core/src/main/scala/org/bdgenomics/adam/rdd/ADAMContext.scala
@@ -2353,22 +2353,10 @@ class ADAMContext(@transient val sc: SparkContext) extends Serializable with Log
     // convert records
     val fastqRecordConverter = new FastqRecordConverter
     val rdd = recordsR1.zip(recordsR2)
-      .flatMap {
+      .map {
         case (r1, r2) =>
-          val r1Fragment = fastqRecordConverter.convertFragment(r1)
-          val r2Fragment = fastqRecordConverter.convertFragment(r2)
-          stringency match {
-            case ValidationStringency.STRICT | ValidationStringency.LENIENT =>
-              val r1Name = r1Fragment.getReadName.takeWhile(_ != ' ').stripSuffix("/1")
-              val r2Name = r2Fragment.getReadName.takeWhile(_ != ' ').stripSuffix("/2")
-              if (r1Name != r2Name) {
-                val msg = s"Fastq 1 ($pathNameR1) and fastq 2 ($pathNameR2) are not in sync, order of the reads should be the same"
-                if (stringency == ValidationStringency.STRICT)
-                  throw new IllegalArgumentException(msg)
-                else logError(msg)
-              }
-          }
-          List(r1Fragment, r2Fragment)
+          val pairText = new Text(r1._2.toString + r2._2.toString)
+          fastqRecordConverter.convertFragment((null, pairText))
       }
     FragmentRDD.fromRdd(rdd)
   }

--- a/adam-core/src/main/scala/org/bdgenomics/adam/rdd/ADAMContext.scala
+++ b/adam-core/src/main/scala/org/bdgenomics/adam/rdd/ADAMContext.scala
@@ -2319,46 +2319,43 @@ class ADAMContext(@transient val sc: SparkContext) extends Serializable with Log
    *   Globs/directories are supported.
    * @param pathNameR2 The path name to load unaligned alignment records from.
    *   Globs/directories are supported.
-   * @param stringency The validation stringency to use when validating paired FASTQ format.
-   *   Defaults to ValidationStringency.STRICT.
    * @return Returns a FragmentRDD containing the paired reads grouped by
    *   sequencing fragment.
    */
   def loadPairedFastqAsFragments(pathNameR1: String,
                                  pathNameR2: String,
-                                 stringency: ValidationStringency = ValidationStringency.STRICT): FragmentRDD = LoadPairedFastqFragments.time {
+                                 recordGroup: RecordGroup): FragmentRDD = LoadPairedFastqFragments.time {
 
-    val job = HadoopUtil.newJob(sc)
-    val conf = ContextUtil.getConfiguration(job)
-    conf.setStrings("io.compression.codecs",
-      classOf[BGZFCodec].getCanonicalName,
-      classOf[BGZFEnhancedGzipCodec].getCanonicalName)
-    val recordsR1 = sc.newAPIHadoopFile(
-      pathNameR1,
-      classOf[InterleavedFastqInputFormat],
-      classOf[Void],
-      classOf[Text],
-      conf
-    )
-    if (Metrics.isRecording) recordsR1.instrument() else recordsR1
-    val recordsR2 = sc.newAPIHadoopFile(
-      pathNameR2,
-      classOf[InterleavedFastqInputFormat],
-      classOf[Void],
-      classOf[Text],
-      conf
-    )
-    if (Metrics.isRecording) recordsR2.instrument() else recordsR2
+    def readFastq(path: String) = {
+      val job = HadoopUtil.newJob(sc)
+      val conf = ContextUtil.getConfiguration(job)
+      conf.setStrings("io.compression.codecs",
+        classOf[BGZFCodec].getCanonicalName,
+        classOf[BGZFEnhancedGzipCodec].getCanonicalName)
+      val file = sc.newAPIHadoopFile(
+        path,
+        classOf[SingleFastqInputFormat],
+        classOf[Void],
+        classOf[Text],
+        conf
+      )
+      if (Metrics.isRecording) file.instrument()
+      else file
+    }
+    val recordsR1 = readFastq(pathNameR1)
+    val recordsR2 = readFastq(pathNameR2)
 
     // convert records
     val fastqRecordConverter = new FastqRecordConverter
+    // Zip will fail if R1 and R2 has an different number of reads
+    // Checking this explicitly like in loadPairedFastq is not required and not blocking anymore
     val rdd = recordsR1.zip(recordsR2)
       .map {
         case (r1, r2) =>
           val pairText = new Text(r1._2.toString + r2._2.toString)
           fastqRecordConverter.convertFragment((null, pairText))
       }
-    FragmentRDD.fromRdd(rdd)
+    FragmentRDD(rdd, SequenceDictionary.empty, RecordGroupDictionary(Seq(recordGroup)), Seq.empty)
   }
 
   /**

--- a/adam-core/src/main/scala/org/bdgenomics/adam/rdd/ADAMContext.scala
+++ b/adam-core/src/main/scala/org/bdgenomics/adam/rdd/ADAMContext.scala
@@ -2319,6 +2319,8 @@ class ADAMContext(@transient val sc: SparkContext) extends Serializable with Log
    *   Globs/directories are supported.
    * @param pathNameR2 The path name to load unaligned alignment records from.
    *   Globs/directories are supported.
+   * @param stringency The validation stringency to use when validating paired FASTQ format.
+   *   Defaults to ValidationStringency.STRICT.
    * @return Returns a FragmentRDD containing the paired reads grouped by
    *   sequencing fragment.
    */

--- a/adam-core/src/test/scala/org/bdgenomics/adam/rdd/ADAMContextSuite.scala
+++ b/adam-core/src/test/scala/org/bdgenomics/adam/rdd/ADAMContextSuite.scala
@@ -271,6 +271,13 @@ class ADAMContextSuite extends ADAMFunSuite {
     })
   }
 
+  sparkTest("load paired fastq as fragments") {
+    val pathR1 = testFile("proper_pairs_1.fq")
+    val pathR2 = testFile("proper_pairs_2.fq")
+    val fragments = sc.loadPairedFastqAsFragments(pathR1, pathR2)
+    assert(fragments.rdd.count === 6)
+  }
+
   (1 to 4) foreach { testNumber =>
     val inputName = "interleaved_fastq_sample%d.ifq".format(testNumber)
     val path = testFile(inputName)

--- a/adam-core/src/test/scala/org/bdgenomics/adam/rdd/ADAMContextSuite.scala
+++ b/adam-core/src/test/scala/org/bdgenomics/adam/rdd/ADAMContextSuite.scala
@@ -275,7 +275,7 @@ class ADAMContextSuite extends ADAMFunSuite {
     val pathR1 = testFile("proper_pairs_1.fq")
     val pathR2 = testFile("proper_pairs_2.fq")
     val fragments = sc.loadPairedFastqAsFragments(pathR1, pathR2)
-    assert(fragments.rdd.count === 6)
+    assert(fragments.rdd.count === 3)
   }
 
   (1 to 4) foreach { testNumber =>


### PR DESCRIPTION
During some talk o gitter I missing this method and looks simple enough to add it myself ;).

Some open issue here are how to do validation if the 2 files are indeed in sync. I can use `stringency: ValidationStringency` like in `loadPairedFastq`. Will follow up this on gitter also.