### PR TITLE
[ADAM-1996] Load and save VariantContexts as partitioned Parquet.

### DIFF
--- a/adam-core/src/main/scala/org/bdgenomics/adam/rdd/ADAMContext.scala
+++ b/adam-core/src/main/scala/org/bdgenomics/adam/rdd/ADAMContext.scala
@@ -1909,7 +1909,7 @@ class ADAMContext(@transient val sc: SparkContext) extends Serializable with Log
   }
 
   /**
-   * Load a path name with range binned partitioned Parquet + Avro format into an AlignmentRecordRDD.
+   * Load a path name with range binned partitioned Parquet format into an AlignmentRecordRDD.
    *
    * @note The sequence dictionary is read from an Avro file stored at
    *   pathName/_seqdict.avro and the record group dictionary is read from an
@@ -1920,8 +1920,8 @@ class ADAMContext(@transient val sc: SparkContext) extends Serializable with Log
    *   Globs/directories are supported.
    * @param regions Optional list of genomic regions to load.
    * @param optLookbackPartitions Number of partitions to lookback to find beginning of an overlapping
-   *         region when using the filterByOverlappingRegions function on the returned dataset.
-   *         Defaults to one partition.
+   *   region when using the filterByOverlappingRegions function on the returned dataset.
+   *   Defaults to one partition.
    * @return Returns an AlignmentRecordRDD.
    */
   def loadPartitionedParquetAlignments(pathName: String,
@@ -1934,7 +1934,7 @@ class ADAMContext(@transient val sc: SparkContext) extends Serializable with Log
       reads.sequences,
       reads.recordGroups,
       reads.processingSteps,
-      true,
+      isPartitioned = true,
       Some(partitionBinSize),
       optLookbackPartitions
     )
@@ -2326,14 +2326,14 @@ class ADAMContext(@transient val sc: SparkContext) extends Serializable with Log
   }
 
   /**
-   * Load a path name with range binned partitioned Parquet + Avro format into GenotypeRDD
+   * Load a path name with range binned partitioned Parquet format into a GenotypeRDD.
    *
    * @param pathName The path name to load alignment records from.
    *   Globs/directories are supported.
    * @param regions Optional list of genomic regions to load.
    * @param optLookbackPartitions Number of partitions to lookback to find beginning of an overlapping
-   *         region when using the filterByOverlappingRegions function on the returned dataset.
-   *         Defaults to one partition.
+   *   region when using the filterByOverlappingRegions function on the returned dataset.
+   *   Defaults to one partition.
    * @return Returns a GenotypeRDD.
    */
   def loadPartitionedParquetGenotypes(pathName: String,
@@ -2346,7 +2346,7 @@ class ADAMContext(@transient val sc: SparkContext) extends Serializable with Log
       genotypes.sequences,
       genotypes.samples,
       genotypes.headerLines,
-      true,
+      isPartitioned = true,
       Some(partitionedBinSize),
       optLookbackPartitions
     )
@@ -2355,9 +2355,9 @@ class ADAMContext(@transient val sc: SparkContext) extends Serializable with Log
   }
 
   /**
-   * Load a path name in Parquet + Avro format into a VariantContextRDD.
+   * Load a path name in VCF or Parquet + Avro format into a VariantContextRDD.
    *
-   * @param pathName The path name to load genotypes from.
+   * @param pathName The path name to load variant context records from.
    *   Globs/directories are supported.
    * @return Returns a VariantContextRDD.
    */
@@ -2374,7 +2374,7 @@ class ADAMContext(@transient val sc: SparkContext) extends Serializable with Log
   /**
    * Load a path name in Parquet + Avro format into a VariantContextRDD.
    *
-   * @param pathName The path name to load genotypes from.
+   * @param pathName The path name to load variant context records from.
    *   Globs/directories are supported.
    * @return Returns a VariantContextRDD.
    */
@@ -2395,6 +2395,35 @@ class ADAMContext(@transient val sc: SparkContext) extends Serializable with Log
     val ds = sqlContext.read.parquet(pathName).as[VariantContextProduct]
 
     new DatasetBoundVariantContextRDD(ds, sd, samples, headers)
