### PR TITLE
Filter supplemental reads from scoring

### DIFF
--- a/adam-core/src/main/scala/org/bdgenomics/adam/rdd/read/MarkDuplicates.scala
+++ b/adam-core/src/main/scala/org/bdgenomics/adam/rdd/read/MarkDuplicates.scala
@@ -45,7 +45,7 @@ private[rdd] object MarkDuplicates extends Serializable with Logging {
   }
 
   private def scoreBucket(bucket: SingleReadBucket): Int = {
-    bucket.primaryMapped.map(score).sum
+    bucket.primaryMapped.filter(r => !r.getSupplementaryAlignment).map(score).sum
   }
 
   private def markReads(reads: Iterable[(ReferencePositionPair, SingleReadBucket)], areDups: Boolean) {

--- a/adam-core/src/test/scala/org/bdgenomics/adam/rdd/read/MarkDuplicatesSuite.scala
+++ b/adam-core/src/test/scala/org/bdgenomics/adam/rdd/read/MarkDuplicatesSuite.scala
@@ -322,4 +322,16 @@ class MarkDuplicatesSuite extends ADAMFunSuite {
     val (dups, nonDups) = marked.partition(_.getDuplicateRead)
     assert(dups.size == 2)
   }
+
+  sparkTest("supplemental reads") {
+    val supplementalPoorName = "supplementalPoor"
+    val supplementalRead = createMappedRead("ref0", 10, 110, "supplementalPoor", avgPhredScore = 10, isPrimaryAlignment = true)
+    supplementalRead.setSupplementaryAlignment(true)
+    val supplementalPoorPair = createPair("ref0", 10, 110, "ref1", 110, 210, avgPhredScore = 30, readName = supplementalPoorName) ++ Seq(supplementalRead)
+    val bestName = "best"
+    val bestPair = createPair("ref0", 10, 110, "ref1", 110, 210, avgPhredScore = 30, readName = bestName)
+    val marked = markDuplicateFragments(bestPair ++ supplementalPoorPair: _*)
+    val (dups, nonDups) = marked.partition(_.getDuplicateRead)
+    assert(nonDups.size == 2 && nonDups.forall(p => p.getReadName.toString == bestName))
+  }
 }


### PR DESCRIPTION
Currently a supplemental read can be added to the sum of base qualities
of a duplicate candidate, artificially inflating its base quality sum
when mark duplicates is trying to choose the best read from the bunch.

This is one (the simplest and most superficial) fix to the problem. Just
filter supplemental reads out when summing.

Another solution could be to use the supplemental flag when setting the
"not primary read flag" in SAMRecordConverter.

Yet another would be to create a separate field in SingleReadBucket for
supplemental reads.

Not sure what the downstream effects of these different approaches are.