### PR TITLE
use parquet-scala_2.11 fork

### DIFF
--- a/adam-core/pom.xml
+++ b/adam-core/pom.xml
@@ -243,8 +243,8 @@
       <scope>compile</scope>
     </dependency>
     <dependency>
-      <groupId>org.apache.parquet</groupId>
-      <artifactId>parquet-scala_2.10</artifactId>
+      <groupId>org.lasersonlab.apache.parquet</groupId>
+      <artifactId>parquet-scala_${scala.version.prefix}</artifactId>
       <scope>compile</scope>
     </dependency>
     <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -525,9 +525,8 @@
         </exclusions>
       </dependency>
       <dependency>
-        <groupId>org.apache.parquet</groupId>
-        <!-- This library has no Scala 2.11 version, but using the 2 dot 10 version seems to work. -->
-        <artifactId>parquet-scala_2.10</artifactId>
+        <groupId>org.lasersonlab.apache.parquet</groupId>
+        <artifactId>parquet-scala_${scala.version.prefix}</artifactId>
         <version>${parquet.version}</version>
         <exclusions>
           <exclusion>

--- a/scripts/move_to_scala_2.11.sh
+++ b/scripts/move_to_scala_2.11.sh
@@ -14,8 +14,6 @@ fi
 find . -name "pom.xml" -exec sed -e "s/2.10.6/2.11.12/g" \
     -e "s/2.10/2.11/g" \
     -i.2.11.bak '{}' \;
-# keep parquet-scala at parquet-scala_2.10
-find . -name "pom.xml" -exec sed -e "s/parquet-scala_2.11/parquet-scala_2.10/g" -i.2.11.2.bak '{}' \;
 # keep maven-javadoc-plugin at version 2.10.4
 find . -name "pom.xml" -exec sed -e "s/2.11.12/2.10.4/g" -i.2.11.3.bak '{}' \;
 find . -name "*.2.11.*bak" -exec rm -f {} \;


### PR DESCRIPTION
[I built parquet-scala 1.8.3 against Scala 2.11](https://github.com/lasersonlab/parquet-mr/compare/apache-parquet-1.8.3...parquet-scala_2.11-1.8.3) and released it as [`org.lasersonlab.apache.parquet:parquet-scala_2.11:1.8.3`](https://oss.sonatype.org/content/repositories/releases/org/lasersonlab/apache/parquet/parquet-scala_2.11/1.8.3/)

This fixes a petrified old ADAM build-smell: using parquet-scala_2.10 in 2.11 builds.

I'll probably PR some of it upstream, but you can merge this first if you like. I put [a 2.10 version under the same forked `org.lasersonlab.apache.parquet` group](https://oss.sonatype.org/content/repositories/releases/org/lasersonlab/apache/parquet/parquet-scala_2.10/1.8.3/) so the existing cross-build here should work with it.

I started on this because I'm lifting my Spark stack onto 2.12, and `parquet-scala_2.10` does in fact break things there, so I also built and released [`parquet-scala_2.12` for `1.8.3`, `1.10.0`, and a `1.12.0` cut from HEAD](https://oss.sonatype.org/content/repositories/releases/org/lasersonlab/apache/parquet/parquet-scala_2.12/) while I was trying to figure out what I wanted.

Using that {`2.12`,`1.10.0`} version, [my old adam-core fork](https://github.com/hammerlab/adam/) builds+tests against {Spark 2.4, Scala 2.12}, which bodes well for #2044! I plan to publish a version of it soon so I will follow up if I encounter anything else of note.