### PR TITLE
Propagate read negative flag to SAM records for unmapped reads

### DIFF
--- a/adam-core/src/main/scala/org/bdgenomics/adam/converters/AlignmentRecordConverter.scala
+++ b/adam-core/src/main/scala/org/bdgenomics/adam/converters/AlignmentRecordConverter.scala
@@ -290,6 +290,10 @@ class AlignmentRecordConverter extends Serializable {
       .foreach(m => {
         builder.setReadUnmappedFlag(!m.booleanValue)
 
+        // Sometimes aligners like BWA-MEM mark a read as negative even if it's not mapped
+        Option(adamRecord.getReadNegativeStrand)
+          .foreach(v => builder.setReadNegativeStrandFlag(v.booleanValue))
+
         // only set alignment flags if read is aligned
         if (m) {
           // if we are aligned, we must have a reference
@@ -301,8 +305,6 @@ class AlignmentRecordConverter extends Serializable {
           // set the old cigar, if provided
           Option(adamRecord.getOldCigar).foreach(v => builder.setAttribute("OC", v))
           // set mapping flags
-          Option(adamRecord.getReadNegativeStrand)
-            .foreach(v => builder.setReadNegativeStrandFlag(v.booleanValue))
           Option(adamRecord.getPrimaryAlignment)
             .foreach(v => builder.setNotPrimaryAlignmentFlag(!v.booleanValue))
           Option(adamRecord.getSupplementaryAlignment)

--- a/adam-core/src/test/scala/org/bdgenomics/adam/converters/AlignmentRecordConverterSuite.scala
+++ b/adam-core/src/test/scala/org/bdgenomics/adam/converters/AlignmentRecordConverterSuite.scala
@@ -326,5 +326,15 @@ class AlignmentRecordConverterSuite extends FunSuite {
     assert(read.getQual === "?????*****")
     assert(read.getContigName === "1")
   }
+
+  test("read negative strand is propagated even when not mapped") {
+    val record = AlignmentRecord.newBuilder()
+      .setReadMapped(false)
+      .setReadNegativeStrand(true)
+      .build()
+    val fragment = Fragment.newBuilder().setAlignments(List(record)).build()
+    val converted = adamRecordConverter.convertFragment(fragment)
+    assert(converted.head.getReadNegativeStrand)
+  }
 }
 


### PR DESCRIPTION
I've seen BWA-MEM flag an unmapped read as negative if the mate is mapped. After this PR, we propagate that information into SAMs or BAMs saved by ADAM.