### PR TITLE
[ADAM-1957] Don't initialize missing likelihoods to MinValue.

### DIFF
--- a/adam-core/src/main/scala/org/bdgenomics/adam/converters/VariantContextConverter.scala
+++ b/adam-core/src/main/scala/org/bdgenomics/adam/converters/VariantContextConverter.scala
@@ -1074,7 +1074,7 @@ class VariantContextConverter(
     val copyNumber = gls.length - 1
     val elements = numPls(copyNumber)
 
-    val array = Array.fill(elements) { Int.MinValue }
+    val array = Array.fill(elements) { PhredUtils.minValue }
 
     (0 to copyNumber).foreach(idx => {
       array(idx) = PhredUtils.logProbabilityToPhred(gls.get(idx))

--- a/adam-core/src/main/scala/org/bdgenomics/adam/util/PhredUtils.scala
+++ b/adam-core/src/main/scala/org/bdgenomics/adam/util/PhredUtils.scala
@@ -36,6 +36,9 @@ import scala.math.{
  */
 object PhredUtils extends Serializable {
 
+  // doubles in log space underflow at the probability equivalent to Phred 3233
+  val minValue = 3233
+
   private lazy val phredToErrorProbabilityCache: Array[Double] = {
     (0 until 256).map { p => pow(10.0, -p / 10.0) }.toArray
   }
@@ -106,8 +109,7 @@ object PhredUtils extends Serializable {
    *   we clip the phred score to Int.MaxValue.
    */
   def logProbabilityToPhred(p: Double): Int = if (p == 0.0 || p == -0.0) {
-    // doubles in log space underflow at the probability equivalent to Phred 3233
-    3233
+    minValue
   } else {
     round(M10_DIV_LOG10 * log(-expm1(p))).toInt
   }


### PR DESCRIPTION
Resolves #1957. Introduces a PhredUtils maximum value constant.