### PR TITLE
[ADAM-1986] Add java-specific methods where missing.

### DIFF
--- a/adam-apis/src/main/scala/org/bdgenomics/adam/api/java/JavaADAMContext.scala
+++ b/adam-apis/src/main/scala/org/bdgenomics/adam/api/java/JavaADAMContext.scala
@@ -51,7 +51,7 @@ class JavaADAMContext(val ac: ADAMContext) extends Serializable {
   def getSparkContext: JavaSparkContext = new JavaSparkContext(ac.sc)
 
   /**
-   * Load alignment records into an AlignmentRecordDataset (java-friendly method).
+   * (Java-specific) Load alignment records into an AlignmentRecordDataset.
    *
    * Loads path names ending in:
    * * .bam/.cram/.sam as BAM/CRAM/SAM format,
@@ -79,7 +79,7 @@ class JavaADAMContext(val ac: ADAMContext) extends Serializable {
   }
 
   /**
-   * Load alignment records into an AlignmentRecordDataset (java-friendly method).
+   * (Java-specific) Load alignment records into an AlignmentRecordDataset.
    *
    * Loads path names ending in:
    * * .bam/.cram/.sam as BAM/CRAM/SAM format,
@@ -111,7 +111,7 @@ class JavaADAMContext(val ac: ADAMContext) extends Serializable {
   }
 
   /**
-   * Functions like loadBam, but uses BAM index files to look at fewer blocks,
+   * (Java-specific) Functions like loadBam, but uses BAM index files to look at fewer blocks,
    * and only returns records within the specified ReferenceRegions. BAM index file required.
    *
    * @param pathName The path name to load indexed BAM formatted alignment records from.
@@ -132,7 +132,7 @@ class JavaADAMContext(val ac: ADAMContext) extends Serializable {
   }
 
   /**
-   * Load nucleotide contig fragments into a NucleotideContigFragmentDataset (java-friendly method).
+   * (Java-specific) Load nucleotide contig fragments into a NucleotideContigFragmentDataset.
    *
    * If the path name has a .fa/.fasta extension, load as FASTA format.
    * Else, fall back to Parquet + Avro.
@@ -152,7 +152,7 @@ class JavaADAMContext(val ac: ADAMContext) extends Serializable {
   }
 
   /**
-   * Load fragments into a FragmentDataset (java-friendly method).
+   * (Java-specific) Load fragments into a FragmentDataset.
    *
    * Loads path names ending in:
    * * .bam/.cram/.sam as BAM/CRAM/SAM format and
@@ -175,7 +175,7 @@ class JavaADAMContext(val ac: ADAMContext) extends Serializable {
   }
 
   /**
-   * Load fragments into a FragmentDataset (java-friendly method).
+   * (Java-specific) Load fragments into a FragmentDataset.
    *
    * Loads path names ending in:
    * * .bam/.cram/.sam as BAM/CRAM/SAM format and
@@ -200,7 +200,7 @@ class JavaADAMContext(val ac: ADAMContext) extends Serializable {
   }
 
   /**
-   * Load features into a FeatureDataset (java-friendly method).
+   * (Java-specific) Load features into a FeatureDataset.
    *
    * Loads path names ending in:
    * * .bed as BED6/12 format,
@@ -227,7 +227,7 @@ class JavaADAMContext(val ac: ADAMContext) extends Serializable {
   }
 
   /**
-   * Load features into a FeatureDataset (java-friendly method).
+   * (Java-specific) Load features into a FeatureDataset.
    *
    * Loads path names ending in:
    * * .bed as BED6/12 format,
@@ -257,7 +257,7 @@ class JavaADAMContext(val ac: ADAMContext) extends Serializable {
   }
 
   /**
-   * Load features into a FeatureDataset and convert to a CoverageDataset (java-friendly method).
+   * (Java-specific) Load features into a FeatureDataset and convert to a CoverageDataset.
    * Coverage is stored in the score field of Feature.
    *
    * Loads path names ending in:
@@ -285,7 +285,7 @@ class JavaADAMContext(val ac: ADAMContext) extends Serializable {
   }
 
   /**
-   * Load features into a FeatureDataset and convert to a CoverageDataset (java-friendly method).
+   * (Java-specific) Load features into a FeatureDataset and convert to a CoverageDataset.
    * Coverage is stored in the score field of Feature.
    *
    * Loads path names ending in:
@@ -317,7 +317,7 @@ class JavaADAMContext(val ac: ADAMContext) extends Serializable {
   }
 
   /**
-   * Load genotypes into a GenotypeDataset (java-friendly method).
+   * (Java-specific) Load genotypes into a GenotypeDataset.
    *
    * If the path name has a .vcf/.vcf.gz/.vcf.bgzf/.vcf.bgz extension, load as VCF format.
    * Else, fall back to Parquet + Avro.
@@ -334,7 +334,7 @@ class JavaADAMContext(val ac: ADAMContext) extends Serializable {
   }
 
   /**
-   * Load genotypes into a GenotypeDataset (java-friendly method).
+   * (Java-specific) Load genotypes into a GenotypeDataset.
    *
    * If the path name has a .vcf/.vcf.gz/.vcf.bgzf/.vcf.bgz extension, load as VCF format.
    * Else, fall back to Parquet + Avro.
@@ -354,7 +354,7 @@ class JavaADAMContext(val ac: ADAMContext) extends Serializable {
   }
 
   /**
-   * Load variants into a VariantDataset (java-friendly method).
+   * (Java-specific) Load variants into a VariantDataset.
    *
    * If the path name has a .vcf/.vcf.gz/.vcf.bgzf/.vcf.bgz extension, load as VCF format.
    * Else, fall back to Parquet + Avro.
@@ -370,7 +370,7 @@ class JavaADAMContext(val ac: ADAMContext) extends Serializable {
   }
 
   /**
-   * Load variants into a VariantDataset (java-friendly method).
+   * (Java-specific) Load variants into a VariantDataset.
    *
    * If the path name has a .vcf/.vcf.gz/.vcf.bgzf/.vcf.bgz extension, load as VCF format.
    * Else, fall back to Parquet + Avro.
@@ -388,7 +388,7 @@ class JavaADAMContext(val ac: ADAMContext) extends Serializable {
   }
 
   /**
-   * Load reference sequences into a broadcastable ReferenceFile (java-friendly method).
+   * (Java-specific) Load reference sequences into a broadcastable ReferenceFile.
    *
    * If the path name has a .2bit extension, loads a 2bit file. Else, uses loadContigFragments
    * to load the reference as an RDD, which is then collected to the driver.
@@ -407,7 +407,7 @@ class JavaADAMContext(val ac: ADAMContext) extends Serializable {
   }
 
   /**
-   * Load reference sequences into a broadcastable ReferenceFile (java-friendly method).
+   * (Java-specific) Load reference sequences into a broadcastable ReferenceFile.
    *
    * If the path name has a .2bit extension, loads a 2bit file. Else, uses loadContigFragments
    * to load the reference as an RDD, which is then collected to the driver. Uses a

--- a/adam-core/src/main/scala/org/bdgenomics/adam/rdd/GenomicDataset.scala
+++ b/adam-core/src/main/scala/org/bdgenomics/adam/rdd/GenomicDataset.scala
@@ -148,7 +148,7 @@ trait GenomicDataset[T, U <: Product, V <: GenomicDataset[T, U, V]] extends Logg
   }
 
   /**
-   * Applies a function that transforms the underlying Dataset into a new Dataset
+   * (Scala-specific) Applies a function that transforms the underlying Dataset into a new Dataset
    * using the Spark SQL API.
    *
    * @param tFn A function that transforms the underlying Dataset as a Dataset.
@@ -158,7 +158,17 @@ trait GenomicDataset[T, U <: Product, V <: GenomicDataset[T, U, V]] extends Logg
   def transformDataset(tFn: Dataset[U] => Dataset[U]): V
 
   /**
-   * Applies a function that transforms the underlying DataFrame into a new DataFrame
+   * (Java-specific) Applies a function that transforms the underlying Dataset into a new Dataset
+   * using the Spark SQL API.
+   *
+   * @param tFn A function that transforms the underlying Dataset as a Dataset.
+   * @return A new genomic dataset where the Dataset of genomic data has been replaced, but the
+   *   metadata (sequence dictionary, and etc) are copied without modification.
+   */
+  def transformDataset(tFn: JFunction[Dataset[U], Dataset[U]]): V
+
+  /**
+   * (Scala-specific) Applies a function that transforms the underlying DataFrame into a new DataFrame
    * using the Spark SQL API.
    *
    * @param tFn A function that transforms the underlying data as a DataFrame.
@@ -175,8 +185,8 @@ trait GenomicDataset[T, U <: Product, V <: GenomicDataset[T, U, V]] extends Logg
   }
 
   /**
-   * Applies a function that transforms the underlying DataFrame into a new DataFrame
-   * using the Spark SQL API. Java-friendly variant.
+   * (Java-specific) Applies a function that transforms the underlying DataFrame into a new DataFrame
+   * using the Spark SQL API.
    *
    * @param tFn A function that transforms the underlying DataFrame as a DataFrame.
    * @return A new genomic dataset where the DataFrame of genomic data has been replaced, but the
@@ -189,7 +199,7 @@ trait GenomicDataset[T, U <: Product, V <: GenomicDataset[T, U, V]] extends Logg
   }
 
   /**
-   * Applies a function that transmutes the underlying Dataset into a new Dataset of a
+   * (Scala-specific) Applies a function that transmutes the underlying Dataset into a new Dataset of a
    * different type.
    *
    * @param tFn A function that transforms the underlying Dataset.
@@ -204,8 +214,8 @@ trait GenomicDataset[T, U <: Product, V <: GenomicDataset[T, U, V]] extends Logg
   }
 
   /**
-   * Applies a function that transmutes the underlying Dataset into a new Dataset of a
-   * different type. Java friendly variant.
+   * (Java-specific) Applies a function that transmutes the underlying Dataset into a new Dataset of a
+   * different type.
    *
    * @param tFn A function that transforms the underlying Dataset.
    * @return A new genomic dataset where the Dataset of genomic data has been replaced, but the
@@ -220,8 +230,8 @@ trait GenomicDataset[T, U <: Product, V <: GenomicDataset[T, U, V]] extends Logg
   }
 
   /**
-   * Applies a function that transmutes the underlying DataFrame into a new DataFrame of a
-   * different type. Java friendly variant.
+   * (Java-specific) Applies a function that transmutes the underlying DataFrame into a new DataFrame of a
+   * different type.
    *
    * @param tFn A function that transforms the underlying DataFrame.
    * @return A new genomic dataset where the DataFrame of genomic data has been replaced, but the
@@ -239,8 +249,8 @@ trait GenomicDataset[T, U <: Product, V <: GenomicDataset[T, U, V]] extends Logg
   }
 
   /**
-   * Applies a function that transmutes the underlying DataFrame into a new DataFrame of a
-   * different type. Java friendly variant.
+   * (Java-specific) Applies a function that transmutes the underlying DataFrame into a new DataFrame of a
+   * different type.
    *
    * @param tFn A function that transforms the underlying DataFrame.
    * @return A new genomic dataset where the DataFrame of genomic data has been replaced, but the
@@ -347,7 +357,6 @@ trait GenomicDataset[T, U <: Product, V <: GenomicDataset[T, U, V]] extends Logg
    *
    * @param pathName The path to save the partitioned Parquet flag file to.
    * @param partitionSize Partition bin size, in base pairs, used in Hive-style partitioning.
-   *
    */
   private def writePartitionedParquetFlag(pathName: String, partitionSize: Int): Unit = {
     val path = new Path(pathName, "_partitionedByStartPos")
@@ -470,14 +479,14 @@ trait GenomicDataset[T, U <: Product, V <: GenomicDataset[T, U, V]] extends Logg
   }
 
   /**
-   * Unions together multiple genomic datasets.
+   * (Scala-specific) Unions together multiple genomic datasets.
    *
    * @param datasets Genomic datasets to union with this genomic dataset.
    */
   def union(datasets: V*): V
 
   /**
-   * Unions together multiple genomic datasets.
+   * (Java-specific) Unions together multiple genomic datasets.
    *
    * @param datasets Genomic datasets to union with this genomic dataset.
    */
@@ -487,7 +496,7 @@ trait GenomicDataset[T, U <: Product, V <: GenomicDataset[T, U, V]] extends Logg
   }
 
   /**
-   * Applies a function that transforms the underlying RDD into a new RDD.
+   * (Scala-specific) Applies a function that transforms the underlying RDD into a new RDD.
    *
    * @param tFn A function that transforms the underlying RDD.
    * @return A new genomic dataset where the RDD of genomic data has been replaced, but the
@@ -498,8 +507,7 @@ trait GenomicDataset[T, U <: Product, V <: GenomicDataset[T, U, V]] extends Logg
   }
 
   /**
-   * Applies a function that transforms the underlying RDD into a new RDD.
-   * Java friendly variant.
+   * (Java-specific) Applies a function that transforms the underlying RDD into a new RDD.
    *
    * @param tFn A function that transforms the underlying RDD.
    * @return A new genomic dataset where the RDD of genomic data has been replaced, but the
@@ -510,7 +518,7 @@ trait GenomicDataset[T, U <: Product, V <: GenomicDataset[T, U, V]] extends Logg
   }
 
   /**
-   * Applies a function that transmutes the underlying RDD into a new RDD of a
+   * (Scala-specific) Applies a function that transmutes the underlying RDD into a new RDD of a
    * different type.
    *
    * @param tFn A function that transforms the underlying RDD.
@@ -523,8 +531,8 @@ trait GenomicDataset[T, U <: Product, V <: GenomicDataset[T, U, V]] extends Logg
   }
 
   /**
-   * Applies a function that transmutes the underlying RDD into a new RDD of a
-   * different type. Java friendly variant.
+   * (Java-specific) Applies a function that transmutes the underlying RDD into a new RDD of a
+   * different type.
    *
    * @param tFn A function that transforms the underlying RDD.
    * @param convFn The conversion function used to build the final RDD.
@@ -692,7 +700,7 @@ trait GenomicDataset[T, U <: Product, V <: GenomicDataset[T, U, V]] extends Logg
    *
    * @param partitions The number of partitions for the new genomic dataset.
    * @param storePartitionMap A Boolean flag to determine whether to store the
-   *                          partition bounds from the resulting genomic dataset.
+   *   partition bounds from the resulting genomic dataset.
    * @param storageLevel The level at which to persist the resulting genomic dataset.
    * @param stringency The level of ValidationStringency to enforce.
    * @return Returns a new genomic dataset containing sorted data.
@@ -741,7 +749,7 @@ trait GenomicDataset[T, U <: Product, V <: GenomicDataset[T, U, V]] extends Logg
   }
 
   /**
-   * Pipes genomic data to a subprocess that runs in parallel using Spark.
+   * (Scala-specific) Pipes genomic data to a subprocess that runs in parallel using Spark.
    *
    * Files are substituted in to the command with a $x syntax. E.g., to invoke
    * a command that uses the first file from the files Seq, use $0. To access
@@ -905,9 +913,7 @@ trait GenomicDataset[T, U <: Product, V <: GenomicDataset[T, U, V]] extends Logg
   }
 
   /**
-   * Pipes genomic data to a subprocess that runs in parallel using Spark.
-   *
-   * SparkR friendly variant.
+   * (R-specific) Pipes genomic data to a subprocess that runs in parallel using Spark.
    *
    * @param cmd Command to run.
    * @param files Files to make locally available to the commands being run.
@@ -944,9 +950,7 @@ trait GenomicDataset[T, U <: Product, V <: GenomicDataset[T, U, V]] extends Logg
   }
 
   /**
-   * Pipes genomic data to a subprocess that runs in parallel using Spark.
-   *
-   * Java/PySpark friendly variant.
+   * (Java/Python-specific) Pipes genomic data to a subprocess that runs in parallel using Spark.
    *
    * @param cmd Command to run.
    * @param files Files to make locally available to the commands being run.
@@ -1035,7 +1039,7 @@ trait GenomicDataset[T, U <: Product, V <: GenomicDataset[T, U, V]] extends Logg
   }
 
   /**
-   * Runs a filter that selects data in the underlying RDD that overlaps
+   * (Scala-specific) Runs a filter that selects data in the underlying RDD that overlaps
    * several genomic regions.
    *
    * @param querys The regions to query for.
@@ -1054,8 +1058,8 @@ trait GenomicDataset[T, U <: Product, V <: GenomicDataset[T, U, V]] extends Logg
   }
 
   /**
-   * Runs a filter that selects data in the underlying RDD that overlaps
-   * several genomic regions. Java friendly version.
+   * (Java-specific) Runs a filter that selects data in the underlying RDD that overlaps
+   * several genomic regions.
    *
    * @param querys The regions to query for.
    * @return Returns a new GenomicDataset containing only data that overlaps the
@@ -1083,13 +1087,13 @@ trait GenomicDataset[T, U <: Product, V <: GenomicDataset[T, U, V]] extends Logg
   }
 
   /**
-   * Performs a broadcast inner join between this genomic dataset and another genomic dataset.
+   * (R-specific) Performs a broadcast inner join between this genomic dataset and another genomic dataset.
    *
    * In a broadcast join, the left genomic dataset (this genomic dataset) is collected to the driver,
    * and broadcast to all the nodes in the cluster. The key equality function
    * used for this join is the reference region overlap function. Since this
    * is an inner join, all values who do not overlap a value from the other
-   * genomic dataset are dropped. SparkR friendly version.
+   * genomic dataset are dropped.
    *
    * @param genomicDataset The right genomic dataset in the join.
    * @param flankSize Sets a flankSize for the distance between elements to be
@@ -1105,13 +1109,13 @@ trait GenomicDataset[T, U <: Product, V <: GenomicDataset[T, U, V]] extends Logg
   }
 
   /**
-   * Performs a broadcast inner join between this genomic dataset and another genomic dataset.
+   * (Java-specific) Performs a broadcast inner join between this genomic dataset and another genomic dataset.
    *
    * In a broadcast join, the left genomic dataset (this genomic dataset) is collected to the driver,
    * and broadcast to all the nodes in the cluster. The key equality function
    * used for this join is the reference region overlap function. Since this
    * is an inner join, all values who do not overlap a value from the other
-   * genomic dataset are dropped. Python/Java friendly version.
+   * genomic dataset are dropped.
    *
    * @param genomicDataset The right genomic dataset in the join.
    * @param flankSize Sets a flankSize for the distance between elements to be
@@ -1237,7 +1241,7 @@ trait GenomicDataset[T, U <: Product, V <: GenomicDataset[T, U, V]] extends Logg
   }
 
   /**
-   * Performs a broadcast right outer join between this genomic dataset and another genomic dataset.
+   * (R-specific) Performs a broadcast right outer join between this genomic dataset and another genomic dataset.
    *
    * In a broadcast join, the left genomic dataset (this genomic dataset) is collected to the driver,
    * and broadcast to all the nodes in the cluster. The key equality function
@@ -1245,7 +1249,7 @@ trait GenomicDataset[T, U <: Product, V <: GenomicDataset[T, U, V]] extends Logg
    * is a right outer join, all values in the left genomic dataset that do not overlap a
    * value from the right genomic dataset are dropped. If a value from the right genomic dataset does
    * not overlap any values in the left genomic dataset, it will be paired with a `None`
-   * in the product of the join. SparkR friendly version.
+   * in the product of the join.
    *
    * @param genomicDataset The right genomic dataset in the join.
    * @param flankSize Sets a flankSize for the distance between elements to be
@@ -1262,7 +1266,7 @@ trait GenomicDataset[T, U <: Product, V <: GenomicDataset[T, U, V]] extends Logg
   }
 
   /**
-   * Performs a broadcast right outer join between this genomic dataset and another genomic dataset.
+   * (Java-specific) Performs a broadcast right outer join between this genomic dataset and another genomic dataset.
    *
    * In a broadcast join, the left genomic dataset (this genomic dataset) is collected to the driver,
    * and broadcast to all the nodes in the cluster. The key equality function
@@ -1270,7 +1274,7 @@ trait GenomicDataset[T, U <: Product, V <: GenomicDataset[T, U, V]] extends Logg
    * is a right outer join, all values in the left genomic dataset that do not overlap a
    * value from the right genomic dataset are dropped. If a value from the right genomic dataset does
    * not overlap any values in the left genomic dataset, it will be paired with a `None`
-   * in the product of the join. PySpark/Java friendly version.
+   * in the product of the join.
    *
    * @param genomicDataset The right genomic dataset in the join.
    * @param flankSize Sets a flankSize for the distance between elements to be
@@ -1405,13 +1409,13 @@ trait GenomicDataset[T, U <: Product, V <: GenomicDataset[T, U, V]] extends Logg
   }
 
   /**
-   * Performs a broadcast inner join between this genomic dataset and another genomic dataset.
+   * (R-specific) Performs a broadcast inner join between this genomic dataset and another genomic dataset.
    *
    * In a broadcast join, the left genomic dataset (this genomic dataset) is collected to the driver,
    * and broadcast to all the nodes in the cluster. The key equality function
    * used for this join is the reference region overlap function. Since this
    * is an inner join, all values who do not overlap a value from the other
-   * genomic dataset are dropped. SparkR friendly variant.
+   * genomic dataset are dropped.
    *
    * @param genomicDataset The right genomic dataset in the join.
    * @param flankSize Sets a flankSize for the distance between elements to be
@@ -1429,13 +1433,13 @@ trait GenomicDataset[T, U <: Product, V <: GenomicDataset[T, U, V]] extends Logg
   }
 
   /**
-   * Performs a broadcast inner join between this genomic dataset and another genomic dataset.
+   * (Java-specific) Performs a broadcast inner join between this genomic dataset and another genomic dataset.
    *
    * In a broadcast join, the left genomic dataset (this genomic dataset) is collected to the driver,
    * and broadcast to all the nodes in the cluster. The key equality function
    * used for this join is the reference region overlap function. Since this
    * is an inner join, all values who do not overlap a value from the other
-   * genomic dataset are dropped. PySpark/Java friendly variant.
+   * genomic dataset are dropped.
    *
    * @param genomicDataset The right genomic dataset in the join.
    * @param flankSize Sets a flankSize for the distance between elements to be
@@ -1566,7 +1570,7 @@ trait GenomicDataset[T, U <: Product, V <: GenomicDataset[T, U, V]] extends Logg
   }
 
   /**
-   * Performs a broadcast right outer join between this genomic dataset and another genomic dataset.
+   * (R-specific) Performs a broadcast right outer join between this genomic dataset and another genomic dataset.
    *
    * In a broadcast join, the left side of the join (broadcastTree) is broadcast to
    * to all the nodes in the cluster. The key equality function
@@ -1574,7 +1578,7 @@ trait GenomicDataset[T, U <: Product, V <: GenomicDataset[T, U, V]] extends Logg
    * is a right outer join, all values in the left genomic dataset that do not overlap a
    * value from the right genomic dataset are dropped. If a value from the right genomic dataset does
    * not overlap any values in the left genomic dataset, it will be paired with a `None`
-   * in the product of the join. SparkR friendly variant.
+   * in the product of the join.
    *
    * @param genomicDataset The right genomic dataset in the join.
    * @param flankSize Sets a flankSize for the distance between elements to be
@@ -1593,7 +1597,7 @@ trait GenomicDataset[T, U <: Product, V <: GenomicDataset[T, U, V]] extends Logg
   }
 
   /**
-   * Performs a broadcast right outer join between this genomic dataset and another genomic dataset.
+   * (Java-specific) Performs a broadcast right outer join between this genomic dataset and another genomic dataset.
    *
    * In a broadcast join, the left side of the join (broadcastTree) is broadcast to
    * to all the nodes in the cluster. The key equality function
@@ -1601,7 +1605,7 @@ trait GenomicDataset[T, U <: Product, V <: GenomicDataset[T, U, V]] extends Logg
    * is a right outer join, all values in the left genomic dataset that do not overlap a
    * value from the right genomic dataset are dropped. If a value from the right genomic dataset does
    * not overlap any values in the left genomic dataset, it will be paired with a `None`
-   * in the product of the join. PySpark/Java friendly variant.
+   * in the product of the join.
    *
    * @param genomicDataset The right genomic dataset in the join.
    * @param flankSize Sets a flankSize for the distance between elements to be
@@ -1773,13 +1777,13 @@ trait GenomicDataset[T, U <: Product, V <: GenomicDataset[T, U, V]] extends Logg
   }
 
   /**
-   * Performs a sort-merge inner join between this genomic dataset and another genomic dataset.
+   * (R-specific) Performs a sort-merge inner join between this genomic dataset and another genomic dataset.
    *
    * In a sort-merge join, both genomic datasets are co-partitioned and sorted. The
    * partitions are then zipped, and we do a merge join on each partition.
    * The key equality function used for this join is the reference region
    * overlap function. Since this is an inner join, all values who do not
-   * overlap a value from the other genomic dataset are dropped. SparkR friendly variant.
+   * overlap a value from the other genomic dataset are dropped.
    *
    * @param genomicDataset The right genomic dataset in the join.
    * @param flankSize Sets a flankSize for the distance between elements to be
@@ -1795,14 +1799,13 @@ trait GenomicDataset[T, U <: Product, V <: GenomicDataset[T, U, V]] extends Logg
   }
 
   /**
-   * Performs a sort-merge inner join between this genomic dataset and another genomic dataset.
+   * (Java-specific) Performs a sort-merge inner join between this genomic dataset and another genomic dataset.
    *
    * In a sort-merge join, both genomic datasets are co-partitioned and sorted. The
    * partitions are then zipped, and we do a merge join on each partition.
    * The key equality function used for this join is the reference region
    * overlap function. Since this is an inner join, all values who do not
-   * overlap a value from the other genomic dataset are dropped. PySpark/Java friendly
-   * variant.
+   * overlap a value from the other genomic dataset are dropped.
    *
    * @param genomicDataset The right genomic dataset in the join.
    * @param flankSize Sets a flankSize for the distance between elements to be
@@ -1920,7 +1923,7 @@ trait GenomicDataset[T, U <: Product, V <: GenomicDataset[T, U, V]] extends Logg
   }
 
   /**
-   * Performs a sort-merge right outer join between this genomic dataset and another genomic dataset.
+   * (R-specific) Performs a sort-merge right outer join between this genomic dataset and another genomic dataset.
    *
    * In a sort-merge join, both genomic datasets are co-partitioned and sorted. The
    * partitions are then zipped, and we do a merge join on each partition.
@@ -1928,8 +1931,7 @@ trait GenomicDataset[T, U <: Product, V <: GenomicDataset[T, U, V]] extends Logg
    * overlap function. Since this is a right outer join, all values in the
    * left genomic dataset that do not overlap a value from the right genomic dataset are dropped.
    * If a value from the right genomic dataset does not overlap any values in the left
-   * genomic dataset, it will be paired with a `None` in the product of the join. SparkR
-   * friendly variant.
+   * genomic dataset, it will be paired with a `None` in the product of the join.
    *
    * @param genomicDataset The right genomic dataset in the join.
    * @param flankSize Sets a flankSize for the distance between elements to be
@@ -1946,7 +1948,7 @@ trait GenomicDataset[T, U <: Product, V <: GenomicDataset[T, U, V]] extends Logg
   }
 
   /**
-   * Performs a sort-merge right outer join between this genomic dataset and another genomic dataset.
+   * (Java-specific) Performs a sort-merge right outer join between this genomic dataset and another genomic dataset.
    *
    * In a sort-merge join, both genomic datasets are co-partitioned and sorted. The
    * partitions are then zipped, and we do a merge join on each partition.
@@ -1955,7 +1957,6 @@ trait GenomicDataset[T, U <: Product, V <: GenomicDataset[T, U, V]] extends Logg
    * left genomic dataset that do not overlap a value from the right genomic dataset are dropped.
    * If a value from the right genomic dataset does not overlap any values in the left
    * genomic dataset, it will be paired with a `None` in the product of the join.
-   * PySpark/Java friendly variant.
    *
    * @param genomicDataset The right genomic dataset in the join.
    * @param flankSize Sets a flankSize for the distance between elements to be
@@ -2085,7 +2086,7 @@ trait GenomicDataset[T, U <: Product, V <: GenomicDataset[T, U, V]] extends Logg
   }
 
   /**
-   * Performs a sort-merge left outer join between this genomic dataset and another genomic dataset.
+   * (R-specific) Performs a sort-merge left outer join between this genomic dataset and another genomic dataset.
    *
    * In a sort-merge join, both genomic datasets are co-partitioned and sorted. The
    * partitions are then zipped, and we do a merge join on each partition.
@@ -2093,8 +2094,7 @@ trait GenomicDataset[T, U <: Product, V <: GenomicDataset[T, U, V]] extends Logg
    * overlap function. Since this is a left outer join, all values in the
    * right genomic dataset that do not overlap a value from the left genomic dataset are dropped.
    * If a value from the left genomic dataset does not overlap any values in the right
-   * genomic dataset, it will be paired with a `None` in the product of the join. SparkR
-   * friendly variant.
+   * genomic dataset, it will be paired with a `None` in the product of the join.
    *
    * @param genomicDataset The right genomic dataset in the join.
    * @param flankSize Sets a flankSize for the distance between elements to be
@@ -2111,7 +2111,7 @@ trait GenomicDataset[T, U <: Product, V <: GenomicDataset[T, U, V]] extends Logg
   }
 
   /**
-   * Performs a sort-merge left outer join between this genomic dataset and another genomic dataset.
+   * (Java-specific) Performs a sort-merge left outer join between this genomic dataset and another genomic dataset.
    *
    * In a sort-merge join, both genomic datasets are co-partitioned and sorted. The
    * partitions are then zipped, and we do a merge join on each partition.
@@ -2120,7 +2120,6 @@ trait GenomicDataset[T, U <: Product, V <: GenomicDataset[T, U, V]] extends Logg
    * right genomic dataset that do not overlap a value from the left genomic dataset are dropped.
    * If a value from the left genomic dataset does not overlap any values in the right
    * genomic dataset, it will be paired with a `None` in the product of the join.
-   * PySpark/Java friendly variant.
    *
    * @param genomicDataset The right genomic dataset in the join.
    * @param flankSize Sets a flankSize for the distance between elements to be
@@ -2248,7 +2247,7 @@ trait GenomicDataset[T, U <: Product, V <: GenomicDataset[T, U, V]] extends Logg
   }
 
   /**
-   * Performs a sort-merge left outer join between this genomic dataset and another genomic dataset,
+   * (R-specific) Performs a sort-merge left outer join between this genomic dataset and another genomic dataset,
    * followed by a groupBy on the left value.
    *
    * In a sort-merge join, both genomic datasets are co-partitioned and sorted. The
@@ -2258,7 +2257,6 @@ trait GenomicDataset[T, U <: Product, V <: GenomicDataset[T, U, V]] extends Logg
    * right genomic dataset that do not overlap a value from the left genomic dataset are dropped.
    * If a value from the left genomic dataset does not overlap any values in the right
    * genomic dataset, it will be paired with an empty Iterable in the product of the join.
-   * SparkR friendly variant.
    *
    * @param genomicDataset The right genomic dataset in the join.
    * @param flankSize Sets a flankSize for the distance between elements to be
@@ -2275,7 +2273,7 @@ trait GenomicDataset[T, U <: Product, V <: GenomicDataset[T, U, V]] extends Logg
   }
 
   /**
-   * Performs a sort-merge left outer join between this genomic dataset and another genomic dataset,
+   * (Java-specific) Performs a sort-merge left outer join between this genomic dataset and another genomic dataset,
    * followed by a groupBy on the left value.
    *
    * In a sort-merge join, both genomic datasets are co-partitioned and sorted. The
@@ -2285,7 +2283,6 @@ trait GenomicDataset[T, U <: Product, V <: GenomicDataset[T, U, V]] extends Logg
    * right genomic dataset that do not overlap a value from the left genomic dataset are dropped.
    * If a value from the left genomic dataset does not overlap any values in the right
    * genomic dataset, it will be paired with an empty Iterable in the product of the join.
-   * PySpark/Java friendly variant.
    *
    * @param genomicDataset The right genomic dataset in the join.
    * @param flankSize Sets a flankSize for the distance between elements to be
@@ -2416,14 +2413,14 @@ trait GenomicDataset[T, U <: Product, V <: GenomicDataset[T, U, V]] extends Logg
   }
 
   /**
-   * Performs a sort-merge full outer join between this genomic dataset and another genomic dataset.
+   * (R-specific) Performs a sort-merge full outer join between this genomic dataset and another genomic dataset.
    *
    * In a sort-merge join, both genomic datasets are co-partitioned and sorted. The
    * partitions are then zipped, and we do a merge join on each partition.
    * The key equality function used for this join is the reference region
    * overlap function. Since this is a full outer join, if a value from either
    * genomic dataset does not overlap any values in the other genomic dataset, it will be paired with
-   * a `None` in the product of the join. SparkR friendly variant.
+   * a `None` in the product of the join.
    *
    * @param genomicDataset The right genomic dataset in the join.
    * @param flankSize Sets a flankSize for the distance between elements to be
@@ -2440,14 +2437,14 @@ trait GenomicDataset[T, U <: Product, V <: GenomicDataset[T, U, V]] extends Logg
   }
 
   /**
-   * Performs a sort-merge full outer join between this genomic dataset and another genomic dataset.
+   * (Python-specific) Performs a sort-merge full outer join between this genomic dataset and another genomic dataset.
    *
    * In a sort-merge join, both genomic datasets are co-partitioned and sorted. The
    * partitions are then zipped, and we do a merge join on each partition.
    * The key equality function used for this join is the reference region
    * overlap function. Since this is a full outer join, if a value from either
    * genomic dataset does not overlap any values in the other genomic dataset, it will be paired with
-   * a `None` in the product of the join. PySpark/Java friendly variant.
+   * a `None` in the product of the join.
    *
    * @param genomicDataset The right genomic dataset in the join.
    * @param flankSize Sets a flankSize for the distance between elements to be
@@ -2572,14 +2569,14 @@ trait GenomicDataset[T, U <: Product, V <: GenomicDataset[T, U, V]] extends Logg
   }
 
   /**
-   * Performs a sort-merge inner join between this genomic dataset and another genomic dataset,
+   * (R-specific) Performs a sort-merge inner join between this genomic dataset and another genomic dataset,
    * followed by a groupBy on the left value.
    *
    * In a sort-merge join, both genomic datasets are co-partitioned and sorted. The
    * partitions are then zipped, and we do a merge join on each partition.
    * The key equality function used for this join is the reference region
    * overlap function. In the same operation, we group all values by the left
-   * item in the genomic dataset. SparkR friendly variant.
+   * item in the genomic dataset.
    *
    * @param genomicDataset The right genomic dataset in the join.
    * @param flankSize Sets a flankSize for the distance between elements to be
@@ -2596,14 +2593,14 @@ trait GenomicDataset[T, U <: Product, V <: GenomicDataset[T, U, V]] extends Logg
   }
 
   /**
-   * Performs a sort-merge inner join between this genomic dataset and another genomic dataset,
+   * (Java-specific) Performs a sort-merge inner join between this genomic dataset and another genomic dataset,
    * followed by a groupBy on the left value.
    *
    * In a sort-merge join, both genomic datasets are co-partitioned and sorted. The
    * partitions are then zipped, and we do a merge join on each partition.
    * The key equality function used for this join is the reference region
    * overlap function. In the same operation, we group all values by the left
-   * item in the genomic dataset. PySpark/Java friendly variant.
+   * item in the genomic dataset.
    *
    * @param genomicDataset The right genomic dataset in the join.
    * @param flankSize Sets a flankSize for the distance between elements to be
@@ -2732,7 +2729,7 @@ trait GenomicDataset[T, U <: Product, V <: GenomicDataset[T, U, V]] extends Logg
   }
 
   /**
-   * Performs a sort-merge right outer join between this genomic dataset and another genomic dataset,
+   * (R-specific) Performs a sort-merge right outer join between this genomic dataset and another genomic dataset,
    * followed by a groupBy on the left value, if not null.
    *
    * In a sort-merge join, both genomic datasets are co-partitioned and sorted. The
@@ -2741,7 +2738,7 @@ trait GenomicDataset[T, U <: Product, V <: GenomicDataset[T, U, V]] extends Logg
    * overlap function. In the same operation, we group all values by the left
    * item in the genomic dataset. Since this is a right outer join, all values from the
    * right genomic dataset who did not overlap a value from the left genomic dataset are placed into
-   * a length-1 Iterable with a `None` key. SparkR friendly variant.
+   * a length-1 Iterable with a `None` key.
    *
    * @param genomicDataset The right genomic dataset in the join.
    * @param flankSize Sets a flankSize for the distance between elements to be
@@ -2759,7 +2756,7 @@ trait GenomicDataset[T, U <: Product, V <: GenomicDataset[T, U, V]] extends Logg
   }
 
   /**
-   * Performs a sort-merge right outer join between this genomic dataset and another genomic dataset,
+   * (Java-specific) Performs a sort-merge right outer join between this genomic dataset and another genomic dataset,
    * followed by a groupBy on the left value, if not null.
    *
    * In a sort-merge join, both genomic datasets are co-partitioned and sorted. The
@@ -2768,7 +2765,7 @@ trait GenomicDataset[T, U <: Product, V <: GenomicDataset[T, U, V]] extends Logg
    * overlap function. In the same operation, we group all values by the left
    * item in the genomic dataset. Since this is a right outer join, all values from the
    * right genomic dataset who did not overlap a value from the left genomic dataset are placed into
-   * a length-1 Iterable with a `None` key. PySpark/Java friendly variant.
+   * a length-1 Iterable with a `None` key.
    *
    * @param genomicDataset The right genomic dataset in the join.
    * @param flankSize Sets a flankSize for the distance between elements to be
@@ -3194,8 +3191,15 @@ case class DatasetBoundGenericGenomicDataset[T, U <: Product](
 
   // this cannot be in the GenericGenomicDataset trait due to need for the
   // implicit classtag
-  def transformDataset(tFn: Dataset[U] => Dataset[U]): GenericGenomicDataset[T, U] = {
+  override def transformDataset(tFn: Dataset[U] => Dataset[U]): GenericGenomicDataset[T, U] = {
     DatasetBoundGenericGenomicDataset(tFn(dataset),
+      sequences,
+      converter,
+      tagHolder)
+  }
+
+  override def transformDataset(tFn: JFunction[Dataset[U], Dataset[U]]): GenericGenomicDataset[T, U] = {
+    DatasetBoundGenericGenomicDataset(tFn.call(dataset),
       sequences,
       converter,
       tagHolder)
@@ -3254,8 +3258,15 @@ case class RDDBoundGenericGenomicDataset[T, U <: Product](
 
   // this cannot be in the GenericGenomicDataset trait due to need for the
   // implicit classtag
-  def transformDataset(tFn: Dataset[U] => Dataset[U]): GenericGenomicDataset[T, U] = {
+  override def transformDataset(tFn: Dataset[U] => Dataset[U]): GenericGenomicDataset[T, U] = {
     DatasetBoundGenericGenomicDataset(tFn(dataset),
+      sequences,
+      converter,
+      tagHolder)
+  }
+
+  override def transformDataset(tFn: JFunction[Dataset[U], Dataset[U]]): GenericGenomicDataset[T, U] = {
+    DatasetBoundGenericGenomicDataset(tFn.call(dataset),
       sequences,
       converter,
       tagHolder)
@@ -3513,7 +3524,7 @@ private[rdd] trait VCFSupportingGenomicDataset[T, U <: Product, V <: VCFSupporti
   }
 
   /**
-   * Adds a VCF header line describing an array format field, with fixed count.
+   * (Scala-specific) Adds a VCF header line describing an array format field, with fixed count.
    *
    * @param id The identifier for the field.
    * @param count The number of elements in the array.
@@ -3529,9 +3540,7 @@ private[rdd] trait VCFSupportingGenomicDataset[T, U <: Product, V <: VCFSupporti
   }
 
   /**
-   * Adds a VCF header line describing an array format field, with fixed count.
-   *
-   * Java friendly variant.
+   * (Java-specific) Adds a VCF header line describing an array format field, with fixed count.
    *
    * @param id The identifier for the field.
    * @param count The number of elements in the array.
@@ -3631,7 +3640,7 @@ private[rdd] trait VCFSupportingGenomicDataset[T, U <: Product, V <: VCFSupporti
   }
 
   /**
-   * Adds a VCF header line describing an array info field, with fixed count.
+   * (Scala-specific) Adds a VCF header line describing an array info field, with fixed count.
    *
    * @param id The identifier for the field.
    * @param count The number of elements in the array.
@@ -3647,9 +3656,7 @@ private[rdd] trait VCFSupportingGenomicDataset[T, U <: Product, V <: VCFSupporti
   }
 
   /**
-   * Adds a VCF header line describing an array info field, with fixed count.
-   *
-   * Java friendly variant.
+   * (Java-specific) Adds a VCF header line describing an array info field, with fixed count.
    *
    * @param id The identifier for the field.
    * @param count The number of elements in the array.
@@ -3880,7 +3887,7 @@ abstract class AvroGenomicDataset[T <% IndexedRecord: Manifest, U <: Product, V 
   }
 
   /**
-   * Saves this genomic dataset to disk as a Parquet file.
+   * (Java-specific) Saves this genomic dataset to disk as a Parquet file.
    *
    * @param pathName Path to save the file at.
    * @param blockSize The size in bytes of blocks to write.

--- a/adam-core/src/main/scala/org/bdgenomics/adam/rdd/feature/CoverageDataset.scala
+++ b/adam-core/src/main/scala/org/bdgenomics/adam/rdd/feature/CoverageDataset.scala
@@ -21,6 +21,7 @@ import com.esotericsoftware.kryo.Kryo
 import com.esotericsoftware.kryo.serializers.FieldSerializer
 import org.apache.parquet.hadoop.metadata.CompressionCodecName
 import org.apache.spark.SparkContext
+import org.apache.spark.api.java.function.{ Function => JFunction }
 import org.apache.spark.rdd.RDD
 import org.apache.spark.sql.{ Dataset, SQLContext }
 import org.bdgenomics.adam.models.{
@@ -255,9 +256,14 @@ abstract class CoverageDataset
       disableDictionaryEncoding)
   }
 
-  def transformDataset(
+  override def transformDataset(
     tFn: Dataset[Coverage] => Dataset[Coverage]): CoverageDataset = {
     DatasetBoundCoverageDataset(tFn(dataset), sequences, samples)
+  }
+
+  override def transformDataset(
+    tFn: JFunction[Dataset[Coverage], Dataset[Coverage]]): CoverageDataset = {
+    DatasetBoundCoverageDataset(tFn.call(dataset), sequences, samples)
   }
 
   /**
@@ -356,11 +362,11 @@ abstract class CoverageDataset
   def toFeatures(): FeatureDataset
 
   /**
-   * Gets coverage overlapping specified ReferenceRegion.
+   * (Java-specific) Gets coverage overlapping specified ReferenceRegion.
    *
    * For large ReferenceRegions, base pairs per bin (bpPerBin) can be specified
    * to bin together ReferenceRegions of equal size. The coverage of each bin is
-   * coverage of the first base pair in that bin. Java friendly variant.
+   * coverage of the first base pair in that bin.
    *
    * @param bpPerBin base pairs per bin, number of bases to combine to one bin.
    * @return Genomic dataset of Coverage Records.
@@ -371,7 +377,8 @@ abstract class CoverageDataset
   }
 
   /**
-   * Gets coverage overlapping specified ReferenceRegion.
+   * (Scala-specific) Gets coverage overlapping specified ReferenceRegion.
+   *
    * For large ReferenceRegions, base pairs per bin (bpPerBin) can be specified
    * to bin together ReferenceRegions of equal size. The coverage of each bin is
    * coverage of the first base pair in that bin.
@@ -393,11 +400,11 @@ abstract class CoverageDataset
   }
 
   /**
-   * Gets coverage overlapping specified ReferenceRegion.
+   * (Java-specific) Gets coverage overlapping specified ReferenceRegion.
    *
    * For large ReferenceRegions, base pairs per bin (bpPerBin) can be specified
    * to bin together ReferenceRegions of equal size. The coverage of each bin is
-   * the mean coverage over all base pairs in that bin. Java friendly variant.
+   * the mean coverage over all base pairs in that bin.
    *
    * @param bpPerBin base pairs per bin, number of bases to combine to one bin.
    * @return Genomic dataset of Coverage Records.
@@ -408,7 +415,7 @@ abstract class CoverageDataset
   }
 
   /**
-   * Gets coverage overlapping specified ReferenceRegion.
+   * (Scala-specific) Gets coverage overlapping specified ReferenceRegion.
    *
    * For large ReferenceRegions, base pairs per bin (bpPerBin) can be specified
    * to bin together ReferenceRegions of equal size. The coverage of each bin is

--- a/adam-core/src/main/scala/org/bdgenomics/adam/rdd/feature/FeatureDataset.scala
+++ b/adam-core/src/main/scala/org/bdgenomics/adam/rdd/feature/FeatureDataset.scala
@@ -22,6 +22,7 @@ import java.util.{ Collections, Comparator }
 import org.apache.hadoop.fs.{ FileSystem, Path }
 import org.apache.parquet.hadoop.metadata.CompressionCodecName
 import org.apache.spark.SparkContext
+import org.apache.spark.api.java.function.{ Function => JFunction }
 import org.apache.spark.rdd.RDD
 import org.apache.spark.sql.{ Dataset, SQLContext }
 import org.bdgenomics.adam.instrumentation.Timers._
@@ -335,6 +336,11 @@ case class DatasetBoundFeatureDataset private[rdd] (
     copy(dataset = tFn(dataset))
   }
 
+  override def transformDataset(
+    tFn: JFunction[Dataset[FeatureProduct], Dataset[FeatureProduct]]): FeatureDataset = {
+    copy(dataset = tFn.call(dataset))
+  }
+
   override def replaceSequences(newSequences: SequenceDictionary): FeatureDataset = {
     copy(sequences = newSequences)
   }
@@ -461,17 +467,14 @@ sealed abstract class FeatureDataset extends AvroGenomicDataset[Feature, Feature
       iterableDatasets.map(_.samples).fold(samples)(_ ++ _))
   }
 
-  /**
-   * Applies a function that transforms the underlying Dataset into a new Dataset using
-   * the Spark SQL API.
-   *
-   * @param tFn A function that transforms the underlying Dataset as a Dataset.
-   * @return A new FeatureDataset where the Dataset of genomic data has been replaced, but the
-   *   metadata (sequence dictionary, and etc) is copied without modification.
-   */
-  def transformDataset(
+  override def transformDataset(
     tFn: Dataset[FeatureProduct] => Dataset[FeatureProduct]): FeatureDataset = {
     DatasetBoundFeatureDataset(tFn(dataset), sequences, samples)
+  }
+
+  override def transformDataset(
+    tFn: JFunction[Dataset[FeatureProduct], Dataset[FeatureProduct]]): FeatureDataset = {
+    DatasetBoundFeatureDataset(tFn.call(dataset), sequences, samples)
   }
 
   /**
@@ -540,7 +543,17 @@ sealed abstract class FeatureDataset extends AvroGenomicDataset[Feature, Feature
   }
 
   /**
-   * Filter this FeatureDataset by feature type to those that match the specified feature types.
+   * (Java-specific) Filter this FeatureDataset by feature type to those that match the specified feature types.
+   *
+   * @param featureType List of feature types to filter by.
+   * @return FeatureDataset filtered by the specified feature types.
+   */
+  def filterToFeatureTypes(featureTypes: java.util.List[String]): FeatureDataset = {
+    filterToFeatureTypes(asScalaBuffer(featureTypes))
+  }
+
+  /**
+   * (Scala-specific) Filter this FeatureDataset by feature type to those that match the specified feature types.
    *
    * @param featureType Sequence of feature types to filter by.
    * @return FeatureDataset filtered by the specified feature types.
@@ -560,7 +573,17 @@ sealed abstract class FeatureDataset extends AvroGenomicDataset[Feature, Feature
   }
 
   /**
-   * Filter this FeatureDataset by gene to those that match the specified genes.
+   * (Java-specific) Filter this FeatureDataset by gene to those that match the specified genes.
+   *
+   * @param geneIds List of genes to filter by.
+   * @return FeatureDataset filtered by the specified genes.
+   */
+  def filterToGenes(geneIds: java.util.List[String]): FeatureDataset = {
+    filterToGenes(asScalaBuffer(geneIds))
+  }
+
+  /**
+   * (Scala-specific) Filter this FeatureDataset by gene to those that match the specified genes.
    *
    * @param geneIds Sequence of genes to filter by.
    * @return FeatureDataset filtered by the specified genes.
@@ -580,7 +603,17 @@ sealed abstract class FeatureDataset extends AvroGenomicDataset[Feature, Feature
   }
 
   /**
-   * Filter this FeatureDataset by transcript to those that match the specified transcripts.
+   * (Java-specific) Filter this FeatureDataset by transcript to those that match the specified transcripts.
+   *
+   * @param transcriptIds List of transcripts to filter by.
+   * @return FeatureDataset filtered by the specified transcripts.
+   */
+  def filterToTranscripts(transcriptIds: java.util.List[String]): FeatureDataset = {
+    filterToTranscripts(asScalaBuffer(transcriptIds))
+  }
+
+  /**
+   * (Scala-specific) Filter this FeatureDataset by transcript to those that match the specified transcripts.
    *
    * @param transcriptIds Sequence of transcripts to filter by.
    * @return FeatureDataset filtered by the specified transcripts.
@@ -600,7 +633,17 @@ sealed abstract class FeatureDataset extends AvroGenomicDataset[Feature, Feature
   }
 
   /**
-   * Filter this FeatureDataset by exon to those that match the specified exons.
+   * (Java-specific) Filter this FeatureDataset by exon to those that match the specified exons.
+   *
+   * @param exonIds List of exons to filter by.
+   * @return FeatureDataset filtered by the specified exons.
+   */
+  def filterToExons(exonIds: java.util.List[String]): FeatureDataset = {
+    filterToExons(asScalaBuffer(exonIds))
+  }
+
+  /**
+   * (Scala-specific) Filter this FeatureDataset by exon to those that match the specified exons.
    *
    * @param exonIds Sequence of exons to filter by.
    * @return FeatureDataset filtered by the specified exons.
@@ -630,7 +673,17 @@ sealed abstract class FeatureDataset extends AvroGenomicDataset[Feature, Feature
   }
 
   /**
-   * Filter this FeatureDataset by parent to those that match the specified parents.
+   * (Java-specific) Filter this FeatureDataset by parent to those that match the specified parents.
+   *
+   * @param parentIds List of parents to filter by.
+   * @return FeatureDataset filtered by the specified parents.
+   */
+  def filterToParents(parentIds: java.util.List[String]): FeatureDataset = {
+    filterToParents(asScalaBuffer(parentIds))
+  }
+
+  /**
+   * (Scala-specific) Filter this FeatureDataset by parent to those that match the specified parents.
    *
    * @param parentIds Sequence of parents to filter by.
    * @return FeatureDataset filtered by the specified parents.

--- a/adam-core/src/test/scala/org/bdgenomics/adam/rdd/feature/CoverageDatasetSuite.scala
+++ b/adam-core/src/test/scala/org/bdgenomics/adam/rdd/feature/CoverageDatasetSuite.scala
@@ -17,6 +17,7 @@
  */
 package org.bdgenomics.adam.rdd.feature
 
+import org.apache.spark.api.java.function.{ Function => JFunction }
 import org.apache.spark.rdd.RDD
 import org.apache.spark.sql.{ Dataset, SQLContext }
 import org.bdgenomics.adam.models.{
@@ -527,6 +528,19 @@ class CoverageDatasetSuite extends ADAMFunSuite {
     val copy = CoverageDataset.apply(coverage.dataset)
     assert(copy.dataset.count() === coverage.dataset.count())
     assert(copy.sequences.containsReferenceName("chr1") == false)
+  }
+
+  sparkTest("transform dataset via java API") {
+    val sd = sc.loadSequenceDictionary(testFile("hg19.genome"))
+    val coverage = sc.loadCoverage(testFile("sample_coverage.bed"), optSequenceDictionary = Some(sd))
+
+    val transformed = coverage.transformDataset(new JFunction[Dataset[Coverage], Dataset[Coverage]]() {
+      override def call(ds: Dataset[Coverage]): Dataset[Coverage] = {
+        ds
+      }
+    })
+
+    assert(coverage.dataset.first().start === transformed.dataset.first().start)
   }
 }
 

--- a/adam-core/src/test/scala/org/bdgenomics/adam/rdd/feature/FeatureDatasetSuite.scala
+++ b/adam-core/src/test/scala/org/bdgenomics/adam/rdd/feature/FeatureDatasetSuite.scala
@@ -19,6 +19,7 @@ package org.bdgenomics.adam.rdd.feature
 
 import com.google.common.collect.ImmutableMap
 import java.io.File
+import org.apache.spark.api.java.function.{ Function => JFunction }
 import org.apache.spark.rdd.RDD
 import org.apache.spark.sql.{ Dataset, SQLContext }
 import org.bdgenomics.adam.models.{
@@ -1377,5 +1378,17 @@ class FeatureDatasetSuite extends ADAMFunSuite {
     val features = sc.loadFeatures(testFile("dvl1.200.gff3"))
     val featuresDs = features.transformDataset(ds => ds)
     assert(features.filterByAttribute("biotype", "protein_coding").rdd.count() === 68)
+  }
+
+  sparkTest("transform dataset via java API") {
+    val features = sc.loadFeatures(testFile("dvl1.200.gff3")).sortByReference()
+
+    val transformed = features.transformDataset(new JFunction[Dataset[FeatureProduct], Dataset[FeatureProduct]]() {
+      override def call(ds: Dataset[FeatureProduct]): Dataset[FeatureProduct] = {
+        ds
+      }
+    })
+
+    assert(features.dataset.first().start.get === transformed.dataset.first().start.get)
   }
 }

--- a/adam-core/src/test/scala/org/bdgenomics/adam/rdd/fragment/FragmentDatasetSuite.scala
+++ b/adam-core/src/test/scala/org/bdgenomics/adam/rdd/fragment/FragmentDatasetSuite.scala
@@ -17,6 +17,7 @@
  */
 package org.bdgenomics.adam.rdd.fragment
 
+import org.apache.spark.api.java.function.{ Function => JFunction }
 import org.apache.spark.rdd.RDD
 import org.apache.spark.sql.{ Dataset, SQLContext }
 import org.bdgenomics.adam.models.{
@@ -609,5 +610,18 @@ class FragmentDatasetSuite extends ADAMFunSuite {
     fragments.rdd.collect().foreach(fragment => {
       assert(fragment.getAlignments.size() == 2)
     })
+  }
+
+  sparkTest("transform dataset via java API") {
+    val path = testFile("read_names_with_index_sequences_interleaved.fq")
+    val fragments = sc.loadInterleavedFastqAsFragments(path)
+
+    val transformed = fragments.transformDataset(new JFunction[Dataset[FragmentProduct], Dataset[FragmentProduct]]() {
+      override def call(ds: Dataset[FragmentProduct]): Dataset[FragmentProduct] = {
+        ds
+      }
+    })
+
+    assert(fragments.dataset.first().alignments.size === transformed.dataset.first().alignments.size)
   }
 }

--- a/adam-core/src/test/scala/org/bdgenomics/adam/rdd/variant/GenotypeDatasetSuite.scala
+++ b/adam-core/src/test/scala/org/bdgenomics/adam/rdd/variant/GenotypeDatasetSuite.scala
@@ -21,6 +21,7 @@ import com.google.common.io.Files
 import htsjdk.samtools.ValidationStringency
 import htsjdk.variant.vcf.VCFHeaderLine
 import java.io.File
+import org.apache.spark.api.java.function.{ Function => JFunction }
 import org.apache.spark.rdd.RDD
 import org.apache.spark.sql.{ Dataset, SQLContext }
 import org.bdgenomics.adam.converters.VariantContextConverter
@@ -780,5 +781,17 @@ class GenotypeDatasetSuite extends ADAMFunSuite {
     assert(firstVcfGenotype.end === Some(16157602L))
     assert(firstVcfGenotype.variant.get.end === Some(16157602L))
     assert(firstVcfGenotype.variant.get.annotation.get.attributes.get("END") === Some("16157602"))
+  }
+
+  sparkTest("transform dataset via java API") {
+    val genotypes = sc.loadGenotypes(testFile("gvcf_multiallelic/multiallelic.vcf"))
+
+    val transformed = genotypes.transformDataset(new JFunction[Dataset[GenotypeProduct], Dataset[GenotypeProduct]]() {
+      override def call(ds: Dataset[GenotypeProduct]): Dataset[GenotypeProduct] = {
+        ds
+      }
+    })
+
+    assert(genotypes.dataset.first().start.get === transformed.dataset.first().start.get)
   }
 }

