### PR TITLE
use readlink to properly source source dir

### DIFF
--- a/bin/adam-shell
+++ b/bin/adam-shell
@@ -25,7 +25,7 @@ if [[ -z $@ && -n "$ADAM_OPTS" ]]; then
     echo "Run adam-shell instead as adam-shell <spark-args>" 1>&2
 fi
 
-SOURCE_DIR=$(dirname ${BASH_SOURCE[0]})
+SOURCE_DIR=$(dirname $(readlink -f ${BASH_SOURCE[0]}))
 
 ADAM_CLI_JAR=$(${SOURCE_DIR}/find-adam-assembly.sh)
 

--- a/bin/adam-submit
+++ b/bin/adam-submit
@@ -21,7 +21,7 @@
 
 set -e
 
-SOURCE_DIR=$(dirname ${BASH_SOURCE[0]})
+SOURCE_DIR=$(dirname $(readlink -f ${BASH_SOURCE[0]}))
 
 # Split args into Spark and ADAM args
 DD=False  # DD is "double dash"

--- a/bin/adamR
+++ b/bin/adamR
@@ -19,7 +19,7 @@
 
 set -e
 
-SOURCE_DIR=$(dirname ${BASH_SOURCE[0]})
+SOURCE_DIR=$(dirname $(readlink -f ${BASH_SOURCE[0]}))
 
 ADAM_CLI_JAR=$(${SOURCE_DIR}/find-adam-assembly.sh)
 

--- a/bin/find-adam-assembly.sh
+++ b/bin/find-adam-assembly.sh
@@ -19,7 +19,7 @@
 
 set -e
 
-SOURCE_DIR=$(dirname ${BASH_SOURCE[0]})
+SOURCE_DIR=$(dirname $(readlink -f ${BASH_SOURCE[0]}))
 . ${SOURCE_DIR}/find-adam-home
 
 # Find ADAM cli assembly jar

--- a/bin/find-adam-egg.sh
+++ b/bin/find-adam-egg.sh
@@ -19,7 +19,7 @@
 
 set -e
 
-SOURCE_DIR=$(dirname ${BASH_SOURCE[0]})
+SOURCE_DIR=$(dirname $(readlink -f ${BASH_SOURCE[0]}))
 . ${SOURCE_DIR}/find-adam-home
 
 # Find ADAM python egg

--- a/bin/pyadam
+++ b/bin/pyadam
@@ -19,7 +19,7 @@
 
 set -e
 
-SOURCE_DIR=$(dirname ${BASH_SOURCE[0]})
+SOURCE_DIR=$(dirname $(readlink -f ${BASH_SOURCE[0]}))
 
 ADAM_CLI_JAR=$(${SOURCE_DIR}/find-adam-assembly.sh)
 ADAM_EGG=$(${SOURCE_DIR}/find-adam-egg.sh)


### PR DESCRIPTION
Adam bin scripts assume you are in the right directory. In standing this up in a docker container, we wanted a central source code location + symlinks to the in scripts. Using readlink, you can easily obtain the real directory.