### PR TITLE
Allow for export of query name sorted SAM files

### DIFF
--- a/adam-core/src/test/resources/readname_sorted.sam
+++ b/adam-core/src/test/resources/readname_sorted.sam
@@ -1,0 +1,10 @@
+@HD	VN:1.5	SO:queryname
+@SQ	SN:1	LN:1000
+@SQ	SN:chr2	LN:1000
+@SQ	SN:3	LN:1000
+@SQ	SN:4	LN:2000
+A	0	1	1	50	10M	*	0	0	ACACACACAC	**********
+B	0	3	11	40	4M2I4M	*	0	0	ACACACACAC	**********
+C	0	4	1001	25	8M	*	0	0	ACACACAC	********
+D	0	chr2	501	55	10M2S	*	0	0	ACACACACACAC	************
+E	0	chr2	101	45	10M	*	0	0	ACACACACAC	**********


### PR DESCRIPTION
Creates function to sort reads by query name, and allows SAM files to be written with all sort orders.