### PR TITLE
[ADAM-1875] Add ability to timeout a piped command.

### DIFF
--- a/adam-core/src/test/resources/timeout.py
+++ b/adam-core/src/test/resources/timeout.py
@@ -1,0 +1,21 @@
+#!/usr/bin/env python
+
+from __future__ import print_function
+import sys
+import time
+
+# read lines from stdin
+lines = sys.stdin.readlines()
+
+def print_lines(skip_header=False):
+    for line in lines:
+        if not (skip_header and line.startswith('@')):
+            print(line.strip().rstrip())
+
+print_lines()
+sys.stdout.flush()
+
+time.sleep(10)
+
+print_lines(skip_header=True)
+sys.stdout.flush()


### PR DESCRIPTION
Resolves #1875. Adds an optional timeout parameter to the `GenomicRDD.pipe` function. If this is provided, a command will be killed (but without failing the Spark task) if it runs for longer than the timeout parameter.