### PR TITLE
[ADAM-2064] Avoid collision between @RG FO and KS fields.

### DIFF
--- a/adam-core/src/main/scala/org/bdgenomics/adam/models/RecordGroupDictionary.scala
+++ b/adam-core/src/main/scala/org/bdgenomics/adam/models/RecordGroupDictionary.scala
@@ -304,7 +304,7 @@ case class RecordGroup(
     description.foreach(rgr.setDescription)
     runDateEpoch.foreach(e => rgr.setRunDate(new Date(e)))
     flowOrder.foreach(rgr.setFlowOrder)
-    keySequence.foreach(rgr.setFlowOrder)
+    keySequence.foreach(rgr.setKeySequence)
     library.foreach(rgr.setLibrary)
     predictedMedianInsertSize.foreach(is => {
       // force implicit conversion

--- a/adam-core/src/test/scala/org/bdgenomics/adam/models/RecordGroupDictionarySuite.scala
+++ b/adam-core/src/test/scala/org/bdgenomics/adam/models/RecordGroupDictionarySuite.scala
@@ -91,4 +91,20 @@ class RecordGroupDictionarySuite extends FunSuite {
     val mergedRgd = rgd ++ rgd
     assert(rgd === mergedRgd)
   }
+
+  test("round trip a record with all attributes set") {
+    val rg = new SAMReadGroupRecord("RG1")
+    rg.setSample("S1")
+    rg.setLibrary("L1")
+    rg.setPlatformUnit("PU1")
+    rg.setPlatform("ILLUMINA")
+    rg.setFlowOrder("ACGT")
+    rg.setKeySequence("AATT")
+    rg.setSequencingCenter("BDG")
+    rg.setDescription("TEST")
+    rg.setPredictedMedianInsertSize(100)
+    val arg = RecordGroup(rg)
+    val htsjdkRg = arg.toSAMReadGroupRecord()
+    assert(rg.equivalent(htsjdkRg))
+  }
 }


### PR DESCRIPTION
Resolves #2064. We were writing the KS (key sequence) read group attribute back into the FO (flow order) attribute. This commit resolves this error and adds a unit test touching all supported @RG attributes.