### PR TITLE
Use build-helper-maven-plugin for build timestamp

### DIFF
--- a/adam-assembly/pom.xml
+++ b/adam-assembly/pom.xml
@@ -11,10 +11,6 @@
   <artifactId>adam-assembly-spark2_2.11</artifactId>
   <packaging>jar</packaging>
   <name>ADAM_${scala.version.prefix}: Assembly</name>
-  <properties>
-    <timestamp>${maven.build.timestamp}</timestamp>
-    <maven.build.timestamp.format>yyyy-MM-dd</maven.build.timestamp.format>
-  </properties>
   <build>
     <plugins>
       <plugin>

--- a/adam-cli/pom.xml
+++ b/adam-cli/pom.xml
@@ -11,10 +11,6 @@
   <artifactId>adam-cli-spark2_2.11</artifactId>
   <packaging>jar</packaging>
   <name>ADAM_${scala.version.prefix}: CLI</name>
-  <properties>
-    <timestamp>${maven.build.timestamp}</timestamp>
-    <maven.build.timestamp.format>yyyy-MM-dd</maven.build.timestamp.format>
-  </properties>
   <build>
     <plugins>
       <plugin>
@@ -98,6 +94,17 @@
               <sources>
                 <source>src/test/scala</source>
               </sources>
+            </configuration>
+          </execution>
+          <execution>
+            <id>timestamp-property</id>
+            <goals>
+              <goal>timestamp-property</goal>
+            </goals>
+            <configuration>
+              <name>build-helper-maven-plugin.build.timestamp</name>
+              <pattern>yyyy-MM-dd</pattern>
+              <locale>en_US</locale>
             </configuration>
           </execution>
         </executions>

--- a/adam-cli/src/main/java-templates/org/bdgenomics/adam/cli/About.java
+++ b/adam-cli/src/main/java-templates/org/bdgenomics/adam/cli/About.java
@@ -22,7 +22,7 @@ package org.bdgenomics.adam.cli;
  */
 public final class About {
     private static final String ARTIFACT_ID = "${project.artifactId}";
-    private static final String BUILD_TIMESTAMP = "${timestamp}";
+    private static final String BUILD_TIMESTAMP = "${build-helper-maven-plugin.build.timestamp}";
     private static final String COMMIT = "${git.commit.id}";
     private static final String HADOOP_VERSION = "${hadoop.version}";
     private static final String SCALA_VERSION = "${scala.version}";

--- a/pom.xml
+++ b/pom.xml
@@ -233,7 +233,7 @@
         <plugin>
           <groupId>org.codehaus.mojo</groupId>
           <artifactId>build-helper-maven-plugin</artifactId>
-          <version>1.12</version>
+          <version>3.0.0</version>
         </plugin>
         <plugin>
           <groupId>org.scalariform</groupId>


### PR DESCRIPTION
Removes the hack necessary to work around issues with `maven.build.timestamp` property.