--- a/adam-core/src/test/scala/org/bdgenomics/adam/rdd/variant/VariantContextDatasetSuite.scala
+++ b/adam-core/src/test/scala/org/bdgenomics/adam/rdd/variant/VariantContextDatasetSuite.scala
@@ -26,7 +26,9 @@ import htsjdk.variant.vcf.{
   VCFInfoHeaderLine
 }
 import java.io.File
+import org.apache.spark.api.java.function.{ Function => JFunction }
 import org.apache.spark.rdd.RDD
+import org.apache.spark.sql.{ Dataset }
 import org.apache.spark.util.CollectionAccumulator
 import org.bdgenomics.adam.converters.DefaultHeaderLines
 import org.bdgenomics.adam.models.{
@@ -538,5 +540,17 @@ class VariantContextDatasetSuite extends ADAMFunSuite {
     testMetadata(regionsVariantContexts)
     assert(regionsVariantContexts.rdd.count === 2)
     assert(regionsVariantContexts.dataset.count === 2)
+  }
+
+  sparkTest("transform dataset via java API") {
+    val variantContexts = sc.loadVcf(testFile("sorted-variants.vcf"))
+
+    val transformed = variantContexts.transformDataset(new JFunction[Dataset[VariantContextProduct], Dataset[VariantContextProduct]]() {
+      override def call(ds: Dataset[VariantContextProduct]): Dataset[VariantContextProduct] = {
+        ds
+      }
+    })
+
+    assert(variantContexts.dataset.first().start === transformed.dataset.first().start)
   }
 }