+  }
+
+  /**
+   * Load a path name with range binned partitioned Parquet format into a VariantContextRDD.
+   *
+   * @param pathName The path name to load variant context records from.
+   *   Globs/directories are supported.
+   * @param regions Optional list of genomic regions to load.
+   * @param optLookbackPartitions Number of partitions to lookback to find beginning of an overlapping
+   *   region when using the filterByOverlappingRegions function on the returned dataset.
+   *   Defaults to one partition.
+   * @return Returns a VariantContextRDD.
+   */
+  def loadPartitionedParquetVariantContexts(pathName: String,
+                                            regions: Iterable[ReferenceRegion] = Iterable.empty,
+                                            optLookbackPartitions: Option[Int] = Some(1)): VariantContextRDD = {
+
+    val partitionedBinSize = getPartitionBinSize(pathName)
+    val variantContexts = loadParquetVariantContexts(pathName)
+    val variantContextsDatasetBound = DatasetBoundVariantContextRDD(variantContexts.dataset,
+      variantContexts.sequences,
+      variantContexts.samples,
+      variantContexts.headerLines,
+      isPartitioned = true,
+      Some(partitionedBinSize),
+      optLookbackPartitions
+    )
+
+    if (regions.nonEmpty) variantContextsDatasetBound.filterByOverlappingRegions(regions) else variantContextsDatasetBound
   }
 
   /**
@@ -2431,15 +2460,15 @@ class ADAMContext(@transient val sc: SparkContext) extends Serializable with Log
   }
 
   /**
-   * Load a path name with range binned partitioned Parquet + Avro format into an VariantRDD.
+   * Load a path name with range binned partitioned Parquet format into a VariantRDD.
    *
    * @param pathName The path name to load alignment records from.
    *   Globs/directories are supported.
    * @param regions Optional list of genomic regions to load.
    * @param optLookbackPartitions Number of partitions to lookback to find beginning of an overlapping
-   *         region when using the filterByOverlappingRegions function on the returned dataset.
-   *         Defaults to one partition.
-   * @return Returns a VariantRDD
+   *   region when using the filterByOverlappingRegions function on the returned dataset.
+   *   Defaults to one partition.
+   * @return Returns a VariantRDD.
    */
   def loadPartitionedParquetVariants(pathName: String,
                                      regions: Iterable[ReferenceRegion] = Iterable.empty,
@@ -2447,15 +2476,15 @@ class ADAMContext(@transient val sc: SparkContext) extends Serializable with Log
 
     val partitionedBinSize = getPartitionBinSize(pathName)
     val variants = loadParquetVariants(pathName)
-    val variantsDatsetBound = DatasetBoundVariantRDD(variants.dataset,
+    val variantsDatasetBound = DatasetBoundVariantRDD(variants.dataset,
       variants.sequences,
       variants.headerLines,
-      true,
+      isPartitioned = true,
       Some(partitionedBinSize),
       optLookbackPartitions
     )
 
-    if (regions.nonEmpty) variantsDatsetBound.filterByOverlappingRegions(regions) else variantsDatsetBound
+    if (regions.nonEmpty) variantsDatasetBound.filterByOverlappingRegions(regions) else variantsDatasetBound
   }
 
   /**
@@ -2775,14 +2804,14 @@ class ADAMContext(@transient val sc: SparkContext) extends Serializable with Log
   }
 
   /**
-   * Load a path name with range binned partitioned Parquet + Avro format into a FeatureRDD.
+   * Load a path name with range binned partitioned Parquet format into a FeatureRDD.
    *
    * @param pathName The path name to load alignment records from.
    *   Globs/directories are supported.
    * @param regions Optional list of genomic regions to load.
    * @param optLookbackPartitions Number of partitions to lookback to find beginning of an overlapping
-   *         region when using the filterByOverlappingRegions function on the returned dataset.
-   *         Defaults to one partition.
+   *   region when using the filterByOverlappingRegions function on the returned dataset.
+   *   Defaults to one partition.
    * @return Returns a FeatureRDD.
    */
   def loadPartitionedParquetFeatures(pathName: String,
@@ -2793,7 +2822,7 @@ class ADAMContext(@transient val sc: SparkContext) extends Serializable with Log
     val features = loadParquetFeatures(pathName)
     val featureDatasetBound = DatasetBoundFeatureRDD(features.dataset,
       features.sequences,
-      true,
+      isPartitioned = true,
       Some(partitionedBinSize),
       optLookbackPartitions
     )
@@ -2834,15 +2863,15 @@ class ADAMContext(@transient val sc: SparkContext) extends Serializable with Log
   }
 
   /**
-   * Load a path name with range binned partitioned Parquet + Avro format into a NucleotideContigFragmentRDD.
+   * Load a path name with range binned partitioned Parquet format into a NucleotideContigFragmentRDD.
    *
    * @param pathName The path name to load alignment records from.
    *   Globs/directories are supported.
    * @param regions Optional list of genomic regions to load.
    * @param optLookbackPartitions Number of partitions to lookback to find beginning of an overlapping
-   *         region when using the filterByOverlappingRegions function on the returned dataset.
-   *         Defaults to one partition.
-   * @return Returns a NucleotideContigFragmentRDD
+   *   region when using the filterByOverlappingRegions function on the returned dataset.
+   *   Defaults to one partition.
+   * @return Returns a NucleotideContigFragmentRDD.
    */
   def loadPartitionedParquetContigFragments(pathName: String,
                                             regions: Iterable[ReferenceRegion] = Iterable.empty,
@@ -2852,7 +2881,7 @@ class ADAMContext(@transient val sc: SparkContext) extends Serializable with Log
     val contigs = loadParquetContigFragments(pathName)
     val contigsDatasetBound = DatasetBoundNucleotideContigFragmentRDD(contigs.dataset,
       contigs.sequences,
-      true,
+      isPartitioned = true,
       Some(partitionedBinSize),
       optLookbackPartitions
     )
@@ -3320,5 +3349,4 @@ class ADAMContext(@transient val sc: SparkContext) extends Serializable with Log
       case e: FileNotFoundException => false
     }
   }
