### PR TITLE
Refactor/mark buckets

### DIFF
--- a/adam-core/src/main/scala/org/bdgenomics/adam/models/RecordGroupDictionary.scala
+++ b/adam-core/src/main/scala/org/bdgenomics/adam/models/RecordGroupDictionary.scala
@@ -53,7 +53,7 @@ object RecordGroupDictionary {
  *
  * @param recordGroups A seq of record groups to populate the dictionary.
  *
- * @throws IllegalArgumentError Throws an assertion error if there are multiple record
+ * @throws IllegalArgumentException Throws an assertion error if there are multiple record
  *   groups with the same name.
  */
 case class RecordGroupDictionary(recordGroups: Seq[RecordGroup]) {


### PR DESCRIPTION
The leftPositionAndLibrary function in markBuckets was a bit hard to understand. This PR refactors it so that it is easier to understand and also so that it uses `Option(None)` instead of `null`. Also minor documentation fix.