### PR TITLE
[ADAM-1847] Update ADAM scripts to support self-contained pip install.

### DIFF
--- a/adam-python/MANIFEST.in
+++ b/adam-python/MANIFEST.in
@@ -1,4 +1,3 @@
-#!/usr/bin/env bash
 #
 # Licensed to Big Data Genomics (BDG) under one
 # or more contributor license agreements.  See the NOTICE file
@@ -17,16 +16,6 @@
 # limitations under the License.
 #
 
-set -e
-
-# Find original directory of this script, resolving symlinks
-# http://stackoverflow.com/questions/59895/can-a-bash-script-tell-what-directory-its-stored-in/246128#246128
-SOURCE="${BASH_SOURCE[0]}"
-while [ -h "$SOURCE" ]; do # resolve $SOURCE until the file is no longer a symlink
-    SCRIPT_DIR="$( cd -P "$( dirname "$SOURCE" )" && pwd )"
-    SOURCE="$(readlink "$SOURCE")"
-    [[ $SOURCE != /* ]] && SOURCE="$SCRIPT_DIR/$SOURCE" # if $SOURCE was a relative symlink, we need to resolve it relative to the path where the symlink file was located
-done
-
-echo $( cd -P "$( dirname "$SOURCE" )" && pwd )
-
+global-exclude *.py[cod] __pycache__ .DS_Store
+recursive-include deps/jars *.jar
+include version.py

--- a/adam-python/README.md
+++ b/adam-python/README.md
@@ -1,0 +1,20 @@
+# ADAM
+
+ADAM is a library and command line tool that enables the use of [Apache
+Spark](https://spark.apache.org) to parallelize genomic data analysis across
+cluster/cloud computing environments. ADAM uses a set of schemas to describe
+genomic sequences, reads, variants/genotypes, and features, and can be used
+with data in legacy genomic file formats such as SAM/BAM/CRAM, BED/GFF3/GTF,
+and VCF, as well as data stored in the columnar
+[Apache Parquet](https://parquet.apache.org) format. On a single node, ADAM
+provides competitive performance to optimized multi-threaded tools, while
+enabling scale out to clusters with more than a thousand cores. ADAM's APIs
+can be used from Scala, Java, Python, R, and SQL.
+
+## Documentation
+
+ADAM's documentation is hosted at [readthedocs](http://adam.readthedocs.io).
+
+## Python Requirements
+
+ADAM depends on having PySpark installed.

--- a/adam-python/bdgenomics/adam/find_adam_home.py
+++ b/adam-python/bdgenomics/adam/find_adam_home.py
@@ -1,0 +1,74 @@
+#!/usr/bin/env python
+
+#
+# Licensed to Big Data Genomics (BDG) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The BDG licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+# This script is copied from Apache Spark, with minor modifications.
+#
+# This script attempt to determine the correct setting for ADAM_HOME given
+# that ADAM may have been installed on the system with pip.
+
+from __future__ import print_function
+import os
+import sys
+
+
+def _find_adam_home():
+    """Find the ADAM_HOME."""
+    # If the enviroment has ADAM_HOME set trust it.
+    if "ADAM_HOME" in os.environ:
+        return os.environ["ADAM_HOME"]
+
+    def is_adam_home(path):
+        """Takes a path and returns true if the provided path could be a reasonable ADAM_HOME"""
+        return (os.path.isfile(os.path.join(path, "bin/adam-submit")) and
+                (os.path.isdir(os.path.join(path, "jars")) or
+                 os.path.isdir(os.path.join(path, "adam-assembly/target"))))
+
+    paths = [os.path.join(os.path.dirname(os.path.realpath(__file__)), "..")]
+
+    # Add the path of the ADAM module if it exists
+    if sys.version < "3":
+        import imp
+        try:
+            module_home = imp.find_module("bdgenomics")[1]
+            paths.append(os.path.join(module_home, "adam"))
+        except ImportError:
+            # Not pip installed no worries
+            pass
+    else:
+        from importlib.util import find_spec
+        try:
+            module_home = os.path.dirname(find_spec("bdgenomics").origin)
+            paths.append(os.path.join(module_home, "adam"))
+        except ImportError:
+            # Not pip installed no worries
+            pass
+
+    # Normalize the paths
+    print(repr(paths), file=sys.stderr)
+    paths = [os.path.abspath(p) for p in paths]
+
+    try:
+        return next(path for path in paths if is_adam_home(path))
+    except StopIteration:
+        print("Could not find valid ADAM_HOME while searching {0}".format(paths), file=sys.stderr)
+        exit(1)
+
+if __name__ == "__main__":
+    print(_find_adam_home())

--- a/adam-python/setup.py
+++ b/adam-python/setup.py
@@ -31,7 +31,7 @@ if sys.version_info < (2, 7):
 
 # Provide guidance about how to use setup.py
 incorrect_invocation_message = """
-If you are installing PyADAM from ADAM's source, you must first build ADAM and
+If you are installing bdgenomics.adam from ADAM's source, you must first build ADAM and
 run make develop.
 
     To build ADAM with maven you can run:
@@ -54,7 +54,7 @@ SCRIPTS_TARGET = os.path.join(TEMP_PATH, "bin")
 if len(JARS_PATH) == 1:
     JARS_PATH = JARS_PATH[0]
 elif len(JARS_PATH) > 1:
-    print("Assembly jars exist for multiple scalas ({0}), please cleanup assembly/target".format(
+    print("Assembly jars exist for multiple Scala versions ({0}), please cleanup assembly/target".format(
         JARS_PATH), file=sys.stderr)
     sys.exit(-1)
 elif len(JARS_PATH) == 0 and not os.path.exists(TEMP_PATH):
@@ -85,8 +85,8 @@ try:
     script_names = os.listdir(SCRIPTS_TARGET)
     scripts = list(map(lambda script: os.path.join(SCRIPTS_TARGET, script), script_names))
 
-    # We add find_adam_home.py to the bin directory we install so that pip installed PySpark
-    # will search for ADAM_HOME with Python.
+    # We add find_adam_home.py to the bin directory we install so that pip installed
+    # bdgenomics.adam will search for ADAM_HOME with Python.
     scripts.append("bdgenomics/adam/find_adam_home.py")
 
     long_description = "!!!!! missing pandoc do not upload to PyPI !!!!"
@@ -94,7 +94,7 @@ try:
         import pypandoc
         long_description = pypandoc.convert('README.md', 'rst')
     except ImportError:
-        print("Could not import pypandoc - required to package PySpark", file=sys.stderr)
+        print("Could not import pypandoc - required to package bdgenomics.adam", file=sys.stderr)
     except OSError:
         print("Could not convert - pandoc is not installed", file=sys.stderr)
 

--- a/adam-python/setup.py
+++ b/adam-python/setup.py
@@ -45,7 +45,9 @@ run make develop.
 ADAM_HOME = os.path.abspath("../")
 TEMP_PATH = "deps"
 
-JARS_PATH = glob.glob(os.path.join(ADAM_HOME, "adam-assembly/target/adam-assembly*.jar"))
+ALL_JARS_PATH = glob.glob(os.path.join(ADAM_HOME, "adam-assembly/target/adam-assembly*.jar"))
+JARS_PATH = filter(lambda x: (("sources" not in x) and ("javadoc" not in x)),
+                   ALL_JARS_PATH)
 JARS_TARGET = os.path.join(TEMP_PATH, "jars")
 
 SCRIPTS_PATH = os.path.join(ADAM_HOME, "bin")

--- a/adam-python/setup.py
+++ b/adam-python/setup.py
@@ -16,15 +16,119 @@
 # limitations under the License.
 #
 
+from __future__ import print_function
+import glob
+import os
+import sys
 from setuptools import find_packages, setup
+
 from version import version as adam_version
 
-setup(
-    name='bdgenomics.adam',
-    version=adam_version,
-    description='A fast, scalable genome analysis system',
-    author='Frank Austin Nothaft',
-    author_email='fnothaft@berkeley.edu',
-    url="https://github.com/bdgenomics/adam",
-    install_requires=[],
-    packages=find_packages(exclude=['*.test.*']))
+if sys.version_info < (2, 7):
+    print("Python versions prior to 2.7 are not supported for pip installed ADAM.",
+          file=sys.stderr)
+    exit(-1)
+
+# Provide guidance about how to use setup.py
+incorrect_invocation_message = """
+If you are installing PyADAM from ADAM's source, you must first build ADAM and
+run make develop.
+
+    To build ADAM with maven you can run:
+      ./build/mvn -DskipTests clean package
+    Building the source dist is done in the Python directory:
+      cd adam-python
+      make sdist
+      pip install dist/*.tar.gz"""
+
+# Figure out where the jars are we need to package
+ADAM_HOME = os.path.abspath("../")
+TEMP_PATH = "deps"
+
+JARS_PATH = glob.glob(os.path.join(ADAM_HOME, "adam-assembly/target/adam-assembly*.jar"))
+JARS_TARGET = os.path.join(TEMP_PATH, "jars")
+
+SCRIPTS_PATH = os.path.join(ADAM_HOME, "bin")
+SCRIPTS_TARGET = os.path.join(TEMP_PATH, "bin")
+
+if len(JARS_PATH) == 1:
+    JARS_PATH = JARS_PATH[0]
+elif len(JARS_PATH) > 1:
+    print("Assembly jars exist for multiple scalas ({0}), please cleanup assembly/target".format(
+        JARS_PATH), file=sys.stderr)
+    sys.exit(-1)
+elif len(JARS_PATH) == 0 and not os.path.exists(TEMP_PATH):
+    print(incorrect_invocation_message, file=sys.stderr)
+    sys.exit(-1)
+
+in_adam = os.path.isfile("../adam-core/src/main/scala/org/bdgenomics/adam/rdd/ADAMContext.scala")
+
+if in_adam:
+    try:
+        os.mkdir(TEMP_PATH)
+    except:
+        print("Temp path for symlink to parent already exists {0}".format(TEMP_PATH),
+              file=sys.stderr)
+        exit(-1)
+
+try:
+    if in_adam:
+        os.mkdir(JARS_TARGET)
+        os.symlink(JARS_PATH, os.path.join(JARS_TARGET, 'adam.jar'))
+        os.symlink(SCRIPTS_PATH, SCRIPTS_TARGET)
+
+    packages = find_packages(exclude=['*.test.*'])
+    packages.extend(['bdgenomics.adam.jars',
+                     'bdgenomics.adam.bin'])
+
+    # Scripts directive requires a list of each script path and does not take wild cards.
+    script_names = os.listdir(SCRIPTS_TARGET)
+    scripts = list(map(lambda script: os.path.join(SCRIPTS_TARGET, script), script_names))
+
+    # We add find_adam_home.py to the bin directory we install so that pip installed PySpark
+    # will search for ADAM_HOME with Python.
+    scripts.append("bdgenomics/adam/find_adam_home.py")
+
+    long_description = "!!!!! missing pandoc do not upload to PyPI !!!!"
+    try:
+        import pypandoc
+        long_description = pypandoc.convert('README.md', 'rst')
+    except ImportError:
+        print("Could not import pypandoc - required to package PySpark", file=sys.stderr)
+    except OSError:
+        print("Could not convert - pandoc is not installed", file=sys.stderr)
+
+    setup(
+        name='bdgenomics.adam',
+        version=adam_version,
+        description='A fast, scalable genome analysis system',
+        long_description=long_description,
+        author='Big Data Genomics',
+        author_email='adam-developers@googlegroups.com',
+        url="https://github.com/bdgenomics/adam",
+        scripts=scripts,
+        packages=packages,
+        include_package_data=True,
+        install_requires=['pyspark>=1.6.0'],
+        package_dir={'bdgenomics.adam.jars': JARS_TARGET,
+                     'bdgenomics.adam.bin': SCRIPTS_TARGET},
+        package_data={'bdgenomics.adam.jars': ['adam.jar'],
+                      'bdgenomics.adam.bin': ['*']},
+        classifiers=[
+            'License :: OSI Approved :: Apache Software License',
+            'Programming Language :: Python :: 2.7',
+            'Programming Language :: Python :: 3',
+            'Programming Language :: Python :: 3.4',
+            'Programming Language :: Python :: 3.5',
+            'Programming Language :: Python :: 3.6',
+            'Programming Language :: Python :: Implementation :: CPython',
+            'Programming Language :: Python :: Implementation :: PyPy',
+            'Topic :: Scientific/Engineering :: Bio-Informatics'])
+
+finally:
+    if in_adam:
+        os.remove(os.path.join(JARS_TARGET, 'adam.jar'))
+        os.rmdir(JARS_TARGET)
+        os.remove(SCRIPTS_TARGET)
+        os.rmdir(TEMP_PATH)
+

--- a/adam-python/version.py
+++ b/adam-python/version.py
@@ -16,7 +16,7 @@
 # limitations under the License.
 #
 
-version = '0.23.0-SNAPSHOT'
+version = '0.23.0rc18'
 
 if __name__ == '__main__':
     print version

--- a/adam-python/version.py
+++ b/adam-python/version.py
@@ -16,7 +16,7 @@
 # limitations under the License.
 #
 
-version = '0.23.0rc18'
+version = '0.23.0-SNAPSHOT'
 
 if __name__ == '__main__':
     print version

--- a/bin/find-adam-assembly.sh
+++ b/bin/find-adam-assembly.sh
@@ -20,15 +20,16 @@
 set -e
 
 SOURCE_DIR=$(dirname ${BASH_SOURCE[0]})
-SCRIPT_DIR=$(${SOURCE_DIR}/find-script-dir.sh)
-INSTALL_DIR=$(dirname $SCRIPT_DIR)
+. ${SOURCE_DIR}/find-adam-home
 
 # Find ADAM cli assembly jar
 ADAM_CLI_JAR=
-if [ -d "$INSTALL_DIR/repo" ]; then
-  ASSEMBLY_DIR="$INSTALL_DIR/repo"
+if [ -d "$ADAM_HOME/repo" ]; then
+  ASSEMBLY_DIR="$ADAM_HOME/repo"
+elif [ -d "$ADAM_HOME/jars" ]; then
+  ASSEMBLY_DIR="$ADAM_HOME/jars"
 else
-  ASSEMBLY_DIR="$INSTALL_DIR/adam-assembly/target"
+  ASSEMBLY_DIR="$ADAM_HOME/adam-assembly/target"
 fi
 
 ASSEMBLY_JARS=$(ls -1 "$ASSEMBLY_DIR" | grep "^adam[0-9A-Za-z\.\_\-]*\.jar$" | grep -v javadoc | grep -v sources || true)

--- a/bin/find-adam-egg.sh
+++ b/bin/find-adam-egg.sh
@@ -20,14 +20,13 @@
 set -e
 
 SOURCE_DIR=$(dirname ${BASH_SOURCE[0]})
-SCRIPT_DIR=$(${SOURCE_DIR}/find-script-dir.sh)
-INSTALL_DIR=$(dirname $SCRIPT_DIR)
+. ${SOURCE_DIR}/find-adam-home
 
 # Find ADAM python egg
-if [ -d "$INSTALL_DIR/repo" ]; then
-  DIST_DIR="$INSTALL_DIR/repo"
+if [ -d "$ADAM_HOME/repo" ]; then
+  DIST_DIR="$ADAM_HOME/repo"
 else
-  DIST_DIR="$INSTALL_DIR/adam-python/dist"
+  DIST_DIR="$ADAM_HOME/adam-python/dist"
 fi
 
 DIST_EGG=$(ls -1 "$DIST_DIR" | grep "^bdgenomics\.adam[0-9A-Za-z\.\_\-]*.egg$" || true)

--- a/bin/find-adam-home
+++ b/bin/find-adam-home
@@ -28,7 +28,7 @@ if [ ! -z "${ADAM_HOME}" ]; then
    exit 0
 elif [ ! -f "$FIND_ADAM_HOME_PYTHON_SCRIPT" ]; then
   # If we are not in the same directory as find_adam_home.py we are not pip installed so we don't
-  # need to search the different Python directories for a Adam installation.
+  # need to search the different Python directories for a ADAM installation.
   # Note only that, if the user has pip installed adam but is directly calling pyadam or
   # adam-submit in another directory we want to use that version of adam rather than the
   # pip installed version of adam.

--- a/bin/find-adam-home
+++ b/bin/find-adam-home
@@ -1,0 +1,43 @@
+#!/usr/bin/env bash
+#
+# Licensed to Big Data Genomics (BDG) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The BDG licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+set -e
+
+# Attempts to find a proper value for ADAM_HOME. Should be included using "source" directive.
+
+FIND_ADAM_HOME_PYTHON_SCRIPT="$(cd "$(dirname "$0")"; pwd)/find_adam_home.py"
+
+# Short cirtuit if the user already has this set.
+if [ ! -z "${ADAM_HOME}" ]; then
+   exit 0
+elif [ ! -f "$FIND_ADAM_HOME_PYTHON_SCRIPT" ]; then
+  # If we are not in the same directory as find_adam_home.py we are not pip installed so we don't
+  # need to search the different Python directories for a Adam installation.
+  # Note only that, if the user has pip installed adam but is directly calling pyadam or
+  # adam-submit in another directory we want to use that version of adam rather than the
+  # pip installed version of adam.
+  export ADAM_HOME="$(cd "$(dirname "$0")"/..; pwd)"
+else
+  # We are pip installed, use the Python script to resolve a reasonable ADAM_HOME
+  # Default to standard python interpreter unless told otherwise
+  if [[ -z "$PYSPARK_DRIVER_PYTHON" ]]; then
+     PYSPARK_DRIVER_PYTHON="${PYSPARK_PYTHON:-"python"}"
+  fi
+  export ADAM_HOME=$($PYSPARK_DRIVER_PYTHON "$FIND_ADAM_HOME_PYTHON_SCRIPT")
+fi

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -71,6 +71,7 @@ of tools built using ADAM's core APIs:
    :maxdepth: 2
 
    installation/source
+   installation/pip
    installation/example
 
 .. toctree::

--- a/docs/installation/pip.rst
+++ b/docs/installation/pip.rst
@@ -1,0 +1,13 @@
+Installing ADAM using Pip
+=========================
+
+ADAM is available through the `Python Package Index`_ and thus can be installed
+using pip. To install ADAM using pip, run:
+
+.. code:: bash
+
+    pip install bdgenomics.adam
+
+Pip will install the bdgenomics.adam Python binding, as well as the ADAM CLI.
+
+.. _Python Package Index: https://pypi.python.org/pypi

--- a/docs/installation/source.rst
+++ b/docs/installation/source.rst
@@ -73,6 +73,7 @@ Once this alias is in place, you can run ADAM by simply typing
 Building for Python
 -------------------
 
+ADAM can be installed using the Pip package manager, or from source.
 To build and test `ADAM's Python bindings <#python>`__, enable the
 ``python`` profile:
 

--- a/scripts/release/release.sh
+++ b/scripts/release/release.sh
@@ -109,6 +109,31 @@ if [ $? != 0 ]; then
   exit 1
 fi
 
+# set up python environment for releasing to pypi
+pushd adam-python
+rm -rf release-venv
+virtualenv release-venv
+. release-venv/bin/activate
+pip install pyspark
+
+# clean any possible extant sdists
+rm -rf dist
+
+# build sdist and push to pypi
+make sdist
+twine upload dist/*.tar.gz
+
+# deactivate the python virtualenv
+deactivate
+rm -rf release-venv
+
+popd
+
+if [ $? != 0 ]; then
+  echo "Releasing bdgenomics.adam to PyPi failed."
+  exit 1
+fi
+
 # publish docs
 ./scripts/publish-scaladoc.sh ${release}
 


### PR DESCRIPTION
Resolves #1847. Cribs heavily from PySpark's script flow for supporting a full, self-contained pip install-able Spark by finding the JARs and bin scripts and packaging them up as packages which are deployed to pip. We then needed to modify the bin scripts to find the pip installed JARs.

To test this out, from inside of a virtualenv, do:

```
pip install pyspark
pip install --index-url https://test.pypi.org/simple/ bdgenomics.adam==0.23.0rc18 
```

You should be able to run `adam-shell`, `adam-submit`, etc. You can see the release docs [here](https://test.pypi.org/project/bdgenomics.adam/0.23.0rc18/).

As you can tell, this took a bit of trial and error...