### PR TITLE
[ADAM-1932] Throw file not found exception if directory is empty.

### DIFF
--- a/adam-core/src/main/scala/org/bdgenomics/adam/rdd/ADAMContext.scala
+++ b/adam-core/src/main/scala/org/bdgenomics/adam/rdd/ADAMContext.scala
@@ -1366,9 +1366,10 @@ class ADAMContext(@transient val sc: SparkContext) extends Serializable with Log
     // elaborate out the path; this returns FileStatuses
     val paths = if (fs.isDirectory(path)) {
       val paths = fs.listStatus(path)
-
-      if (paths == null || paths.isEmpty) {
-        s"Couldn't find any files matching ${path.toUri}"
+      if (paths.isEmpty) {
+        throw new FileNotFoundException(
+          s"Couldn't find any files matching ${path.toUri}, directory is empty"
+        )
       }
       fs.listStatus(path, filter)
     } else {

--- a/adam-core/src/test/scala/org/bdgenomics/adam/rdd/ADAMContextSuite.scala
+++ b/adam-core/src/test/scala/org/bdgenomics/adam/rdd/ADAMContextSuite.scala
@@ -55,6 +55,15 @@ class ADAMContextSuite extends ADAMFunSuite {
     new ADAMContext(sc)
   }
 
+  sparkTest("load from an empty directory") {
+    val emptyDirectory = java.nio.file.Files.createTempDirectory("").toAbsolutePath.toString
+
+    val e = intercept[FileNotFoundException] {
+      sc.loadAlignments(emptyDirectory)
+    }
+    assert(e.getMessage.contains("directory is empty"))
+  }
+
   sparkTest("sc.loadParquet should not fail on unmapped reads") {
     val readsFilepath = testFile("unmapped.sam")
 


### PR DESCRIPTION
Fixes #1932