### PR TITLE
Remove python and R profiles from release script

### DIFF
--- a/scripts/release/release.sh
+++ b/scripts/release/release.sh
@@ -16,6 +16,7 @@ devel=$2
 branch=$(git status -bs | awk '{ print $2 }' | awk -F'.' '{ print $1 }' | head -n 1)
 
 # manually edit and commit changelog changes
+# see https://github.com/bigdatagenomics/adam/issues/936
 #./scripts/changelog.sh $1 | tee CHANGES.md
 #git commit -a -m "Modifying changelog."
 
@@ -27,7 +28,7 @@ git push origin ${branch}
 # do scala 2.10 release
 git checkout -b maint_2.10-${release} ${branch}
 mvn --batch-mode \
-  -P distribution,python \
+  -P distribution \
   -Dresume=false \
   -Dtag=adam-parent_2.10-${release} \
   -DreleaseVersion=${release} \
@@ -52,7 +53,7 @@ git checkout -b maint_2.11-${release} ${branch}
 ./scripts/move_to_scala_2.11.sh
 git commit -a -m "Modifying pom.xml files for Spark 1, Scala 2.11 release."
 mvn --batch-mode \
-  -P distribution,python \
+  -P distribution \
   -Dresume=false \
   -Dtag=adam-parent_2.11-${release} \
   -DreleaseVersion=${release} \
@@ -72,7 +73,7 @@ git checkout -b maint_spark2_2.10-${release} ${branch}
 ./scripts/move_to_spark_2.sh
 git commit -a -m "Modifying pom.xml files for Spark 2, Scala 2.10 release."
 mvn --batch-mode \
-  -P distribution,python,r \
+  -P distribution \
   -Dresume=false \
   -Dtag=adam-parent-spark2_2.10-${release} \
   -DreleaseVersion=${release} \
@@ -93,7 +94,7 @@ git checkout -b maint_spark2_2.11-${release} ${branch}
 ./scripts/move_to_scala_2.11.sh
 git commit -a -m "Modifying pom.xml files for Spark 2, Scala 2.11 release."
 mvn --batch-mode \
-  -P distribution,python,r \
+  -P distribution \
   -Dresume=false \
   -Dtag=adam-parent-spark2_2.11-${release} \
   -DreleaseVersion=${release} \

--- a/scripts/release/release.sh
+++ b/scripts/release/release.sh
@@ -27,7 +27,7 @@ git push origin ${branch}
 # do scala 2.10 release
 git checkout -b maint_2.10-${release} ${branch}
 mvn --batch-mode \
-  -P distribution,python,r \
+  -P distribution,python \
   -Dresume=false \
   -Dtag=adam-parent_2.10-${release} \
   -DreleaseVersion=${release} \
@@ -52,7 +52,7 @@ git checkout -b maint_2.11-${release} ${branch}
 ./scripts/move_to_scala_2.11.sh
 git commit -a -m "Modifying pom.xml files for Spark 1, Scala 2.11 release."
 mvn --batch-mode \
-  -P distribution,python,r \
+  -P distribution,python \
   -Dresume=false \
   -Dtag=adam-parent_2.11-${release} \
   -DreleaseVersion=${release} \

--- a/scripts/release/release.sh
+++ b/scripts/release/release.sh
@@ -27,7 +27,7 @@ git push origin ${branch}
 # do scala 2.10 release
 git checkout -b maint_2.10-${release} ${branch}
 mvn --batch-mode \
-  -P distribution,python \
+  -P distribution,python,r \
   -Dresume=false \
   -Dtag=adam-parent_2.10-${release} \
   -DreleaseVersion=${release} \
@@ -52,7 +52,7 @@ git checkout -b maint_2.11-${release} ${branch}
 ./scripts/move_to_scala_2.11.sh
 git commit -a -m "Modifying pom.xml files for Spark 1, Scala 2.11 release."
 mvn --batch-mode \
-  -P distribution,python \
+  -P distribution,python,r \
   -Dresume=false \
   -Dtag=adam-parent_2.11-${release} \
   -DreleaseVersion=${release} \
@@ -72,7 +72,7 @@ git checkout -b maint_spark2_2.10-${release} ${branch}
 ./scripts/move_to_spark_2.sh
 git commit -a -m "Modifying pom.xml files for Spark 2, Scala 2.10 release."
 mvn --batch-mode \
-  -P distribution,python \
+  -P distribution,python,r \
   -Dresume=false \
   -Dtag=adam-parent-spark2_2.10-${release} \
   -DreleaseVersion=${release} \
@@ -93,7 +93,7 @@ git checkout -b maint_spark2_2.11-${release} ${branch}
 ./scripts/move_to_scala_2.11.sh
 git commit -a -m "Modifying pom.xml files for Spark 2, Scala 2.11 release."
 mvn --batch-mode \
-  -P distribution,python \
+  -P distribution,python,r \
   -Dresume=false \
   -Dtag=adam-parent-spark2_2.11-${release} \
   -DreleaseVersion=${release} \


### PR DESCRIPTION
Opened a new branch for updates to the release script.

I'm not confident this will work, the build from source instructions look for the assembly jar relative to an `${ADAM_HOME}`, which will keep moving during a release build (once at the normal depth and then nested for the build from the checked out release tag)
```
# put adam jar on the pyspark path
ASSEMBLY_DIR="${ADAM_HOME}/adam-assembly/target"
ASSEMBLY_JAR="$(ls -1 "$ASSEMBLY_DIR" | grep "^adam[0-9A-Za-z\.\_-]*\.jar$" | grep -v -e javadoc -e sources || true)"
export PYSPARK_SUBMIT_ARGS="--jars ${ASSEMBLY_DIR}/${ASSEMBLY_JAR} --driver-class-path ${ASSEMBLY_DIR}/${ASSEMBLY_JAR} pyspark-shell"
```
```
# put adam jar on the SparkR path
ASSEMBLY_DIR="${ADAM_HOME}/adam-assembly/target"
ASSEMBLY_JAR="$(ls -1 "$ASSEMBLY_DIR" | grep "^adam[0-9A-Za-z\_\.-]*\.jar$" | grep -v javadoc | grep -v sources || true)"
export SPARKR_SUBMIT_ARGS="--jars ${ASSEMBLY_DIR}/${ASSEMBLY_JAR} --driver-class-path ${ASSEMBLY_DIR}/${ASSEMBLY_JAR} sparkr-shell"
```