### PR TITLE
Update dependency versions, including htsjdk to 2.16.1 and guava to 27.0-jre

### DIFF
--- a/adam-cli/src/main/scala/org/bdgenomics/adam/cli/ADAMMain.scala
+++ b/adam-cli/src/main/scala/org/bdgenomics/adam/cli/ADAMMain.scala
@@ -142,7 +142,7 @@ class ADAMMain @Inject() (commandGroups: List[CommandGroup]) extends Logging {
 }
 
 class ADAMModule extends AbstractModule with ScalaModule {
-  def configure() {
+  override def configure() {
     bind[List[CommandGroup]].toInstance(ADAMMain.defaultCommandGroups)
   }
 }

--- a/adam-cli/src/test/scala/org/bdgenomics/adam/cli/ADAMMainSuite.scala
+++ b/adam-cli/src/test/scala/org/bdgenomics/adam/cli/ADAMMainSuite.scala
@@ -96,7 +96,7 @@ class ADAMMainSuite extends FunSuite {
     val stream = new ByteArrayOutputStream()
     Console.withOut(stream) {
       val module = new AbstractModule with ScalaModule {
-        def configure() = {
+        override def configure() = {
           bind[List[CommandGroup]].toInstance(List(CommandGroup("SINGLE COMMAND GROUP", List(TransformAlignments))))
         }
       }
@@ -114,7 +114,7 @@ class ADAMMainSuite extends FunSuite {
     val stream = new ByteArrayOutputStream()
     Console.withOut(stream) {
       val module = new AbstractModule with ScalaModule {
-        def configure() = {
+        override def configure() = {
           bind[List[CommandGroup]].toInstance(defaultCommandGroups.union(List(CommandGroup("NEW COMMAND GROUP", List(TransformAlignments)))))
         }
       }

--- a/adam-core/src/main/scala/org/bdgenomics/adam/rdd/VCFHeaderUtils.scala
+++ b/adam-core/src/main/scala/org/bdgenomics/adam/rdd/VCFHeaderUtils.scala
@@ -17,6 +17,7 @@
  */
 package org.bdgenomics.adam.rdd
 
+import java.io.File
 import htsjdk.samtools.util.BlockCompressedOutputStream
 import htsjdk.variant.variantcontext.writer.{
   Options,
@@ -73,7 +74,7 @@ private[rdd] object VCFHeaderUtils {
     val os = if (isCompressed) {
       // BGZF stream requires java.io.File
       // we can't get one in hadoop land, so it is OK to provide a null file
-      new BlockCompressedOutputStream(fos, null)
+      new BlockCompressedOutputStream(fos, null.asInstanceOf[File])
     } else {
       fos
     }

--- a/adam-core/src/main/scala/org/bdgenomics/adam/rdd/read/AlignmentRecordRDD.scala
+++ b/adam-core/src/main/scala/org/bdgenomics/adam/rdd/read/AlignmentRecordRDD.scala
@@ -20,7 +20,7 @@ package org.bdgenomics.adam.rdd.read
 import htsjdk.samtools._
 import htsjdk.samtools.cram.ref.ReferenceSource
 import htsjdk.samtools.util.{ BinaryCodec, BlockCompressedOutputStream }
-import java.io.{ OutputStream, StringWriter, Writer }
+import java.io.{ File, OutputStream, StringWriter, Writer }
 import java.net.URI
 import java.nio.file.Paths
 import org.apache.hadoop.fs.Path
@@ -798,7 +798,7 @@ sealed abstract class AlignmentRecordRDD extends AvroRecordGroupGenomicDataset[A
         .asInstanceOf[OutputStream]
 
       // create htsjdk specific streams for writing the bam header
-      val compressedOut: OutputStream = new BlockCompressedOutputStream(os, null)
+      val compressedOut: OutputStream = new BlockCompressedOutputStream(os, null.asInstanceOf[File])
       val binaryCodec = new BinaryCodec(compressedOut)
 
       // write a bam header - cribbed from Hadoop-BAM

--- a/pom.xml
+++ b/pom.xml
@@ -24,12 +24,12 @@
     <spark.version>2.3.2</spark.version>
     <parquet.version>1.8.3</parquet.version>
     <!-- Edit the following line to configure the Hadoop (HDFS) version. -->
-    <hadoop.version>2.7.3</hadoop.version>
+    <hadoop.version>2.7.5</hadoop.version>
     <hadoop-bam.version>7.9.2</hadoop-bam.version>
     <slf4j.version>1.7.25</slf4j.version>
     <bdg-formats.version>0.11.3</bdg-formats.version>
     <bdg-utils.version>0.2.13</bdg-utils.version>
-    <htsjdk.version>2.13.2</htsjdk.version>
+    <htsjdk.version>2.16.1</htsjdk.version>
     <scoverage.plugin.version>1.1.1</scoverage.plugin.version>
   </properties>
 
@@ -77,12 +77,12 @@
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-assembly-plugin</artifactId>
-          <version>2.6</version>
+          <version>3.1.0</version>
         </plugin>
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-javadoc-plugin</artifactId>
-          <version>2.10.4</version>
+          <version>3.0.1</version>
         </plugin>
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
@@ -112,12 +112,12 @@
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-clean-plugin</artifactId>
-          <version>3.0.0</version>
+          <version>3.1.0</version>
         </plugin>
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-compiler-plugin</artifactId>
-          <version>3.5.1</version>
+          <version>3.8.0</version>
           <configuration>
             <source>${java.version}</source>
             <target>${java.version}</target>
@@ -161,7 +161,7 @@
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-jar-plugin</artifactId>
-          <version>3.0.1</version>
+          <version>3.1.0</version>
         </plugin>
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
@@ -171,7 +171,7 @@
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-shade-plugin</artifactId>
-          <version>2.4.3</version>
+          <version>3.2.0</version>
         </plugin>
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
@@ -181,7 +181,7 @@
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-surefire-plugin</artifactId>
-          <version>2.19.1</version>
+          <version>2.22.1</version>
         </plugin>
         <plugin>
           <groupId>org.codehaus.mojo</groupId>
@@ -196,7 +196,7 @@
         <plugin>
           <groupId>pl.project13.maven</groupId>
           <artifactId>git-commit-id-plugin</artifactId>
-          <version>2.2.1</version>
+          <version>2.2.2</version>
           <configuration>
             <gitDescribe>
               <always>true</always>
@@ -336,7 +336,7 @@
       <dependency>
         <groupId>commons-io</groupId>
         <artifactId>commons-io</artifactId>
-        <version>2.5</version>
+        <version>2.6</version>
       </dependency>
       <dependency>
         <groupId>it.unimi.dsi</groupId>
@@ -602,18 +602,18 @@
      <dependency>
         <groupId>com.google.guava</groupId>
         <artifactId>guava</artifactId>
-        <version>16.0.1</version> <!-- note: version 17.0 breaks hadoop 2.6+ at runtime -->
+        <version>27.0-jre</version>
       </dependency>
       <dependency>
         <groupId>org.mockito</groupId>
         <artifactId>mockito-core</artifactId>
-        <version>2.6.4</version>
+        <version>2.23.0</version>
         <scope>test</scope>
       </dependency>
       <dependency>
         <groupId>net.codingwell</groupId>
         <artifactId>scala-guice_${scala.version.prefix}</artifactId>
-        <version>4.1.0</version>
+        <version>4.2.1</version>
       </dependency>
       <dependency>
         <groupId>org.bdgenomics.adam</groupId>
@@ -675,7 +675,7 @@
           <plugin>
             <groupId>org.apache.maven.plugins</groupId>
             <artifactId>maven-javadoc-plugin</artifactId>
-            <version>2.10.4</version>
+            <version>3.0.1</version>
             <executions>
               <execution>
                 <id>attach-javadocs</id>


### PR DESCRIPTION
* htsjdk 2.13.2 &rarr; 2.16.1 required changes to `BlockCompressedOutputStream` ctr calls
* Guice 4.1.0 &rarr; 4.2.1 required `override` annotation to `configure` method
* Guava > 16.0 used to throw runtime exceptions due to classpath conflicts; updating to 27.0-jre seems to work fine now, at least with Hadoop 2.7.5 and Spark 2.3.2
* Hadoop default 2.7.3 &rarr; 2.7.5