### PR TITLE
Remove dependency on org.hammerlab:genomic-loci.

### DIFF
--- a/adam-core/pom.xml
+++ b/adam-core/pom.xml
@@ -189,11 +189,6 @@
       <scope>compile</scope>
     </dependency>
     <dependency>
-      <groupId>org.hammerlab</groupId>
-      <artifactId>genomic-loci_${scala.version.prefix}</artifactId>
-      <scope>compile</scope>
-    </dependency>
-    <dependency>
       <groupId>com.esotericsoftware.kryo</groupId>
       <artifactId>kryo</artifactId>
       <scope>compile</scope>

--- a/adam-core/src/test/scala/org/bdgenomics/adam/models/ReferenceRegionSuite.scala
+++ b/adam-core/src/test/scala/org/bdgenomics/adam/models/ReferenceRegionSuite.scala
@@ -39,13 +39,38 @@ class ReferenceRegionSuite extends FunSuite {
     }
   }
 
-  test("can't parse all locus") {
+  test("parse empty string throws IllegalArgumentException") {
     intercept[IllegalArgumentException] {
-      ReferenceRegion.fromString("all")
+      ReferenceRegion.fromString("")
     }
     intercept[IllegalArgumentException] {
-      ReferenceRegion.fromString("1:100-200,all")
+      ReferenceRegion.fromString(" \t")
     }
+    intercept[IllegalArgumentException] {
+      ReferenceRegion.fromString(",, ")
+    }
+  }
+
+  test("parse contigName only string into reference regions") {
+    val loci = ReferenceRegion.fromString("1")
+    assert(loci.size === 1)
+    val ctg1 = loci.filter(_.referenceName == "1")
+    assert(ctg1.size === 1)
+    assert(ctg1.head.start === 0L)
+    assert(ctg1.head.end === Long.MaxValue)
+  }
+
+  test("parse to end strings into reference regions") {
+    val loci = ReferenceRegion.fromString("1:100+,2:101+")
+    assert(loci.size === 2)
+    val ctg1 = loci.filter(_.referenceName == "1")
+    assert(ctg1.size === 1)
+    assert(ctg1.head.start === 100L)
+    assert(ctg1.head.end === Long.MaxValue)
+    val ctg2 = loci.filter(_.referenceName == "2")
+    assert(ctg2.size === 1)
+    assert(ctg2.head.start === 101L)
+    assert(ctg2.head.end === Long.MaxValue)
   }
 
   test("parse string into reference regions") {

--- a/pom.xml
+++ b/pom.xml
@@ -403,17 +403,6 @@
         </exclusions>
       </dependency>
       <dependency>
-        <groupId>org.hammerlab</groupId>
-        <artifactId>genomic-loci_${scala.version.prefix}</artifactId>
-        <version>1.4.4</version>
-        <exclusions>
-          <exclusion>
-            <groupId>org.bdgenomics.bdg-formats</groupId>
-            <artifactId>*</artifactId>
-          </exclusion>
-        </exclusions>
-      </dependency>
-      <dependency>
         <groupId>org.bdgenomics.utils</groupId>
         <artifactId>utils-cli-spark2_${scala.version.prefix}</artifactId>
         <version>${bdg-utils.version}</version>


### PR DESCRIPTION
Re-opened to reduce effort when adding Scala 2.12 support.