### PR TITLE
Ignore VCF INFO fields with number=G when stringency=LENIENT

### DIFF
--- a/adam-core/src/test/scala/org/bdgenomics/adam/converters/VariantContextConverterSuite.scala
+++ b/adam-core/src/test/scala/org/bdgenomics/adam/converters/VariantContextConverterSuite.scala
@@ -2093,7 +2093,7 @@ class VariantContextConverterSuite extends ADAMFunSuite {
       "Number=G Type=String")
 
     intercept[IllegalArgumentException] {
-      val vc = new VariantContextConverter(DefaultHeaderLines.allHeaderLines :+ gStringHeader, lenient, false)
+      val vc = new VariantContextConverter(DefaultHeaderLines.allHeaderLines :+ gStringHeader, ValidationStringency.STRICT, false)
         .convert(adamVc).orNull
     }
   }
@@ -2244,7 +2244,7 @@ class VariantContextConverterSuite extends ADAMFunSuite {
       "Number=G Type=String")
 
     intercept[IllegalArgumentException] {
-      val adamVc = new VariantContextConverter(DefaultHeaderLines.allHeaderLines :+ gStringHeader, lenient, false)
+      val adamVc = new VariantContextConverter(DefaultHeaderLines.allHeaderLines :+ gStringHeader, ValidationStringency.STRICT, false)
         .convert(vc)
     }
   }


### PR DESCRIPTION
Ignores, and logs a warning, for  non-specifically-supported INFO fields with Number=G when Stringency = LENIENT
rather than  the current behavior of throwing IllegalArgumentException

Needed because I want to be able to parse directly the gnomAD VCF file contains tags such as:
```
INFO=<ID=GC_Male,Number=G,Type=Integer,Description="Count of Male individuals for each genotype">
```
These INFO number=G tags don't have a simple/general  meaning for multi-allelic variants which are split when loaded to ADAM, which is why in status quo this produces `IllegalArgumentException("Number=G INFO lines are not supported in split-allelic model: %s".` 
Simply allowing the user to choose to ignore INFO tags of number=G seems a workable solution to me.

Aside: 
At the least, there is not a general solution for INFO Number=G fields that can be implemented in `lineToVariantContextExtractor`.
If we do decide that we want to do something specific for an INFO Number=G  tag like `GC_Male` we can consider adding it as a supported tag and adding custom logic to parse it later.