-
 }

--- a/adam-core/src/main/scala/org/bdgenomics/adam/rdd/contig/NucleotideContigFragmentRDD.scala
+++ b/adam-core/src/main/scala/org/bdgenomics/adam/rdd/contig/NucleotideContigFragmentRDD.scala
@@ -152,7 +152,7 @@ case class DatasetBoundNucleotideContigFragmentRDD private[rdd] (
                              pageSize: Int = 1 * 1024 * 1024,
                              compressCodec: CompressionCodecName = CompressionCodecName.GZIP,
                              disableDictionaryEncoding: Boolean = false) {
-    log.warn("Saving directly as Parquet from SQL. Options other than compression codec are ignored.")
+    log.info("Saving directly as Parquet from SQL. Options other than compression codec are ignored.")
     dataset.toDF()
       .write
       .format("parquet")

--- a/adam-core/src/main/scala/org/bdgenomics/adam/rdd/feature/FeatureRDD.scala
+++ b/adam-core/src/main/scala/org/bdgenomics/adam/rdd/feature/FeatureRDD.scala
@@ -290,7 +290,7 @@ case class DatasetBoundFeatureRDD private[rdd] (
                              pageSize: Int = 1 * 1024 * 1024,
                              compressCodec: CompressionCodecName = CompressionCodecName.GZIP,
                              disableDictionaryEncoding: Boolean = false) {
-    log.warn("Saving directly as Parquet from SQL. Options other than compression codec are ignored.")
+    log.info("Saving directly as Parquet from SQL. Options other than compression codec are ignored.")
     dataset.toDF()
       .write
       .format("parquet")

--- a/adam-core/src/main/scala/org/bdgenomics/adam/rdd/fragment/FragmentRDD.scala
+++ b/adam-core/src/main/scala/org/bdgenomics/adam/rdd/fragment/FragmentRDD.scala
@@ -202,7 +202,7 @@ case class DatasetBoundFragmentRDD private[rdd] (
                              pageSize: Int = 1 * 1024 * 1024,
                              compressCodec: CompressionCodecName = CompressionCodecName.GZIP,
                              disableDictionaryEncoding: Boolean = false) {
-    log.warn("Saving directly as Parquet from SQL. Options other than compression codec are ignored.")
+    log.info("Saving directly as Parquet from SQL. Options other than compression codec are ignored.")
     dataset.toDF()
       .write
       .format("parquet")

--- a/adam-core/src/main/scala/org/bdgenomics/adam/rdd/read/AlignmentRecordRDD.scala
+++ b/adam-core/src/main/scala/org/bdgenomics/adam/rdd/read/AlignmentRecordRDD.scala
@@ -252,7 +252,7 @@ case class DatasetBoundAlignmentRecordRDD private[rdd] (
                              pageSize: Int = 1 * 1024 * 1024,
                              compressCodec: CompressionCodecName = CompressionCodecName.GZIP,
                              disableDictionaryEncoding: Boolean = false) {
-    log.warn("Saving directly as Parquet from SQL. Options other than compression codec are ignored.")
+    log.info("Saving directly as Parquet from SQL. Options other than compression codec are ignored.")
     dataset.toDF()
       .write
       .format("parquet")

--- a/adam-core/src/main/scala/org/bdgenomics/adam/rdd/variant/GenotypeRDD.scala
+++ b/adam-core/src/main/scala/org/bdgenomics/adam/rdd/variant/GenotypeRDD.scala
@@ -164,7 +164,7 @@ case class DatasetBoundGenotypeRDD private[rdd] (
                              pageSize: Int = 1 * 1024 * 1024,
                              compressCodec: CompressionCodecName = CompressionCodecName.GZIP,
                              disableDictionaryEncoding: Boolean = false) {
-    log.warn("Saving directly as Parquet from SQL. Options other than compression codec are ignored.")
+    log.info("Saving directly as Parquet from SQL. Options other than compression codec are ignored.")
     dataset.toDF()
       .write
       .format("parquet")

--- a/adam-core/src/main/scala/org/bdgenomics/adam/rdd/variant/VariantRDD.scala
+++ b/adam-core/src/main/scala/org/bdgenomics/adam/rdd/variant/VariantRDD.scala
@@ -151,7 +151,7 @@ case class DatasetBoundVariantRDD private[rdd] (
                              pageSize: Int = 1 * 1024 * 1024,
                              compressCodec: CompressionCodecName = CompressionCodecName.GZIP,
                              disableDictionaryEncoding: Boolean = false) {
-    log.warn("Saving directly as Parquet from SQL. Options other than compression codec are ignored.")
+    log.info("Saving directly as Parquet from SQL. Options other than compression codec are ignored.")
     dataset.toDF()
       .write
       .format("parquet")

--- a/adam-core/src/test/scala/org/bdgenomics/adam/rdd/variant/VariantContextRDDSuite.scala
+++ b/adam-core/src/test/scala/org/bdgenomics/adam/rdd/variant/VariantContextRDDSuite.scala
@@ -31,6 +31,7 @@ import org.apache.spark.util.CollectionAccumulator
 import org.bdgenomics.adam.converters.DefaultHeaderLines
 import org.bdgenomics.adam.models.{
   Coverage,
+  ReferenceRegion,
   SequenceDictionary,
   SequenceRecord,
   VariantContext
@@ -501,5 +502,28 @@ class VariantContextRDDSuite extends ADAMFunSuite {
       })
 
     checkSave(variants)
+  }
+
+  sparkTest("save and reload from partitioned parquet") {
+    def testMetadata(vcs: VariantContextRDD) {
+      assert(vcs.sequences.containsRefName("13"))
+      assert(vcs.samples.isEmpty)
+      assert(vcs.headerLines.exists(_.getKey == "GATKCommandLine"))
+    }
+
+    val variantContexts = sc.loadVcf(testFile("sorted-variants.vcf"))
+    val outputPath = tmpLocation()
+    variantContexts.saveAsPartitionedParquet(outputPath, partitionSize = 1000000)
+    val unfilteredVariantContexts = sc.loadPartitionedParquetVariantContexts(outputPath)
+    testMetadata(unfilteredVariantContexts)
+    assert(unfilteredVariantContexts.rdd.count === 6)
+    assert(unfilteredVariantContexts.dataset.count === 6)
+
+    val regionsVariantContexts = sc.loadPartitionedParquetVariantContexts(outputPath,
+      List(ReferenceRegion("2", 19000L, 21000L),
+        ReferenceRegion("13", 752700L, 752750L)))
+    testMetadata(regionsVariantContexts)
+    assert(regionsVariantContexts.rdd.count === 2)
+    assert(regionsVariantContexts.dataset.count === 2)
   }
 }


### PR DESCRIPTION
Fixes #1996.