### PR TITLE
Keep information for <NON_REF> alleles

### DIFF
--- a/adam-core/src/main/scala/org/bdgenomics/adam/converters/VariantContextConverter.scala
+++ b/adam-core/src/main/scala/org/bdgenomics/adam/converters/VariantContextConverter.scala
@@ -1979,7 +1979,14 @@ class VariantContextConverter(
         formatNonRefGenotypeLikelihoods(g, convertedCore, nrIndices)
       })
 
-      val vcAnns = VariantCallingAnnotations.newBuilder(coreWithOptNonRefs.build.getVariantCallingAnnotations)
+      val vcAnns = if (coreWithOptNonRefs.hasVariantCallingAnnotations) {
+        VariantCallingAnnotations.newBuilder(coreWithOptNonRefs.getVariantCallingAnnotations)
+      } else if (coreWithOptNonRefs.hasVariantCallingAnnotationsBuilder) {
+        VariantCallingAnnotations.newBuilder(coreWithOptNonRefs.getVariantCallingAnnotationsBuilder)
+      } else {
+        VariantCallingAnnotations.newBuilder
+      }
+
 
       // bind the annotation conversion functions and fold
       val boundAnnotationFns: Iterable[VariantCallingAnnotations.Builder => VariantCallingAnnotations.Builder] = genotypeAnnotationFormatFns

--- a/adam-core/src/main/scala/org/bdgenomics/adam/converters/VariantContextConverter.scala
+++ b/adam-core/src/main/scala/org/bdgenomics/adam/converters/VariantContextConverter.scala
@@ -1119,7 +1119,7 @@ class VariantContextConverter(
     }
     (Option(g.getReferenceReadDepth), Option(g.getAlternateReadDepth), nonRefAd) match {
       case (Some(ref), Some(alt), Some(nonRef)) => gb.AD(Array(ref, alt, nonRef.toInt))
-      case (Some(ref), Some(alt), None) => gb.AD(Array(ref, alt))
+      case (Some(ref), Some(alt), None)         => gb.AD(Array(ref, alt))
       case (Some(_), None, _) => {
         throw new IllegalArgumentException("Had reference depth but no alternate depth in %s.".format(g))
       }
@@ -1986,7 +1986,6 @@ class VariantContextConverter(
       } else {
         VariantCallingAnnotations.newBuilder
       }
-
 
       // bind the annotation conversion functions and fold
       val boundAnnotationFns: Iterable[VariantCallingAnnotations.Builder => VariantCallingAnnotations.Builder] = genotypeAnnotationFormatFns

--- a/adam-core/src/test/scala/org/bdgenomics/adam/rdd/ADAMContextSuite.scala
+++ b/adam-core/src/test/scala/org/bdgenomics/adam/rdd/ADAMContextSuite.scala
@@ -536,7 +536,7 @@ class ADAMContextSuite extends ADAMFunSuite {
     val mleCounts = multiAllelicVariants.map(_.getAnnotation.getAttributes.get("MLEAC"))
     //ALT    T,TA,TAA,<NON_REF>
     //MLEAC  0,1,1,0
-    assert(mleCounts === Array("0", "1", "1"))
+    assert(mleCounts === Array("0,0", "1,0", "1,0"))
   }
 
   sparkTest("load parquet with globs") {


### PR DESCRIPTION
INFO and FORMAT fields with Number=<A/R/G> are not properly stored in ADAM for the <NON_REF> allele. This is a problem with both default and non-default fields. During conversion to ADAM, most fields lose any information related to the <NON_REF> allele. This is with the exception of PL, for which the majority of values is stored between `genotypeLikelihoods` and `nonRefLikelihoods`. However, this still drops the value for the ALT/<NON_REF> genotype.

As a result of this bug, the output list for most fields with Number=<A/R/G> does not contain enough values in the resulting gVCF (those with Number=A should have 2 but have 1, those with Number=R should have 3 but have 2, and those with Number=G should have 10 but have 6). For PL, the missing value for the ALT/<NON_REF> genotype contains `3223`.

To fix this problem, this PR does the following:
- The <NON_REF> allele index is passed into the FORMAT functions.
- For non-default fields with Number=<A/R>, the value for the <NON_REF> allele is added to the output list for addition to the attribute map (`VariantAnnotation.attributes` for INFO fields, and `VariantCallingAnnotations.attributes` for FORMAT fields).
- For default fields with Number=<A/R>, the value for the <NON_REF> allele is added to the attribute map keyed as "NON_REF_<FIELD_NAME>" and restored to the output list during extraction if present.
- For all fields with Number=G, the indices include those for REF, ALT, and <NON_REF>.