--- a/adam-core/src/test/scala/org/bdgenomics/adam/rdd/variant/VariantDatasetSuite.scala
+++ b/adam-core/src/test/scala/org/bdgenomics/adam/rdd/variant/VariantDatasetSuite.scala
@@ -18,6 +18,7 @@
 package org.bdgenomics.adam.rdd.variant
 
 import htsjdk.variant.vcf.VCFHeaderLine
+import org.apache.spark.api.java.function.{ Function => JFunction }
 import org.apache.spark.rdd.RDD
 import org.apache.spark.sql.{ Dataset, SQLContext }
 import org.bdgenomics.adam.models.{
@@ -707,5 +708,17 @@ class VariantDatasetSuite extends ADAMFunSuite {
     val variants = sc.loadVariants(testFile("NA12878.chr22.tiny.freebayes.vcf"))
     val variantsDs = variants.transformDataset(ds => ds)
     assert(variantsDs.filterToIndels().dataset.count() === 2)
+  }
+
+  sparkTest("transform dataset via java API") {
+    val variants = sc.loadVariants(testFile("NA12878.chr22.tiny.freebayes.vcf")).sort()
+
+    val transformed = variants.transformDataset(new JFunction[Dataset[VariantProduct], Dataset[VariantProduct]]() {
+      override def call(ds: Dataset[VariantProduct]): Dataset[VariantProduct] = {
+        ds
+      }
+    })
+
+    assert(variants.dataset.first().start.get === transformed.dataset.first().start.get)
   }
 }


### PR DESCRIPTION
Fixes #1986.  Also adds java-specific methods where missing, most significantly `GenomicRDD.transformDataset(JFunction)`.