### PR TITLE
Resolve common-codec dependency

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -511,6 +511,11 @@
         <version>${avro.version}</version>
       </dependency>
       <dependency>
+        <artifactId>commons-codec</artifactId>
+        <groupId>commons-codec</groupId>
+        <version>1.11</version>
+      </dependency>
+      <dependency>
         <groupId>org.apache.parquet</groupId>
         <artifactId>parquet-avro</artifactId>
         <!--


### PR DESCRIPTION
Dear,

Currently, when trying to build ADAM from sources, maven try to find commons-codec-2.0-SNAPSHOT and fail.
This behavior is due to [jets3t](https://bitbucket.org/jmurty/jets3t). Indeed the project defines a range pulls version.

```xml
        <dependency>
            <groupId>commons-codec</groupId>
            <artifactId>commons-codec</artifactId>
            <version>[1.8,2.0)</version>
            <scope>compile</scope>
        </dependency>
```

This unwanted behavior has been reported and described in the issue [246](https://bitbucket.org/jmurty/jets3t/issues/246/commons-codec-dependency-range-pulls)

This patch set the commons-codec required version to `1.11` which allow building ADAM framework on my computer.
