### PR TITLE
Add ADAMContext APIs to create genomic RDDs from dataframes

### DIFF
--- a/adam-core/src/main/scala/org/bdgenomics/adam/rdd/ADAMContext.scala
+++ b/adam-core/src/main/scala/org/bdgenomics/adam/rdd/ADAMContext.scala
@@ -1072,6 +1072,8 @@ private class NoPrefixFileFilter(private val prefix: String) extends PathFilter 
  * @param sc The SparkContext to wrap.
  */
 class ADAMContext(@transient val sc: SparkContext) extends Serializable with Logging {
+  @transient val spark = SQLContext.getOrCreate(sc).sparkSession
+  import spark.implicits._
 
   /**
    * @param samHeader The header to extract a sequence dictionary from.

--- a/adam-core/src/main/scala/org/bdgenomics/adam/rdd/ADAMContext.scala
+++ b/adam-core/src/main/scala/org/bdgenomics/adam/rdd/ADAMContext.scala
@@ -52,7 +52,7 @@ import org.bdgenomics.adam.rich.RichAlignmentRecord
 import org.bdgenomics.adam.sql.{ AlignmentRecord => AlignmentRecordProduct, Feature => FeatureProduct, Fragment => FragmentProduct, Genotype => GenotypeProduct, NucleotideContigFragment => NucleotideContigFragmentProduct, Variant => VariantProduct, VariantContext => VariantContextProduct }
 import org.bdgenomics.adam.util.FileExtensions._
 import org.bdgenomics.adam.util.{ GenomeFileReader, ReferenceContigMap, ReferenceFile, SequenceDictionaryReader, TwoBitFile }
-import org.bdgenomics.formats.avro.{ AlignmentRecord, Contig, Feature, Fragment, Genotype, NucleotideContigFragment, ProcessingStep, Sample, Variant, RecordGroup => RecordGroupMetadata }
+import org.bdgenomics.formats.avro.{ RecordGroup => RecordGroupMetadata, _ }
 import org.bdgenomics.utils.instrumentation.Metrics
 import org.bdgenomics.utils.io.LocalFileByteAccess
 import org.bdgenomics.utils.misc.{ HadoopUtil, Logging }

--- a/adam-core/src/main/scala/org/bdgenomics/adam/rdd/ADAMContext.scala
+++ b/adam-core/src/main/scala/org/bdgenomics/adam/rdd/ADAMContext.scala
@@ -1071,13 +1071,7 @@ private class NoPrefixFileFilter(private val prefix: String) extends PathFilter 
  *
  * @param sc The SparkContext to wrap.
  */
-class ADAMContext(@transient val spark: SparkSession) extends Serializable with Logging {
-  import spark.implicits._
-  @transient val sc: SparkContext = spark.sparkContext
-
-  def this(sc: SparkContext) {
-    this(SQLContext.getOrCreate(sc).sparkSession)
-  }
+class ADAMContext(@transient val sc: SparkContext) extends Serializable with Logging {
 
   /**
    * @param samHeader The header to extract a sequence dictionary from.
@@ -2339,7 +2333,6 @@ class ADAMContext(@transient val spark: SparkSession) extends Serializable with 
   def loadParquetVariantContexts(
     pathName: String): VariantContextRDD = {
     val sqlContext = SQLContext.getOrCreate(sc)
-    import sqlContext.implicits._
     val df = sqlContext.read.parquet(pathName)
     loadVariantContexts(df, pathName)
   }
@@ -2837,7 +2830,6 @@ class ADAMContext(@transient val spark: SparkSession) extends Serializable with 
         ParquetUnboundFragmentRDD(sc, pathName, sd, rgd, pgs)
       }
       case (_, _) => {
-        val df = SQLContext.getOrCreate(sc)
         // load from disk
         val rdd = loadParquet[Fragment](pathName, optPredicate, optProjection)
 

--- a/adam-core/src/test/scala/org/bdgenomics/adam/rdd/ADAMContextSuite.scala
+++ b/adam-core/src/test/scala/org/bdgenomics/adam/rdd/ADAMContextSuite.scala
@@ -770,8 +770,8 @@ class ADAMContextSuite extends ADAMFunSuite {
     assert(reloaded.sequences == vcs.sequences)
     assert(reloaded.headerLines.toSet == vcs.headerLines.toSet)
     assert(reloaded.samples == vcs.samples)
-    assert(reloaded.rdd.collect().map(VCProduct.fromModel).deep.sorted ==
-      vcs.rdd.collect().map(VCProduct.fromModel).deep.sorted)
+    assert(reloaded.rdd.collect().map(VCProduct.fromModel).deep ==
+      vcs.rdd.collect().map(VCProduct.fromModel).deep)
   }
 
   sparkTest("load features from dataframe") {
@@ -815,10 +815,10 @@ class ADAMContextSuite extends ADAMFunSuite {
     val outputDir = tmpLocation()
     variants.saveAsParquet(outputDir)
     val df = SQLContext.getOrCreate(sc).read.parquet(outputDir)
-    val reloadedVariants = sc.loadVariants(df, outputDir)
-    assert(reloadedVariants.sequences == variants.sequences)
-    assert(reloadedVariants.headerLines.toSet == variants.headerLines.toSet)
-    assert(reloadedVariants.rdd.collect().deep == variants.rdd.collect().deep)
+    val reloaded = sc.loadVariants(df, outputDir)
+    assert(reloaded.sequences == variants.sequences)
+    assert(reloaded.headerLines.toSet == variants.headerLines.toSet)
+    assert(reloaded.rdd.collect().deep == variants.rdd.collect().deep)
   }
 
   sparkTest("load alignments from dataframe") {


### PR DESCRIPTION
In some cases, it's convenient to use vanilla Spark APIs to load genomic data and apply some basic transformations before creating an ADAM object. This PR adds methods to `ADAMContext` to load each type of genomic RDD from a Spark SQL dataframe and a metadata path. We look for metadata like the sequence and record group dictionaries in the metadata path.