### PR TITLE
[ADAM-1840] Support adding VCF header lines from Python.

### DIFF
--- a/adam-core/src/main/scala/org/bdgenomics/adam/rdd/variant/GenotypeRDD.scala
+++ b/adam-core/src/main/scala/org/bdgenomics/adam/rdd/variant/GenotypeRDD.scala
@@ -35,7 +35,8 @@ import org.bdgenomics.adam.rdd.ADAMContext._
 import org.bdgenomics.adam.rdd.{
   DatasetBoundGenomicDataset,
   MultisampleAvroGenomicRDD,
-  VCFHeaderUtils
+  VCFHeaderUtils,
+  VCFSupportingGenomicRDD
 }
 import org.bdgenomics.adam.rich.RichVariant
 import org.bdgenomics.adam.serialization.AvroSerializer
@@ -215,39 +216,9 @@ case class RDDBoundGenotypeRDD private[rdd] (
   }
 }
 
-sealed abstract class GenotypeRDD extends MultisampleAvroGenomicRDD[Genotype, GenotypeProduct, GenotypeRDD] {
+sealed abstract class GenotypeRDD extends MultisampleAvroGenomicRDD[Genotype, GenotypeProduct, GenotypeRDD] with VCFSupportingGenomicRDD[Genotype, GenotypeRDD] {
 
   @transient val uTag: TypeTag[GenotypeProduct] = typeTag[GenotypeProduct]
-
-  val headerLines: Seq[VCFHeaderLine]
-
-  /**
-   * Replaces the header lines attached to this RDD.
-   *
-   * @param newHeaderLines The new header lines to attach to this RDD.
-   * @return A new RDD with the header lines replaced.
-   */
-  def replaceHeaderLines(newHeaderLines: Seq[VCFHeaderLine]): GenotypeRDD
-
-  /**
-   * Appends new header lines to the existing lines.
-   *
-   * @param headerLinesToAdd Zero or more header lines to add.
-   * @return A new RDD with the new header lines added.
-   */
-  def addHeaderLines(headerLinesToAdd: Seq[VCFHeaderLine]): GenotypeRDD = {
-    replaceHeaderLines(headerLines ++ headerLinesToAdd)
-  }
-
-  /**
-   * Appends a new header line to the existing lines.
-   *
-   * @param headerLineToAdd A header line to add.
-   * @return A new RDD with the new header line added.
-   */
-  def addHeaderLine(headerLineToAdd: VCFHeaderLine): GenotypeRDD = {
-    addHeaderLines(Seq(headerLineToAdd))
-  }
 
   /**
    * Save the VCF headers to disk.

--- a/adam-core/src/main/scala/org/bdgenomics/adam/rdd/variant/VariantContextRDD.scala
+++ b/adam-core/src/main/scala/org/bdgenomics/adam/rdd/variant/VariantContextRDD.scala
@@ -44,7 +44,8 @@ import org.bdgenomics.adam.models.{
 import org.bdgenomics.adam.rdd.{
   ADAMSaveAnyArgs,
   MultisampleGenomicRDD,
-  VCFHeaderUtils
+  VCFHeaderUtils,
+  VCFSupportingGenomicRDD
 }
 import org.bdgenomics.adam.util.{ FileMerger, FileExtensions }
 import org.bdgenomics.formats.avro.Sample
@@ -125,7 +126,8 @@ case class VariantContextRDD(rdd: RDD[VariantContext],
                              @transient samples: Seq[Sample],
                              @transient headerLines: Seq[VCFHeaderLine],
                              optPartitionMap: Option[Array[Option[(ReferenceRegion, ReferenceRegion)]]]) extends MultisampleGenomicRDD[VariantContext, VariantContextRDD]
-    with Logging {
+    with Logging
+    with VCFSupportingGenomicRDD[VariantContext, VariantContextRDD] {
 
   def replaceSequences(
     newSequences: SequenceDictionary): VariantContextRDD = {
@@ -140,26 +142,6 @@ case class VariantContextRDD(rdd: RDD[VariantContext],
    */
   def replaceHeaderLines(newHeaderLines: Seq[VCFHeaderLine]): VariantContextRDD = {
     copy(headerLines = newHeaderLines)
-  }
-
-  /**
-   * Appends new header lines to the existing lines.
-   *
-   * @param headerLinesToAdd Zero or more header lines to add.
-   * @return A new RDD with the new header lines added.
-   */
-  def addHeaderLines(headerLinesToAdd: Seq[VCFHeaderLine]): VariantContextRDD = {
-    replaceHeaderLines(headerLines ++ headerLinesToAdd)
-  }
-
-  /**
-   * Appends a new header line to the existing lines.
-   *
-   * @param headerLineToAdd A header line to add.
-   * @return A new RDD with the new header line added.
-   */
-  def addHeaderLine(headerLineToAdd: VCFHeaderLine): VariantContextRDD = {
-    addHeaderLines(Seq(headerLineToAdd))
   }
 
   def replaceSamples(newSamples: Iterable[Sample]): VariantContextRDD = {

--- a/adam-core/src/main/scala/org/bdgenomics/adam/rdd/variant/VariantRDD.scala
+++ b/adam-core/src/main/scala/org/bdgenomics/adam/rdd/variant/VariantRDD.scala
@@ -34,7 +34,8 @@ import org.bdgenomics.adam.rdd.ADAMContext._
 import org.bdgenomics.adam.rdd.{
   DatasetBoundGenomicDataset,
   AvroGenomicRDD,
-  VCFHeaderUtils
+  VCFHeaderUtils,
+  VCFSupportingGenomicRDD
 }
 import org.bdgenomics.adam.serialization.AvroSerializer
 import org.bdgenomics.adam.sql.{ Variant => VariantProduct }
@@ -196,39 +197,9 @@ case class RDDBoundVariantRDD private[rdd] (
   }
 }
 
-sealed abstract class VariantRDD extends AvroGenomicRDD[Variant, VariantProduct, VariantRDD] {
+sealed abstract class VariantRDD extends AvroGenomicRDD[Variant, VariantProduct, VariantRDD] with VCFSupportingGenomicRDD[Variant, VariantRDD] {
 
   @transient val uTag: TypeTag[VariantProduct] = typeTag[VariantProduct]
-
-  val headerLines: Seq[VCFHeaderLine]
-
-  /**
-   * Replaces the header lines attached to this RDD.
-   *
-   * @param newHeaderLines The new header lines to attach to this RDD.
-   * @return A new RDD with the header lines replaced.
-   */
-  def replaceHeaderLines(newHeaderLines: Seq[VCFHeaderLine]): VariantRDD
-
-  /**
-   * Appends new header lines to the existing lines.
-   *
-   * @param headerLinesToAdd Zero or more header lines to add.
-   * @return A new RDD with the new header lines added.
-   */
-  def addHeaderLines(headerLinesToAdd: Seq[VCFHeaderLine]): VariantRDD = {
-    replaceHeaderLines(headerLines ++ headerLinesToAdd)
-  }
-
-  /**
-   * Appends a new header line to the existing lines.
-   *
-   * @param headerLineToAdd A header line to add.
-   * @return A new RDD with the new header line added.
-   */
-  def addHeaderLine(headerLineToAdd: VCFHeaderLine): VariantRDD = {
-    addHeaderLines(Seq(headerLineToAdd))
-  }
 
   /**
    * Save the VCF headers to disk.

--- a/adam-python/bdgenomics/adam/rdd.py
+++ b/adam-python/bdgenomics/adam/rdd.py
@@ -284,6 +284,266 @@ class GenomicRDD(object):
                                                   xFormatterInst,
                                                   convFnInst))
 
+class VCFSupportingGenomicRDD(GenomicRDD):
+
+
+    def __init__(self, jvmRdd, sc):
+        """
+        Constructs a Python GenomicRDD from a JVM GenomicRDD.
+        Should not be called from user code; should only be called from
+        implementing classes.
+
+        :param jvmRdd: Py4j handle to the underlying JVM GenomicRDD.
+        :param pyspark.context.SparkContext sc: Active Spark Context.
+        """
+
+        GenomicRDD.__init__(self, jvmRdd, sc)
+
+
+    def _javaType(self, lineType):
+        """
+        Converts a python type into a VCFHeaderLineType enum.
+
+        :param lineType: A Python type.
+        """
+        
+        jvm = self.sc._jvm
+
+        if lineType == str:
+            return jvm.htsjdk.variant.vcf.VCFHeaderLineType.String
+
+        elif lineType == int:
+            return jvm.htsjdk.variant.vcf.VCFHeaderLineType.Integer
+
+        elif lineType == float:
+            return jvm.htsjdk.variant.vcf.VCFHeaderLineType.Float
+
+        elif lineType == chr:
+            return jvm.htsjdk.variant.vcf.VCFHeaderLineType.Character
+
+        elif lineType == bool:
+            return jvm.htsjdk.variant.vcf.VCFHeaderLineType.Flag
+
+        else:
+            raise ValueError('Invalid type {}. Supported types are str, int, float, chr, bool'.format(lineType))
+        
+
+    def addFixedArrayFormatHeaderLine(self,
+                                      name,
+                                      count,
+                                      description,
+                                      lineType):
+        """
+        Adds a VCF header line describing an array format field, with fixed count.
+
+        :param str name: The identifier for the field.
+        :param int count: The number of elements in the array.
+        :param str description: A description of the data stored in this format
+        field.
+        :param lineType: A Python primitive type corresponding to the type of
+        data stored in the array. Supported types include str, int, float, and chr.
+        :return: A new RDD with the new header line added.
+        """
+
+        return self._replaceRdd(self._jvmRdd.addFixedArrayFormatHeaderLine(name,
+                                                                           count,
+                                                                           self._javaType(lineType),
+                                                                           description))
+
+
+    def addScalarFormatHeaderLine(self,
+                                  name,
+                                  description,
+                                  lineType):
+        """
+        Adds a VCF header line describing a scalar format field.
+
+        :param str name: The identifier for the field.
+        :param str description: A description of the data stored in this format
+        field.
+        :param lineType: A Python primitive type corresponding to the type of
+        data stored in the array. Supported types include str, int, float, and chr.
+        :return: A new RDD with the new header line added.
+        """
+
+        return self._replaceRdd(self._jvmRdd.addScalarFormatHeaderLine(name,
+                                                                       description,
+                                                                       self._javaType(lineType)))
+
+
+    def addGenotypeArrayFormatHeaderLine(self,
+                                         name,
+                                         description,
+                                         lineType):
+        """
+        Adds a VCF header line describing an 'G' array format field.
+
+        This adds a format field that is an array whose length is equal to the
+        number of genotypes for the genotype we are annotating.
+
+        :param str name: The identifier for the field.
+        :param str description: A description of the data stored in this format
+        field.
+        :param lineType: A Python primitive type corresponding to the type of
+        data stored in the array. Supported types include str, int, float, and chr.
+        :return: A new RDD with the new header line added.
+        """
+
+        return self._replaceRdd(self._jvmRdd.addGenotypeArrayFormatHeaderLine(name,
+                                                                              description,
+                                                                              self._javaType(lineType)))
+
+
+    def addAlternateAlleleArrayFormatHeaderLine(self,
+                                                name,
+                                                description,
+                                                lineType):
+        """
+        Adds a VCF header line describing an 'A' array format field.
+
+        This adds a format field that is an array whose length is equal to the
+        number of alternate alleles for the genotype we are annotating.
+
+        :param str name: The identifier for the field.
+        :param str description: A description of the data stored in this format
+        field.
+        :param lineType: A Python primitive type corresponding to the type of
+        data stored in the array. Supported types include str, int, float, and chr.
+        :return: A new RDD with the new header line added.
+        """
+
+        return self._replaceRdd(self._jvmRdd.addAlternateAlleleArrayFormatHeaderLine(name,
+                                                                                     description,
+                                                                                     self._javaType(lineType)))
+
+
+    def addAllAlleleArrayFormatHeaderLine(self,
+                                          name,
+                                          description,
+                                          lineType):
+        """
+        Adds a VCF header line describing an 'R' array format field.
+
+        This adds a format field that is an array whose length is equal to the
+        total number of alleles (including the reference allele) for the
+        genotype we are annotating.
+
+        :param str name: The identifier for the field.
+        :param str description: A description of the data stored in this format
+        field.
+        :param lineType: A Python primitive type corresponding to the type of
+        data stored in the array. Supported types include str, int, float, and chr.
+        :return: A new RDD with the new header line added.
+        """
+
+        return self._replaceRdd(self._jvmRdd.addAllAlleleArrayFormatHeaderLine(name,
+                                                                               description,
+                                                                               self._javaType(lineType)))
+        
+
+    def addFixedArrayInfoHeaderLine(self,
+                                      name,
+                                      count,
+                                      description,
+                                      lineType):
+        """
+        Adds a VCF header line describing an array info field, with fixed count.
+
+        :param str name: The identifier for the field.
+        :param int count: The number of elements in the array.
+        :param str description: A description of the data stored in this info
+        field.
+        :param lineType: A Python primitive type corresponding to the type of
+        data stored in the array. Supported types include str, int, float, and chr.
+        :return: A new RDD with the new header line added.
+        """
+
+        return self._replaceRdd(self._jvmRdd.addFixedArrayInfoHeaderLine(name,
+                                                                         count,
+                                                                         self._javaType(lineType),
+                                                                         description))
+
+
+    def addScalarInfoHeaderLine(self,
+                                  name,
+                                  description,
+                                  lineType):
+        """
+        Adds a VCF header line describing a scalar info field.
+
+        :param str name: The identifier for the field.
+        :param str description: A description of the data stored in this info
+        field.
+        :param lineType: A Python primitive type corresponding to the type of
+        data stored in the array. Supported types include str, int, float, and chr.
+        :return: A new RDD with the new header line added.
+        """
+
+        return self._replaceRdd(self._jvmRdd.addScalarInfoHeaderLine(name,
+                                                                     description,
+                                                                     self._javaType(lineType)))
+
+
+    def addAlternateAlleleArrayInfoHeaderLine(self,
+                                                name,
+                                                description,
+                                                lineType):
+        """
+        Adds a VCF header line describing an 'A' array info field.
+
+        This adds a info field that is an array whose length is equal to the
+        number of alternate alleles for the genotype we are annotating.
+
+        :param str name: The identifier for the field.
+        :param str description: A description of the data stored in this info
+        field.
+        :param lineType: A Python primitive type corresponding to the type of
+        data stored in the array. Supported types include str, int, float, and chr.
+        :return: A new RDD with the new header line added.
+        """
+
+        return self._replaceRdd(self._jvmRdd.addAlternateAlleleArrayInfoHeaderLine(name,
+                                                                                   description,
+                                                                                   self._javaType(lineType)))
+
+
+    def addAllAlleleArrayInfoHeaderLine(self,
+                                          name,
+                                          description,
+                                          lineType):
+        """
+        Adds a VCF header line describing an 'R' array info field.
+
+        This adds a info field that is an array whose length is equal to the
+        total number of alleles (including the reference allele) for the
+        genotype we are annotating.
+
+        :param str name: The identifier for the field.
+        :param str description: A description of the data stored in this info
+        field.
+        :param lineType: A Python primitive type corresponding to the type of
+        data stored in the array. Supported types include str, int, float, and chr.
+        :return: A new RDD with the new header line added.
+        """
+
+        return self._replaceRdd(self._jvmRdd.addAllAlleleArrayInfoHeaderLine(name,
+                                                                             description,
+                                                                             self._javaType(lineType)))
+
+
+    def addFilterHeaderLine(self,
+                            name,
+                            description):
+        """
+        Adds a VCF header line describing a variant/genotype filter.
+
+        :param str id: The identifier for the filter.
+        :param str description: A description of the filter.
+        :return: A new RDD with the new header line added.
+        """
+
+        return self._replaceRdd(self._jvmRdd.addFilterHeaderLine(name, description))
+        
     
 class GenomicDataset(GenomicRDD):
 
@@ -871,7 +1131,7 @@ class FragmentRDD(GenomicDataset):
         return "org.bdgenomics.adam.api.java.FragmentsTo%s" % self._destClassSuffix(destClass)
 
 
-class GenotypeRDD(GenomicDataset):
+class GenotypeRDD(GenomicDataset, VCFSupportingGenomicRDD):
 
 
     def _replaceRdd(self, newRdd):
@@ -984,7 +1244,7 @@ class NucleotideContigFragmentRDD(GenomicDataset):
         return "org.bdgenomics.adam.api.java.ContigsTo%s" % self._destClassSuffix(destClass)
 
 
-class VariantRDD(GenomicDataset):
+class VariantRDD(GenomicDataset, VCFSupportingGenomicRDD):
 
 
     def _replaceRdd(self, newRdd):
@@ -1029,7 +1289,7 @@ class VariantRDD(GenomicDataset):
         return "org.bdgenomics.adam.api.java.VariantsTo%s" % self._destClassSuffix(destClass)
 
     
-class VariantContextRDD(GenomicRDD):
+class VariantContextRDD(VCFSupportingGenomicRDD):
 
 
     def _replaceRdd(self, newRdd):

--- a/adam-python/bdgenomics/adam/test/genotypeRdd_test.py
+++ b/adam-python/bdgenomics/adam/test/genotypeRdd_test.py
@@ -23,6 +23,21 @@ from bdgenomics.adam.test import SparkTestCase
 
 class GenotypeRDDTest(SparkTestCase):
 
+    def check_for_line_in_file(self, path, line):
+
+        try:
+            fp = open(path)
+            foundLine = False
+
+            for l in fp:
+                if l.strip().rstrip() == line:
+                    foundLine = True
+                    break
+            
+            self.assertTrue(foundLine)
+        finally:
+            fp.close()
+
     
     def test_vcf_round_trip(self):
         
@@ -39,7 +54,166 @@ class GenotypeRDDTest(SparkTestCase):
         self.assertEquals(genotypes._jvmRdd.jrdd().count(),
                           savedGenotypes._jvmRdd.jrdd().count())
 
-    
+        
+    def test_vcf_add_filter(self):
+        
+        testFile = self.resourceFile("small.vcf")
+        ac = ADAMContext(self.ss)
+        
+        genotypes = ac.loadGenotypes(testFile)
+
+        tmpPath = self.tmpFile() + ".vcf"
+        genotypes.toVariantContexts().addFilterHeaderLine("BAD",
+                                                          "Bad variant.").saveAsVcf(tmpPath)
+
+        self.check_for_line_in_file(tmpPath, '##FILTER=<ID=BAD,Description="Bad variant.">')
+
+
+    def test_vcf_add_format_array(self):
+        
+        testFile = self.resourceFile("small.vcf")
+        ac = ADAMContext(self.ss)
+        
+        genotypes = ac.loadGenotypes(testFile)
+
+        tmpPath = self.tmpFile() + ".vcf"
+        genotypes.toVariantContexts().addFixedArrayFormatHeaderLine("FA4",
+                                                                    4,
+                                                                    "Fixed array of 4 elements.",
+                                                                    int).saveAsVcf(tmpPath)
+
+        self.check_for_line_in_file(tmpPath,
+                                    '##FORMAT=<ID=FA4,Number=4,Type=Integer,Description="Fixed array of 4 elements.">')
+
+
+    def test_vcf_add_format_scalar(self):
+        
+        testFile = self.resourceFile("small.vcf")
+        ac = ADAMContext(self.ss)
+        
+        genotypes = ac.loadGenotypes(testFile)
+
+        tmpPath = self.tmpFile() + ".vcf"
+        genotypes.toVariantContexts().addScalarFormatHeaderLine("SC",
+                                                                "Scalar.",
+                                                                str).saveAsVcf(tmpPath)
+
+        self.check_for_line_in_file(tmpPath,
+                                    '##FORMAT=<ID=SC,Number=1,Type=String,Description="Scalar.">')
+
+
+    def test_vcf_add_format_genotype_array(self):
+        
+        testFile = self.resourceFile("small.vcf")
+        ac = ADAMContext(self.ss)
+        
+        genotypes = ac.loadGenotypes(testFile)
+
+        tmpPath = self.tmpFile() + ".vcf"
+        genotypes.toVariantContexts().addGenotypeArrayFormatHeaderLine("GA",
+                                                                       "Array with # genotypes.",
+                                                                       float).saveAsVcf(tmpPath)
+
+        self.check_for_line_in_file(tmpPath,
+                                    '##FORMAT=<ID=GA,Number=G,Type=Float,Description="Array with # genotypes.">')
+
+    def test_vcf_add_format_alts_array(self):
+        
+        testFile = self.resourceFile("small.vcf")
+        ac = ADAMContext(self.ss)
+        
+        genotypes = ac.loadGenotypes(testFile)
+
+        tmpPath = self.tmpFile() + ".vcf"
+        genotypes.toVariantContexts().addAlternateAlleleArrayFormatHeaderLine("AA",
+                                                                              "Array with # alts.",
+                                                                              chr).saveAsVcf(tmpPath)
+
+        self.check_for_line_in_file(tmpPath,
+                                    '##FORMAT=<ID=AA,Number=A,Type=Character,Description="Array with # alts.">')
+
+            
+    def test_vcf_add_format_all_array(self):
+        
+        testFile = self.resourceFile("small.vcf")
+        ac = ADAMContext(self.ss)
+        
+        genotypes = ac.loadGenotypes(testFile)
+
+        tmpPath = self.tmpFile() + ".vcf"
+        genotypes.toVariantContexts().addAllAlleleArrayFormatHeaderLine("RA",
+                                                                        "Array with # alleles.",
+                                                                        float).saveAsVcf(tmpPath)
+
+        self.check_for_line_in_file(tmpPath,
+                                    '##FORMAT=<ID=RA,Number=R,Type=Float,Description="Array with # alleles.">')
+
+
+    def test_vcf_add_info_array(self):
+        
+        testFile = self.resourceFile("small.vcf")
+        ac = ADAMContext(self.ss)
+        
+        genotypes = ac.loadGenotypes(testFile)
+
+        tmpPath = self.tmpFile() + ".vcf"
+        genotypes.toVariantContexts().addFixedArrayInfoHeaderLine("FA4",
+                                                                  4,
+                                                                  "Fixed array of 4 elements.",
+                                                                  int).saveAsVcf(tmpPath)
+
+        self.check_for_line_in_file(tmpPath,
+                                    '##INFO=<ID=FA4,Number=4,Type=Integer,Description="Fixed array of 4 elements.">')
+
+
+    def test_vcf_add_info_scalar(self):
+        
+        testFile = self.resourceFile("small.vcf")
+        ac = ADAMContext(self.ss)
+        
+        genotypes = ac.loadGenotypes(testFile)
+
+        tmpPath = self.tmpFile() + ".vcf"
+        genotypes.toVariantContexts().addScalarInfoHeaderLine("SC",
+                                                              "Scalar.",
+                                                              bool).saveAsVcf(tmpPath)
+
+        self.check_for_line_in_file(tmpPath,
+                                    '##INFO=<ID=SC,Number=0,Type=Flag,Description="Scalar.">')
+
+
+    def test_vcf_add_info_alts_array(self):
+        
+        testFile = self.resourceFile("small.vcf")
+        ac = ADAMContext(self.ss)
+        
+        genotypes = ac.loadGenotypes(testFile)
+
+        tmpPath = self.tmpFile() + ".vcf"
+        genotypes.toVariantContexts().addAlternateAlleleArrayInfoHeaderLine("AA",
+                                                                            "Array with # alts.",
+                                                                            chr).saveAsVcf(tmpPath)
+
+        self.check_for_line_in_file(tmpPath,
+                                    '##INFO=<ID=AA,Number=A,Type=Character,Description="Array with # alts.">')
+
+            
+    def test_vcf_add_info_all_array(self):
+        
+        testFile = self.resourceFile("small.vcf")
+        ac = ADAMContext(self.ss)
+        
+        genotypes = ac.loadGenotypes(testFile)
+
+        tmpPath = self.tmpFile() + ".vcf"
+        genotypes.toVariantContexts().addAllAlleleArrayInfoHeaderLine("RA",
+                                                                      "Array with # alleles.",
+                                                                      float).saveAsVcf(tmpPath)
+
+        self.check_for_line_in_file(tmpPath,
+                                    '##INFO=<ID=RA,Number=R,Type=Float,Description="Array with # alleles.">')
+
+            
     def test_vcf_sort(self):
     
         testFile = self.resourceFile("random.vcf")


### PR DESCRIPTION
Resolves #1840. Split header line functionality out into VCFSupportingGenomicRDD trait, which has a Scala/Java API for adding header lines. This is then mirrored in Python.