### PR TITLE
Update for  Spark version 2.3.0

### DIFF
--- a/adam-core/src/main/scala/org/bdgenomics/adam/serialization/ADAMKryoRegistrator.scala
+++ b/adam-core/src/main/scala/org/bdgenomics/adam/serialization/ADAMKryoRegistrator.scala
@@ -283,9 +283,11 @@ class ADAMKryoRegistrator extends KryoRegistrator with Logging {
     try {
       kryo.register(Class.forName("org.apache.spark.internal.io.FileCommitProtocol$TaskCommitMessage"))
       kryo.register(Class.forName("org.apache.spark.sql.execution.datasources.FileFormatWriter$WriteTaskResult"))
+      kryo.register(Class.forName("org.apache.spark.sql.execution.datasources.BasicWriteTaskStats"))
+      kryo.register(Class.forName("org.apache.spark.sql.execution.datasources.ExecutedWriteSummary"))
     } catch {
       case cnfe: java.lang.ClassNotFoundException => {
-        log.info("Did not find Spark internal class. This is expected for Spark 1.")
+        log.info("Did not find Spark internal class. This is expected for earlier Spark versions.")
       }
     }
     kryo.register(classOf[org.apache.spark.sql.catalyst.expressions.UnsafeRow])


### PR DESCRIPTION
Adds Kryo registration for two classes which is are required for Spark 2.3.0.rc2
With these changes ADAM compiles and passes all tests for Spark-2.3.0.rc2

~~These changes fail to compile with Spark-2.2.1, so must be accompanied by Spark version bump.~~

 If there is a better way to note these changes than a PR against master, let me know.