### PR TITLE
[ADAM-1712] Replace utils.Logger with grizzled.slf4j.Logger

### DIFF
--- a/adam-cli/src/main/scala/org/bdgenomics/adam/cli/ADAM2Fasta.scala
+++ b/adam-cli/src/main/scala/org/bdgenomics/adam/cli/ADAM2Fasta.scala
@@ -17,11 +17,11 @@
  */
 package org.bdgenomics.adam.cli
 
+import grizzled.slf4j.Logging
 import org.apache.spark.SparkContext
 import org.bdgenomics.adam.cli.FileSystemUtils._
 import org.bdgenomics.adam.rdd.ADAMContext._
 import org.bdgenomics.utils.cli._
-import org.bdgenomics.utils.misc.Logging
 import org.kohsuke.args4j.{ Argument, Option => Args4jOption }
 
 class ADAM2FastaArgs extends Args4jBase {
@@ -55,10 +55,10 @@ class ADAM2Fasta(val args: ADAM2FastaArgs) extends BDGSparkCommand[ADAM2FastaArg
   override def run(sc: SparkContext): Unit = {
     checkWriteablePath(args.outputPath, sc.hadoopConfiguration)
 
-    log.info("Loading ADAM nucleotide contig fragments from disk.")
+    info("Loading ADAM nucleotide contig fragments from disk.")
     val contigFragments = sc.loadContigFragments(args.inputPath)
 
-    log.info("Merging fragments and writing FASTA to disk.")
+    info("Merging fragments and writing FASTA to disk.")
     val contigs = contigFragments.mergeFragments()
 
     val cc = if (args.coalesce > 0) {

--- a/adam-cli/src/main/scala/org/bdgenomics/adam/cli/ADAM2Fastq.scala
+++ b/adam-cli/src/main/scala/org/bdgenomics/adam/cli/ADAM2Fastq.scala
@@ -80,7 +80,7 @@ class ADAM2Fastq(val args: ADAM2FastqArgs) extends BDGSparkCommand[ADAM2FastqArg
     var reads = sc.loadAlignments(args.inputPath, optProjection = projectionOpt)
 
     if (args.repartition != -1) {
-      log.info("Repartitioning reads to to '%d' partitions".format(args.repartition))
+      info("Repartitioning reads to to '%d' partitions".format(args.repartition))
       reads = reads.transform(_.repartition(args.repartition))
     }
 

--- a/adam-cli/src/main/scala/org/bdgenomics/adam/cli/ADAMMain.scala
+++ b/adam-cli/src/main/scala/org/bdgenomics/adam/cli/ADAMMain.scala
@@ -21,7 +21,7 @@ import java.util.logging.Level._
 import javax.inject.Inject
 import com.google.inject.AbstractModule
 import net.codingwell.scalaguice.ScalaModule
-import org.bdgenomics.utils.misc.Logging
+import grizzled.slf4j.Logging
 import org.bdgenomics.adam.util.ParquetLogger
 import org.bdgenomics.utils.cli._
 
@@ -106,7 +106,7 @@ class ADAMMain @Inject() (commandGroups: List[CommandGroup]) extends Logging {
   }
 
   def apply(args: Array[String]) {
-    log.info("ADAM invoked with args: %s".format(argsToString(args)))
+    info("ADAM invoked with args: %s".format(argsToString(args)))
     if (args.length < 1) {
       printCommands()
     } else if (args.contains("--version") || args.contains("-version")) {

--- a/adam-cli/src/main/scala/org/bdgenomics/adam/cli/CountContigKmers.scala
+++ b/adam-cli/src/main/scala/org/bdgenomics/adam/cli/CountContigKmers.scala
@@ -17,11 +17,11 @@
  */
 package org.bdgenomics.adam.cli
 
+import grizzled.slf4j.Logging
 import org.apache.spark.SparkContext
 import org.bdgenomics.adam.rdd.ADAMContext._
 import org.bdgenomics.adam.cli.FileSystemUtils._
 import org.bdgenomics.utils.cli._
-import org.bdgenomics.utils.misc.Logging
 import org.kohsuke.args4j.{ Argument, Option => Args4jOption }
 
 object CountContigKmers extends BDGCommandCompanion {

--- a/adam-cli/src/main/scala/org/bdgenomics/adam/cli/CountReadKmers.scala
+++ b/adam-cli/src/main/scala/org/bdgenomics/adam/cli/CountReadKmers.scala
@@ -17,12 +17,12 @@
  */
 package org.bdgenomics.adam.cli
 
+import grizzled.slf4j.Logging
 import org.apache.spark.SparkContext
 import org.bdgenomics.adam.cli.FileSystemUtils._
 import org.bdgenomics.adam.projections.{ AlignmentRecordField, Projection }
 import org.bdgenomics.adam.rdd.ADAMContext._
 import org.bdgenomics.utils.cli._
-import org.bdgenomics.utils.misc.Logging
 import org.kohsuke.args4j.{ Argument, Option => Args4jOption }
 
 object CountReadKmers extends BDGCommandCompanion {
@@ -60,7 +60,7 @@ class CountReadKmers(protected val args: CountReadKmersArgs) extends BDGSparkCom
     )
 
     if (args.repartition != -1) {
-      log.info("Repartitioning reads to '%d' partitions".format(args.repartition))
+      info("Repartitioning reads to '%d' partitions".format(args.repartition))
       adamRecords = adamRecords.transform(_.repartition(args.repartition))
     }
 

--- a/adam-cli/src/main/scala/org/bdgenomics/adam/cli/Fasta2ADAM.scala
+++ b/adam-cli/src/main/scala/org/bdgenomics/adam/cli/Fasta2ADAM.scala
@@ -17,11 +17,11 @@
  */
 package org.bdgenomics.adam.cli
 
+import grizzled.slf4j.Logging
 import org.apache.spark.SparkContext
 import org.bdgenomics.adam.cli.FileSystemUtils._
 import org.bdgenomics.adam.rdd.ADAMContext._
 import org.bdgenomics.utils.cli._
-import org.bdgenomics.utils.misc.Logging
 import org.kohsuke.args4j.{ Argument, Option => Args4jOption }
 
 object Fasta2ADAM extends BDGCommandCompanion {
@@ -54,14 +54,14 @@ class Fasta2ADAM(protected val args: Fasta2ADAMArgs) extends BDGSparkCommand[Fas
   def run(sc: SparkContext) {
     checkWriteablePath(args.outputPath, sc.hadoopConfiguration)
 
-    log.info("Loading FASTA data from disk.")
+    info("Loading FASTA data from disk.")
     val adamFasta = sc.loadFasta(args.fastaFile, maximumLength = args.maximumLength)
 
     if (args.verbose) {
-      log.info("FASTA contains: %s", adamFasta.sequences.toString)
+      info("FASTA contains: %s".format(adamFasta.sequences.toString))
     }
 
-    log.info("Writing records to disk.")
+    info("Writing records to disk.")
     val finalFasta = if (args.partitions > 0) {
       adamFasta.transform(_.repartition(args.partitions))
     } else {

--- a/adam-cli/src/main/scala/org/bdgenomics/adam/cli/FileSystemUtils.scala
+++ b/adam-cli/src/main/scala/org/bdgenomics/adam/cli/FileSystemUtils.scala
@@ -20,12 +20,11 @@ package org.bdgenomics.adam.cli
 import org.apache.hadoop.conf.Configuration
 import org.apache.hadoop.fs.Path
 import org.apache.hadoop.mapred.FileAlreadyExistsException
-import org.bdgenomics.utils.misc.Logging
 
 /**
  * Utility methods for file systems.
  */
-private[cli] object FileSystemUtils extends Logging {
+private[cli] object FileSystemUtils {
   private def exists(pathName: String, conf: Configuration): Boolean = {
     val p = new Path(pathName)
     val fs = p.getFileSystem(conf)

--- a/adam-cli/src/main/scala/org/bdgenomics/adam/cli/TransformFragments.scala
+++ b/adam-cli/src/main/scala/org/bdgenomics/adam/cli/TransformFragments.scala
@@ -17,6 +17,7 @@
  */
 package org.bdgenomics.adam.cli
 
+import grizzled.slf4j.Logging
 import org.apache.spark.SparkContext
 import org.bdgenomics.adam.cli.FileSystemUtils._
 import org.bdgenomics.adam.io.FastqRecordReader
@@ -25,7 +26,6 @@ import org.bdgenomics.adam.rdd.ADAMSaveAnyArgs
 import org.bdgenomics.adam.rdd.read.QualityScoreBin
 import org.bdgenomics.adam.rdd.fragment.FragmentDataset
 import org.bdgenomics.utils.cli._
-import org.bdgenomics.utils.misc.Logging
 import org.kohsuke.args4j.{ Argument, Option => Args4jOption }
 
 object TransformFragments extends BDGCommandCompanion {
@@ -99,7 +99,7 @@ class TransformFragments(protected val args: TransformFragmentsArgs) extends BDG
     checkWriteablePath(args.outputPath, sc.hadoopConfiguration)
 
     if (args.loadAsReads && args.saveAsReads) {
-      log.warn("If loading and saving as reads, consider using TransformAlignments instead.")
+      warn("If loading and saving as reads, consider using TransformAlignments instead.")
     }
     if (args.sortReads) {
       require(args.saveAsReads,

--- a/adam-cli/src/main/scala/org/bdgenomics/adam/cli/TransformGenotypes.scala
+++ b/adam-cli/src/main/scala/org/bdgenomics/adam/cli/TransformGenotypes.scala
@@ -95,7 +95,7 @@ class TransformGenotypes(val args: TransformGenotypesArgs)
    */
   private def maybeCoalesce[U <: GenomicDataset[_, _, U]](rdd: U): U = {
     if (args.coalesce != -1) {
-      log.info("Coalescing the number of partitions to '%d'".format(args.coalesce))
+      info("Coalescing the number of partitions to '%d'".format(args.coalesce))
       if (args.coalesce > rdd.rdd.partitions.length || args.forceShuffle) {
         rdd.transform(_.coalesce(args.coalesce, shuffle = true))
       } else {
@@ -114,10 +114,10 @@ class TransformGenotypes(val args: TransformGenotypesArgs)
    */
   private def maybeSort[U <: GenomicDataset[_, _, U]](rdd: U): U = {
     if (args.sort) {
-      log.info("Sorting before saving")
+      info("Sorting before saving")
       rdd.sort()
     } else if (args.sortLexicographically) {
-      log.info("Sorting lexicographically before saving")
+      info("Sorting lexicographically before saving")
       rdd.sortLexicographically()
     } else {
       rdd
@@ -131,7 +131,7 @@ class TransformGenotypes(val args: TransformGenotypesArgs)
       "Cannot set both -sort_on_save and -sort_lexicographically_on_save.")
 
     if (args.nestedAnnotations) {
-      log.info("Populating the variant.annotation field in the Genotype records")
+      info("Populating the variant.annotation field in the Genotype records")
       sc.hadoopConfiguration.setBoolean(VariantContextConverter.nestAnnotationInGenotypesProperty, true)
     }
 

--- a/adam-cli/src/main/scala/org/bdgenomics/adam/cli/TransformVariants.scala
+++ b/adam-cli/src/main/scala/org/bdgenomics/adam/cli/TransformVariants.scala
@@ -85,7 +85,7 @@ class TransformVariants(val args: TransformVariantsArgs)
    */
   private def maybeCoalesce[U <: GenomicDataset[_, _, U]](rdd: U): U = {
     if (args.coalesce != -1) {
-      log.info("Coalescing the number of partitions to '%d'".format(args.coalesce))
+      info("Coalescing the number of partitions to '%d'".format(args.coalesce))
       if (args.coalesce > rdd.rdd.partitions.length || args.forceShuffle) {
         rdd.transform(_.coalesce(args.coalesce, shuffle = true))
       } else {
@@ -104,10 +104,10 @@ class TransformVariants(val args: TransformVariantsArgs)
    */
   private def maybeSort[U <: GenomicDataset[_, _, U]](rdd: U): U = {
     if (args.sort) {
-      log.info("Sorting before saving")
+      info("Sorting before saving")
       rdd.sort()
     } else if (args.sortLexicographically) {
-      log.info("Sorting lexicographically before saving")
+      info("Sorting lexicographically before saving")
       rdd.sortLexicographically()
     } else {
       rdd

--- a/adam-cli/src/test/scala/org/bdgenomics/adam/cli/ParquetLister.scala
+++ b/adam-cli/src/test/scala/org/bdgenomics/adam/cli/ParquetLister.scala
@@ -19,11 +19,11 @@ package org.bdgenomics.adam.cli
 
 import java.io.File
 
+import grizzled.slf4j.Logging
 import org.apache.avro.Schema
 import org.apache.avro.generic.IndexedRecord
 import org.apache.hadoop.conf.Configuration
 import org.apache.hadoop.fs.Path
-import org.bdgenomics.utils.misc.Logging
 import org.apache.parquet.avro.AvroReadSupport
 import org.apache.parquet.hadoop.ParquetReader
 
@@ -54,7 +54,7 @@ class ParquetLister[T <: IndexedRecord](projectionSchema: Option[Schema] = None)
             materialize(f)
           } catch {
             case e: IllegalArgumentException =>
-              logInfo("File %s doesn't appear to be a Parquet file; skipping".format(f))
+              info("File %s doesn't appear to be a Parquet file; skipping".format(f))
               Seq()
           }
       }.iterator
@@ -62,7 +62,7 @@ class ParquetLister[T <: IndexedRecord](projectionSchema: Option[Schema] = None)
   }
 
   private def materialize(file: File): Iterator[T] = {
-    logInfo("Materializing file %s".format(file))
+    info("Materializing file %s".format(file))
     val conf = new Configuration
     if (projectionSchema.isDefined) {
       AvroReadSupport.setRequestedProjection(conf, projectionSchema.get)

--- a/adam-core/pom.xml
+++ b/adam-core/pom.xml
@@ -233,6 +233,11 @@
       <scope>compile</scope>
     </dependency>
     <dependency>
+      <groupId>org.clapper</groupId>
+      <artifactId>grizzled-slf4j_${scala.version.prefix}</artifactId>
+      <scope>compile</scope>
+    </dependency>
+    <dependency>
       <groupId>org.slf4j</groupId>
       <artifactId>slf4j-log4j12</artifactId>
       <scope>test</scope>

--- a/adam-core/src/main/scala/org/bdgenomics/adam/converters/FastqRecordConverter.scala
+++ b/adam-core/src/main/scala/org/bdgenomics/adam/converters/FastqRecordConverter.scala
@@ -17,13 +17,13 @@
  */
 package org.bdgenomics.adam.converters
 
+import grizzled.slf4j.Logging
 import htsjdk.samtools.ValidationStringency
 import org.apache.hadoop.io.Text
 import org.bdgenomics.formats.avro.{
   AlignmentRecord,
   Fragment
 }
-import org.bdgenomics.utils.misc.Logging
 import scala.collection.JavaConversions._
 
 /**
@@ -91,7 +91,7 @@ private[adam] class FastqRecordConverter extends Serializable with Logging {
           if (stringency == ValidationStringency.STRICT) {
             throw e
           } else if (stringency == ValidationStringency.LENIENT) {
-            log.warn("Read had improper pair suffix: %s".format(e.getMessage))
+            warn("Read had improper pair suffix: %s".format(e.getMessage))
           }
         }
       }

--- a/adam-core/src/main/scala/org/bdgenomics/adam/converters/SAMRecordConverter.scala
+++ b/adam-core/src/main/scala/org/bdgenomics/adam/converters/SAMRecordConverter.scala
@@ -17,12 +17,12 @@
  */
 package org.bdgenomics.adam.converters
 
+import grizzled.slf4j.Logging
 import htsjdk.samtools.{
   SAMReadGroupRecord,
   SAMRecord,
   SAMUtils
 }
-import org.bdgenomics.utils.misc.Logging
 import org.bdgenomics.adam.models.Attribute
 import org.bdgenomics.adam.util.AttributeUtils
 import org.bdgenomics.formats.avro.AlignmentRecord
@@ -212,7 +212,7 @@ private[adam] class SAMRecordConverter extends Serializable with Logging {
       builder.build
     } catch {
       case t: Throwable => {
-        log.error("Conversion of read: " + samRecord + " failed.")
+        error("Conversion of read: " + samRecord + " failed.")
         throw t
       }
     }

--- a/adam-core/src/main/scala/org/bdgenomics/adam/converters/TranscriptEffectConverter.scala
+++ b/adam-core/src/main/scala/org/bdgenomics/adam/converters/TranscriptEffectConverter.scala
@@ -17,6 +17,7 @@
  */
 package org.bdgenomics.adam.converters
 
+import grizzled.slf4j.Logging
 import htsjdk.samtools.ValidationStringency
 import htsjdk.variant.vcf.VCFConstants
 import htsjdk.variant.variantcontext.VariantContext
@@ -26,7 +27,6 @@ import org.bdgenomics.formats.avro.{
   Variant,
   VariantAnnotationMessage
 }
-import org.bdgenomics.utils.misc.Logging
 import scala.collection.JavaConverters._
 
 /**
@@ -220,7 +220,7 @@ private[adam] object TranscriptEffectConverter extends Serializable with Logging
         if (stringency == ValidationStringency.STRICT) {
           throw t
         } else if (stringency == ValidationStringency.LENIENT) {
-          log.warn("Could not convert VCF INFO reserved key ANN value to TranscriptEffect, caught %s.".format(t))
+          warn("Could not convert VCF INFO reserved key ANN value to TranscriptEffect, caught %s.".format(t))
         }
         None
       }
@@ -248,7 +248,7 @@ private[adam] object TranscriptEffectConverter extends Serializable with Logging
           "%d".format(n)
         }
         case (None, Some(d)) => {
-          log.warn("Incorrect fractional value ?/%d, missing numerator".format(d))
+          warn("Incorrect fractional value ?/%d, missing numerator".format(d))
           ""
         }
         case (Some(n), Some(d)) => {

--- a/adam-core/src/main/scala/org/bdgenomics/adam/models/IndelTable.scala
+++ b/adam-core/src/main/scala/org/bdgenomics/adam/models/IndelTable.scala
@@ -17,15 +17,15 @@
  */
 package org.bdgenomics.adam.models
 
+import grizzled.slf4j.Logging
 import org.apache.spark.SparkContext
 import org.apache.spark.rdd.RDD
 import org.bdgenomics.adam.algorithms.consensus.Consensus
 import org.bdgenomics.adam.rdd.ADAMContext._
 import org.bdgenomics.formats.avro.Variant
-import org.bdgenomics.utils.misc.Logging
 
 private[adam] class IndelTable(private val table: Map[String, Iterable[Consensus]]) extends Serializable with Logging {
-  log.info("Indel table has %s reference sequences and %s entries".format(
+  info("Indel table has %s reference sequences and %s entries".format(
     table.size,
     table.values.map(_.size).sum
   ))

--- a/adam-core/src/main/scala/org/bdgenomics/adam/models/SnpTable.scala
+++ b/adam-core/src/main/scala/org/bdgenomics/adam/models/SnpTable.scala
@@ -23,7 +23,6 @@ import org.apache.spark.rdd.MetricsContext._
 import org.apache.spark.rdd.RDD
 import org.bdgenomics.adam.instrumentation.Timers._
 import org.bdgenomics.adam.rdd.variant.VariantDataset
-import org.bdgenomics.utils.misc.Logging
 import scala.annotation.tailrec
 import scala.math.{ max, min }
 
@@ -37,7 +36,7 @@ import scala.math.{ max, min }
  */
 class SnpTable private[models] (
     private[models] val indices: Map[String, (Int, Int)],
-    private[models] val sites: Array[Long]) extends Serializable with Logging {
+    private[models] val sites: Array[Long]) extends Serializable {
 
   private val midpoints: Map[String, Int] = {
     @tailrec def pow2ceil(length: Int, i: Int = 1): Int = {

--- a/adam-core/src/main/scala/org/bdgenomics/adam/rdd/GenomicDataset.scala
+++ b/adam-core/src/main/scala/org/bdgenomics/adam/rdd/GenomicDataset.scala
@@ -18,6 +18,7 @@
 package org.bdgenomics.adam.rdd
 
 import java.nio.file.Paths
+import grizzled.slf4j.Logging
 import htsjdk.samtools.ValidationStringency
 import htsjdk.variant.vcf.{
   VCFFilterHeaderLine,
@@ -61,7 +62,7 @@ import org.bdgenomics.formats.avro.{
 }
 import org.bdgenomics.utils.cli.SaveArgs
 import org.bdgenomics.utils.interval.array.IntervalArray
-import org.bdgenomics.utils.misc.{ HadoopUtil, Logging }
+import org.bdgenomics.utils.misc.HadoopUtil
 import org.json4s.JsonDSL._
 import org.json4s.jackson.JsonMethods._
 import scala.annotation.tailrec
@@ -376,7 +377,7 @@ trait GenomicDataset[T, U <: Product, V <: GenomicDataset[T, U, V]] extends Logg
   def saveAsPartitionedParquet(pathName: String,
                                compressCodec: CompressionCodecName = CompressionCodecName.GZIP,
                                partitionSize: Int = 1000000) {
-    log.info("Saving directly as Hive-partitioned Parquet from SQL. " +
+    info("Saving directly as Hive-partitioned Parquet from SQL. " +
       "Options other than compression codec are ignored.")
     val df = toDF()
     df.withColumn("positionBin", floor(df("start") / partitionSize))
@@ -614,7 +615,7 @@ trait GenomicDataset[T, U <: Product, V <: GenomicDataset[T, U, V]] extends Logg
       case ValidationStringency.STRICT => {
         throw new IllegalArgumentException(message)
       }
-      case ValidationStringency.LENIENT => log.warn(message)
+      case ValidationStringency.LENIENT => warn(message)
       case _                            =>
     }
     None
@@ -3102,7 +3103,7 @@ sealed abstract class GenericGenomicDataset[T, U <: Product] extends GenomicData
                     pageSize: Int = 1 * 1024 * 1024,
                     compressCodec: CompressionCodecName = CompressionCodecName.GZIP,
                     disableDictionaryEncoding: Boolean = false) {
-    log.warn("Saving directly as Parquet from SQL. Options other than compression codec are ignored.")
+    warn("Saving directly as Parquet from SQL. Options other than compression codec are ignored.")
     dataset.toDF()
       .write
       .format("parquet")
@@ -3797,7 +3798,7 @@ abstract class AvroGenomicDataset[T <% IndexedRecord: Manifest, U <: Product, V 
     compressCodec: CompressionCodecName = CompressionCodecName.GZIP,
     disableDictionaryEncoding: Boolean = false,
     optSchema: Option[Schema] = None): Unit = SaveAsADAM.time {
-    log.info("Saving data in ADAM format")
+    info("Saving data in ADAM format")
 
     val job = HadoopUtil.newJob(rdd.context)
     ParquetOutputFormat.setCompression(job, compressCodec)

--- a/adam-core/src/main/scala/org/bdgenomics/adam/rdd/GenomicPartitioners.scala
+++ b/adam-core/src/main/scala/org/bdgenomics/adam/rdd/GenomicPartitioners.scala
@@ -17,8 +17,8 @@
  */
 package org.bdgenomics.adam.rdd
 
+import grizzled.slf4j.Logging
 import org.bdgenomics.adam.models.{ ReferenceRegion, ReferencePosition, SequenceDictionary }
-import org.bdgenomics.utils.misc.Logging
 import org.apache.spark.Partitioner
 import scala.math._
 
@@ -38,8 +38,10 @@ import scala.math._
  */
 case class GenomicPositionPartitioner(numParts: Int, seqLengths: Map[String, Long]) extends Partitioner with Logging {
 
-  log.info("Have genomic position partitioner with " + numParts + " partitions, and sequences:")
-  seqLengths.foreach(kv => log.info("Contig " + kv._1 + " with length " + kv._2))
+  info("Have genomic position partitioner with " + numParts + " partitions, and sequences:")
+  if (isInfoEnabled) {
+    seqLengths.foreach(kv => info("Contig " + kv._1 + " with length " + kv._2))
+  }
 
   private val names: Seq[String] = seqLengths.keys.toSeq.sortWith(_ < _)
   private val lengths: Seq[Long] = names.map(seqLengths(_))

--- a/adam-core/src/main/scala/org/bdgenomics/adam/rdd/OutFormatter.scala
+++ b/adam-core/src/main/scala/org/bdgenomics/adam/rdd/OutFormatter.scala
@@ -20,7 +20,7 @@ package org.bdgenomics.adam.rdd
 import java.io.InputStream
 import java.lang.Process
 import java.util.concurrent.{ Callable, TimeUnit }
-import org.bdgenomics.utils.misc.Logging
+import grizzled.slf4j.Logging
 
 private[rdd] class OutFormatterRunner[T, U <: OutFormatter[T]](formatter: U,
                                                                is: InputStream,
@@ -45,7 +45,7 @@ private[rdd] class OutFormatterRunner[T, U <: OutFormatter[T]](formatter: U,
 
   def hasNext: Boolean = {
     if (hasTimedOut()) {
-      log.warn("Piped command %s timed out after %d seconds.".format(
+      warn("Piped command %s timed out after %d seconds.".format(
         finalCmd, optTimeout.get))
       process.destroy()
       false
@@ -57,7 +57,7 @@ private[rdd] class OutFormatterRunner[T, U <: OutFormatter[T]](formatter: U,
         if (exited) {
           process.exitValue()
         } else {
-          log.warn("Piped command %s timed out after %d seconds.".format(
+          warn("Piped command %s timed out after %d seconds.".format(
             finalCmd, timeout))
           process.destroy()
           0

--- a/adam-core/src/main/scala/org/bdgenomics/adam/rdd/contig/NucleotideContigFragmentDataset.scala
+++ b/adam-core/src/main/scala/org/bdgenomics/adam/rdd/contig/NucleotideContigFragmentDataset.scala
@@ -155,7 +155,7 @@ case class DatasetBoundNucleotideContigFragmentDataset private[rdd] (
                              pageSize: Int = 1 * 1024 * 1024,
                              compressCodec: CompressionCodecName = CompressionCodecName.GZIP,
                              disableDictionaryEncoding: Boolean = false) {
-    log.info("Saving directly as Parquet from SQL. Options other than compression codec are ignored.")
+    info("Saving directly as Parquet from SQL. Options other than compression codec are ignored.")
     dataset.toDF()
       .write
       .format("parquet")
@@ -259,7 +259,7 @@ sealed abstract class NucleotideContigFragmentDataset extends AvroGenomicDataset
   override def saveAsPartitionedParquet(pathName: String,
                                         compressCodec: CompressionCodecName = CompressionCodecName.GZIP,
                                         partitionSize: Int = 1000000) {
-    log.info("Saving directly as Hive-partitioned Parquet from SQL. " +
+    info("Saving directly as Hive-partitioned Parquet from SQL. " +
       "Options other than compression codec are ignored.")
     val df = toDF()
       .withColumnRenamed("contigName", "referenceName")

--- a/adam-core/src/main/scala/org/bdgenomics/adam/rdd/feature/BEDInFormatter.scala
+++ b/adam-core/src/main/scala/org/bdgenomics/adam/rdd/feature/BEDInFormatter.scala
@@ -25,7 +25,6 @@ import java.io.{
 import org.bdgenomics.adam.rdd.{ InFormatter, InFormatterCompanion }
 import org.bdgenomics.adam.sql.{ Feature => FeatureProduct }
 import org.bdgenomics.formats.avro.Feature
-import org.bdgenomics.utils.misc.Logging
 
 /**
  * InFormatter companion that builds a BEDInFormatter to write features in BED format to a pipe.

--- a/adam-core/src/main/scala/org/bdgenomics/adam/rdd/feature/FeatureDataset.scala
+++ b/adam-core/src/main/scala/org/bdgenomics/adam/rdd/feature/FeatureDataset.scala
@@ -322,7 +322,7 @@ case class DatasetBoundFeatureDataset private[rdd] (
                              pageSize: Int = 1 * 1024 * 1024,
                              compressCodec: CompressionCodecName = CompressionCodecName.GZIP,
                              disableDictionaryEncoding: Boolean = false) {
-    log.info("Saving directly as Parquet from SQL. Options other than compression codec are ignored.")
+    info("Saving directly as Parquet from SQL. Options other than compression codec are ignored.")
     dataset.toDF()
       .write
       .format("parquet")
@@ -519,7 +519,7 @@ sealed abstract class FeatureDataset extends AvroGenomicDataset[Feature, Feature
         disableFastConcat = disableFastConcat)
     } else {
       if (asSingleFile) {
-        log.warn("asSingleFile = true ignored when saving as Parquet.")
+        warn("asSingleFile = true ignored when saving as Parquet.")
       }
       saveAsParquet(new JavaSaveArgs(filePath))
     }

--- a/adam-core/src/main/scala/org/bdgenomics/adam/rdd/feature/FeatureParser.scala
+++ b/adam-core/src/main/scala/org/bdgenomics/adam/rdd/feature/FeatureParser.scala
@@ -17,10 +17,10 @@
  */
 package org.bdgenomics.adam.rdd.feature
 
+import grizzled.slf4j.Logging
 import htsjdk.samtools.ValidationStringency
 import org.bdgenomics.adam.models.SequenceRecord
 import org.bdgenomics.formats.avro.Feature
-import org.bdgenomics.utils.misc.Logging
 import scala.collection.JavaConversions._
 import scala.collection.mutable.ArrayBuffer
 
@@ -42,7 +42,7 @@ private[rdd] sealed trait FeatureParser extends Serializable with Logging {
     if (stringency == ValidationStringency.STRICT) {
       throw new IllegalArgumentException(message.format(line))
     } else if (stringency == ValidationStringency.LENIENT) {
-      log.warn(message.format(line))
+      warn(message.format(line))
     }
     None
   }
@@ -251,7 +251,7 @@ private[rdd] class IntervalListParser extends FeatureParser {
               throw new Exception(s"Expected fields of the form 'key:value' in field $field but got: $x. Line:\n$line")
             } else {
               if (stringency == ValidationStringency.LENIENT) {
-                log.warn(s"Expected fields of the form 'key:value' in field $field but got: $x. Line:\n$line")
+                warn(s"Expected fields of the form 'key:value' in field $field but got: $x. Line:\n$line")
               }
               None
             }

--- a/adam-core/src/main/scala/org/bdgenomics/adam/rdd/feature/GFF3InFormatter.scala
+++ b/adam-core/src/main/scala/org/bdgenomics/adam/rdd/feature/GFF3InFormatter.scala
@@ -25,7 +25,6 @@ import java.io.{
 import org.bdgenomics.adam.rdd.{ InFormatter, InFormatterCompanion }
 import org.bdgenomics.adam.sql.{ Feature => FeatureProduct }
 import org.bdgenomics.formats.avro.Feature
-import org.bdgenomics.utils.misc.Logging
 
 /**
  * InFormatter companion that builds a GFF3InFormatter to write features in GFF3 format to a pipe.

--- a/adam-core/src/main/scala/org/bdgenomics/adam/rdd/feature/GTFInFormatter.scala
+++ b/adam-core/src/main/scala/org/bdgenomics/adam/rdd/feature/GTFInFormatter.scala
@@ -25,7 +25,6 @@ import java.io.{
 import org.bdgenomics.adam.rdd.{ InFormatter, InFormatterCompanion }
 import org.bdgenomics.adam.sql.{ Feature => FeatureProduct }
 import org.bdgenomics.formats.avro.Feature
-import org.bdgenomics.utils.misc.Logging
 
 /**
  * InFormatter companion that builds a GTFInFormatter to write features in GTF format to a pipe.

--- a/adam-core/src/main/scala/org/bdgenomics/adam/rdd/feature/NarrowPeakInFormatter.scala
+++ b/adam-core/src/main/scala/org/bdgenomics/adam/rdd/feature/NarrowPeakInFormatter.scala
@@ -25,7 +25,6 @@ import java.io.{
 import org.bdgenomics.adam.rdd.{ InFormatter, InFormatterCompanion }
 import org.bdgenomics.adam.sql.{ Feature => FeatureProduct }
 import org.bdgenomics.formats.avro.Feature
-import org.bdgenomics.utils.misc.Logging
 
 /**
  * InFormatter companion that builds a NarrowPeakInFormatter to write features in NarrowPeak format to a pipe.

--- a/adam-core/src/main/scala/org/bdgenomics/adam/rdd/fragment/FragmentDataset.scala
+++ b/adam-core/src/main/scala/org/bdgenomics/adam/rdd/fragment/FragmentDataset.scala
@@ -17,6 +17,7 @@
  */
 package org.bdgenomics.adam.rdd.fragment
 
+import grizzled.slf4j.Logging
 import org.apache.parquet.hadoop.metadata.CompressionCodecName
 import org.apache.spark.SparkContext
 import org.apache.spark.api.java.function.{ Function => JFunction }
@@ -49,7 +50,6 @@ import org.bdgenomics.utils.interval.array.{
   IntervalArray,
   IntervalArraySerializer
 }
-import org.bdgenomics.utils.misc.Logging
 import scala.collection.JavaConversions._
 import scala.collection.JavaConverters._
 import scala.reflect.ClassTag
@@ -203,7 +203,7 @@ case class DatasetBoundFragmentDataset private[rdd] (
                              pageSize: Int = 1 * 1024 * 1024,
                              compressCodec: CompressionCodecName = CompressionCodecName.GZIP,
                              disableDictionaryEncoding: Boolean = false) {
-    log.info("Saving directly as Parquet from SQL. Options other than compression codec are ignored.")
+    info("Saving directly as Parquet from SQL. Options other than compression codec are ignored.")
     dataset.toDF()
       .write
       .format("parquet")

--- a/adam-core/src/main/scala/org/bdgenomics/adam/rdd/fragment/InterleavedFASTQInFormatter.scala
+++ b/adam-core/src/main/scala/org/bdgenomics/adam/rdd/fragment/InterleavedFASTQInFormatter.scala
@@ -18,12 +18,12 @@
 package org.bdgenomics.adam.rdd.fragment
 
 import java.io.OutputStream
+import grizzled.slf4j.Logging
 import org.apache.hadoop.conf.Configuration
 import org.bdgenomics.adam.converters.AlignmentRecordConverter
 import org.bdgenomics.adam.rdd.{ InFormatter, InFormatterCompanion }
 import org.bdgenomics.adam.sql.{ Fragment => FragmentProduct }
 import org.bdgenomics.formats.avro.Fragment
-import org.bdgenomics.utils.misc.Logging
 
 /**
  * InFormatter companion that creates an InFormatter that writes interleaved
@@ -61,11 +61,11 @@ class InterleavedFASTQInFormatter private (
       val reads = converter.convertFragment(frag).toSeq
 
       if (reads.size < 2) {
-        log.warn("Fewer than two reads for %s. Dropping...".format(frag))
+        warn("Fewer than two reads for %s. Dropping...".format(frag))
         None
       } else {
         if (reads.size > 2) {
-          log.warn("More than two reads for %s. Taking first 2.".format(frag))
+          warn("More than two reads for %s. Taking first 2.".format(frag))
         }
         Some((reads(0), reads(1)))
       }
@@ -91,7 +91,7 @@ class InterleavedFASTQInFormatter private (
         os.write(fastq2.getBytes)
         os.write(fastq1.getBytes)
       } else {
-        log.warn("Improper pair of reads in fragment %s. Dropping...".format(p))
+        warn("Improper pair of reads in fragment %s. Dropping...".format(p))
       }
     })
   }

--- a/adam-core/src/main/scala/org/bdgenomics/adam/rdd/fragment/Tab5InFormatter.scala
+++ b/adam-core/src/main/scala/org/bdgenomics/adam/rdd/fragment/Tab5InFormatter.scala
@@ -18,12 +18,12 @@
 package org.bdgenomics.adam.rdd.fragment
 
 import java.io.OutputStream
+import grizzled.slf4j.Logging
 import org.apache.hadoop.conf.Configuration
 import org.bdgenomics.adam.converters.AlignmentRecordConverter
 import org.bdgenomics.adam.rdd.{ InFormatter, InFormatterCompanion }
 import org.bdgenomics.adam.sql.{ Fragment => FragmentProduct }
 import org.bdgenomics.formats.avro.Fragment
-import org.bdgenomics.utils.misc.Logging
 
 /**
  * InFormatter companion that creates an InFormatter that writes Bowtie tab5 format.
@@ -70,7 +70,7 @@ class Tab5InFormatter private (
         reads
       } else {
         if (reads.size > 2) {
-          log.warn("More than two reads for %s. Taking first 2.".format(frag))
+          warn("More than two reads for %s. Taking first 2.".format(frag))
         }
         reads.take(2)
       }

--- a/adam-core/src/main/scala/org/bdgenomics/adam/rdd/fragment/Tab6InFormatter.scala
+++ b/adam-core/src/main/scala/org/bdgenomics/adam/rdd/fragment/Tab6InFormatter.scala
@@ -18,12 +18,12 @@
 package org.bdgenomics.adam.rdd.fragment
 
 import java.io.OutputStream
+import grizzled.slf4j.Logging
 import org.apache.hadoop.conf.Configuration
 import org.bdgenomics.adam.converters.AlignmentRecordConverter
 import org.bdgenomics.adam.rdd.{ InFormatter, InFormatterCompanion }
 import org.bdgenomics.adam.sql.{ Fragment => FragmentProduct }
 import org.bdgenomics.formats.avro.Fragment
-import org.bdgenomics.utils.misc.Logging
 
 /**
  * InFormatter companion that creates an InFormatter that writes Bowtie tab6 format.
@@ -69,7 +69,7 @@ class Tab6InFormatter private (
         reads
       } else {
         if (reads.size > 2) {
-          log.warn("More than two reads for %s. Taking first 2.".format(frag))
+          warn("More than two reads for %s. Taking first 2.".format(frag))
         }
         reads.take(2)
       }

--- a/adam-core/src/main/scala/org/bdgenomics/adam/rdd/read/AlignmentRecordDataset.scala
+++ b/adam-core/src/main/scala/org/bdgenomics/adam/rdd/read/AlignmentRecordDataset.scala
@@ -261,7 +261,7 @@ case class DatasetBoundAlignmentRecordDataset private[rdd] (
                              pageSize: Int = 1 * 1024 * 1024,
                              compressCodec: CompressionCodecName = CompressionCodecName.GZIP,
                              disableDictionaryEncoding: Boolean = false) {
-    log.info("Saving directly as Parquet from SQL. Options other than compression codec are ignored.")
+    info("Saving directly as Parquet from SQL. Options other than compression codec are ignored.")
     dataset.toDF()
       .write
       .format("parquet")
@@ -552,7 +552,7 @@ sealed abstract class AlignmentRecordDataset extends AvroReadGroupGenomicDataset
     if (args.outputPath.endsWith(".sam") ||
       args.outputPath.endsWith(".bam") ||
       args.outputPath.endsWith(".cram")) {
-      log.info("Saving data in SAM/BAM/CRAM format")
+      info("Saving data in SAM/BAM/CRAM format")
       saveAsSam(
         args.outputPath,
         isSorted = isSorted,
@@ -882,7 +882,7 @@ sealed abstract class AlignmentRecordDataset extends AvroReadGroupGenomicDataset
       // clean up the header after writing
       fs.delete(headPath, true)
     } else {
-      log.info(s"Writing single ${fileType} file (not Hadoop-style directory)")
+      info(s"Writing single ${fileType} file (not Hadoop-style directory)")
 
       val tailPath = new Path(filePath + "_tail")
       val outputPath = new Path(filePath)
@@ -942,7 +942,7 @@ sealed abstract class AlignmentRecordDataset extends AvroReadGroupGenomicDataset
    * @return Returns a new RDD containing sorted reads.
    */
   def sortReadsByReadName(): AlignmentRecordDataset = SortReads.time {
-    log.info("Sorting reads by read name")
+    info("Sorting reads by read name")
 
     transformDataset(_.orderBy("readName", "readInFragment"))
   }
@@ -959,7 +959,7 @@ sealed abstract class AlignmentRecordDataset extends AvroReadGroupGenomicDataset
    * @see sortReadsByReferencePositionAndIndex
    */
   def sortReadsByReferencePosition(): AlignmentRecordDataset = SortReads.time {
-    log.info("Sorting reads by reference position")
+    info("Sorting reads by reference position")
 
     // NOTE: In order to keep unmapped reads from swamping a single partition
     // we sort the unmapped reads by read name. We prefix with tildes ("~";
@@ -986,7 +986,7 @@ sealed abstract class AlignmentRecordDataset extends AvroReadGroupGenomicDataset
    * @see sortReadsByReferencePosition
    */
   def sortReadsByReferencePositionAndIndex(): AlignmentRecordDataset = SortByIndex.time {
-    log.info("Sorting reads by reference index, using %s.".format(sequences))
+    info("Sorting reads by reference index, using %s.".format(sequences))
 
     import scala.math.Ordering.{ Int => ImplicitIntOrdering, _ }
 
@@ -1431,7 +1431,7 @@ sealed abstract class AlignmentRecordDataset extends AvroReadGroupGenomicDataset
           if (validationStringency == ValidationStringency.STRICT)
             throw new IllegalArgumentException(msg)
           else if (validationStringency == ValidationStringency.LENIENT)
-            logError(msg)
+            warn(msg)
         }
       case ValidationStringency.SILENT =>
     }
@@ -1452,7 +1452,7 @@ sealed abstract class AlignmentRecordDataset extends AvroReadGroupGenomicDataset
 
     maybeUnpersist(pairedRecords)
 
-    log.info(
+    info(
       "%d/%d records are properly paired: %d firsts, %d seconds".format(
         numPairedRecords,
         numRecords,
@@ -1558,7 +1558,7 @@ sealed abstract class AlignmentRecordDataset extends AvroReadGroupGenomicDataset
     validationStringency: ValidationStringency = ValidationStringency.LENIENT,
     persistLevel: Option[StorageLevel] = None) {
 
-    log.info("Saving data in FASTQ format.")
+    info("Saving data in FASTQ format.")
     fileName2Opt match {
       case Some(fileName2) =>
         saveAsPairedFastq(

--- a/adam-core/src/main/scala/org/bdgenomics/adam/rdd/read/FASTQInFormatter.scala
+++ b/adam-core/src/main/scala/org/bdgenomics/adam/rdd/read/FASTQInFormatter.scala
@@ -24,7 +24,6 @@ import org.bdgenomics.adam.rdd.{ InFormatter, InFormatterCompanion }
 import org.bdgenomics.adam.rdd.fragment.FragmentDataset
 import org.bdgenomics.adam.sql.{ AlignmentRecord => AlignmentRecordProduct }
 import org.bdgenomics.formats.avro.AlignmentRecord
-import org.bdgenomics.utils.misc.Logging
 
 /**
  * InFormatter companion that creates an InFormatter that writes FASTQ.
@@ -43,7 +42,7 @@ object FASTQInFormatter extends InFormatterCompanion[AlignmentRecord, AlignmentR
 }
 
 class FASTQInFormatter private (
-    conf: Configuration) extends InFormatter[AlignmentRecord, AlignmentRecordProduct, AlignmentRecordDataset, FASTQInFormatter] with Logging {
+    conf: Configuration) extends InFormatter[AlignmentRecord, AlignmentRecordProduct, AlignmentRecordDataset, FASTQInFormatter] {
 
   protected val companion = FASTQInFormatter
   private val converter = new AlignmentRecordConverter

--- a/adam-core/src/main/scala/org/bdgenomics/adam/rdd/read/MDTagging.scala
+++ b/adam-core/src/main/scala/org/bdgenomics/adam/rdd/read/MDTagging.scala
@@ -17,12 +17,12 @@
  */
 package org.bdgenomics.adam.rdd.read
 
+import grizzled.slf4j.Logging
 import htsjdk.samtools.{ TextCigarCodec, ValidationStringency }
 import org.apache.spark.rdd.RDD
 import org.bdgenomics.adam.models.{ MdTag, ReferenceRegion }
 import org.bdgenomics.adam.util.ReferenceFile
 import org.bdgenomics.formats.avro.AlignmentRecord
-import org.bdgenomics.utils.misc.Logging
 
 private[read] case class MDTagging(
     reads: RDD[AlignmentRecord],
@@ -53,7 +53,7 @@ private[read] case class MDTagging(
           if (validationStringency == ValidationStringency.STRICT) {
             throw exception
           } else if (validationStringency == ValidationStringency.LENIENT) {
-            log.warn(exception.getMessage)
+            warn(exception.getMessage)
           }
         }
       }
@@ -79,7 +79,7 @@ private[read] case class MDTagging(
             if (validationStringency == ValidationStringency.STRICT) {
               throw t
             } else if (validationStringency == ValidationStringency.LENIENT) {
-              log.warn("Caught exception when processing read %s: %s".format(
+              warn("Caught exception when processing read %s: %s".format(
                 read.getReferenceName, t))
             }
             read

--- a/adam-core/src/main/scala/org/bdgenomics/adam/rdd/read/MarkDuplicates.scala
+++ b/adam-core/src/main/scala/org/bdgenomics/adam/rdd/read/MarkDuplicates.scala
@@ -17,7 +17,7 @@
  */
 package org.bdgenomics.adam.rdd.read
 
-import org.bdgenomics.utils.misc.Logging
+import grizzled.slf4j.Logging
 import org.apache.spark.rdd.RDD
 import org.bdgenomics.adam.instrumentation.Timers._
 import org.bdgenomics.adam.models.{ ReadGroupDictionary, ReferencePosition }
@@ -80,12 +80,12 @@ private[rdd] object MarkDuplicates extends Serializable with Logging {
       .filter(_.library.isEmpty)
 
     emptyRgs.foreach(rg => {
-      log.warn("Library ID is empty for read group %s from sample %s.".format(rg.id,
+      warn("Library ID is empty for read group %s from sample %s.".format(rg.id,
         rg.sampleId))
     })
 
     if (emptyRgs.nonEmpty) {
-      log.warn("For duplicate marking, all reads whose library is unknown will be treated as coming from the same library.")
+      warn("For duplicate marking, all reads whose library is unknown will be treated as coming from the same library.")
     }
   }
 

--- a/adam-core/src/main/scala/org/bdgenomics/adam/rdd/read/ReferencePositionPair.scala
+++ b/adam-core/src/main/scala/org/bdgenomics/adam/rdd/read/ReferencePositionPair.scala
@@ -19,7 +19,6 @@ package org.bdgenomics.adam.rdd.read
 
 import com.esotericsoftware.kryo.{ Kryo, Serializer }
 import com.esotericsoftware.kryo.io.{ Input, Output }
-import org.bdgenomics.utils.misc.Logging
 import org.bdgenomics.adam.instrumentation.Timers.CreateReferencePositionPair
 import org.bdgenomics.adam.models.{
   ReferencePosition,
@@ -31,7 +30,7 @@ import org.bdgenomics.formats.avro.AlignmentRecord
 /**
  * A singleton object for creating reference position pairs.
  */
-private[read] object ReferencePositionPair extends Logging {
+private[read] object ReferencePositionPair {
 
   /**
    * Extracts the reference positions from a bucket of reads from a single fragment.

--- a/adam-core/src/main/scala/org/bdgenomics/adam/rdd/read/SingleReadBucket.scala
+++ b/adam-core/src/main/scala/org/bdgenomics/adam/rdd/read/SingleReadBucket.scala
@@ -19,7 +19,6 @@ package org.bdgenomics.adam.rdd.read
 
 import com.esotericsoftware.kryo.{ Kryo, Serializer }
 import com.esotericsoftware.kryo.io.{ Output, Input }
-import org.bdgenomics.utils.misc.Logging
 import org.apache.spark.rdd.RDD
 import org.bdgenomics.adam.serialization.AvroSerializer
 import org.bdgenomics.formats.avro.{
@@ -62,7 +61,7 @@ private class FragmentIterator(
 /**
  * Companion object for building SingleReadBuckets.
  */
-private[read] object SingleReadBucket extends Logging {
+private[read] object SingleReadBucket {
 
   private def fromGroupedReads(reads: Iterable[AlignmentRecord]): SingleReadBucket = {
     // split by mapping

--- a/adam-core/src/main/scala/org/bdgenomics/adam/rdd/read/realignment/IndelRealignmentTarget.scala
+++ b/adam-core/src/main/scala/org/bdgenomics/adam/rdd/read/realignment/IndelRealignmentTarget.scala
@@ -20,7 +20,6 @@ package org.bdgenomics.adam.rdd.read.realignment
 import com.esotericsoftware.kryo.io.{ Input, Output }
 import com.esotericsoftware.kryo.{ Kryo, Serializer }
 import htsjdk.samtools.CigarOperator
-import org.bdgenomics.utils.misc.Logging
 import org.bdgenomics.adam.models.ReferenceRegion
 import org.bdgenomics.adam.rich.RichAlignmentRecord
 import org.bdgenomics.formats.avro.AlignmentRecord
@@ -149,7 +148,7 @@ private[adam] class IndelRealignmentTargetSerializer extends Serializer[IndelRea
 
 private[adam] class IndelRealignmentTarget(
     val variation: Option[ReferenceRegion],
-    val readRange: ReferenceRegion) extends Logging with Serializable {
+    val readRange: ReferenceRegion) extends Serializable {
 
   assert(variation.map(r => r.referenceName).forall(_ == readRange.referenceName))
 

--- a/adam-core/src/main/scala/org/bdgenomics/adam/rdd/read/realignment/RealignmentTargetFinder.scala
+++ b/adam-core/src/main/scala/org/bdgenomics/adam/rdd/read/realignment/RealignmentTargetFinder.scala
@@ -17,7 +17,6 @@
  */
 package org.bdgenomics.adam.rdd.read.realignment
 
-import org.bdgenomics.utils.misc.Logging
 import org.apache.spark.rdd.RDD
 import org.bdgenomics.adam.algorithms.consensus.{ ConsensusGenerator, ConsensusGeneratorFromReads }
 import org.bdgenomics.adam.rich.RichAlignmentRecord
@@ -43,7 +42,7 @@ private[realignment] object RealignmentTargetFinder {
   }
 }
 
-private[realignment] class RealignmentTargetFinder extends Serializable with Logging {
+private[realignment] class RealignmentTargetFinder extends Serializable {
 
   /**
    * Joins two sorted sets of targets together. Is tail call recursive.

--- a/adam-core/src/main/scala/org/bdgenomics/adam/rdd/read/recalibration/BaseQualityRecalibration.scala
+++ b/adam-core/src/main/scala/org/bdgenomics/adam/rdd/read/recalibration/BaseQualityRecalibration.scala
@@ -17,6 +17,7 @@
  */
 package org.bdgenomics.adam.rdd.read.recalibration
 
+import grizzled.slf4j.Logging
 import htsjdk.samtools.{
   CigarElement,
   CigarOperator,
@@ -34,7 +35,6 @@ import org.bdgenomics.adam.models.{
 }
 import org.bdgenomics.adam.instrumentation.Timers._
 import org.bdgenomics.formats.avro.AlignmentRecord
-import org.bdgenomics.utils.misc.Logging
 import scala.annotation.tailrec
 
 /**
@@ -81,7 +81,7 @@ private class BaseQualityRecalibration(
     })
 
     optStorageLevel.fold(covRdd)(sl => {
-      log.info("User requested %s persistance for covariate RDD.".format(sl))
+      info("User requested %s persistance for covariate RDD.".format(sl))
       covRdd.persist(sl)
     })
   }

--- a/adam-core/src/main/scala/org/bdgenomics/adam/rdd/variant/GenotypeDataset.scala
+++ b/adam-core/src/main/scala/org/bdgenomics/adam/rdd/variant/GenotypeDataset.scala
@@ -172,7 +172,7 @@ case class DatasetBoundGenotypeDataset private[rdd] (
                              pageSize: Int = 1 * 1024 * 1024,
                              compressCodec: CompressionCodecName = CompressionCodecName.GZIP,
                              disableDictionaryEncoding: Boolean = false) {
-    log.info("Saving directly as Parquet from SQL. Options other than compression codec are ignored.")
+    info("Saving directly as Parquet from SQL. Options other than compression codec are ignored.")
     dataset.toDF()
       .write
       .format("parquet")

--- a/adam-core/src/main/scala/org/bdgenomics/adam/rdd/variant/VCFOutFormatter.scala
+++ b/adam-core/src/main/scala/org/bdgenomics/adam/rdd/variant/VCFOutFormatter.scala
@@ -17,6 +17,7 @@
  */
 package org.bdgenomics.adam.rdd.variant
 
+import grizzled.slf4j.Logging
 import htsjdk.samtools.ValidationStringency
 import htsjdk.variant.vcf.{
   VCFCodec,
@@ -34,7 +35,6 @@ import org.bdgenomics.adam.converters.VariantContextConverter._
 import org.bdgenomics.adam.converters.VariantContextConverter
 import org.bdgenomics.adam.models.VariantContext
 import org.bdgenomics.adam.rdd.OutFormatter
-import org.bdgenomics.utils.misc.Logging
 import scala.annotation.tailrec
 import scala.collection.mutable.ListBuffer
 
@@ -104,7 +104,7 @@ case class VCFOutFormatter(
     val header = codec.readActualHeader(lri).asInstanceOf[VCFHeader]
 
     // merge header lines with our supported header lines
-    val lines = cleanAndMixInSupportedLines(headerLines(header), stringency, log)
+    val lines = cleanAndMixInSupportedLines(headerLines(header), stringency, logger.logger)
 
     // accumulate header lines if desired
     optHeaderLines.map(accumulator => lines.foreach(line => accumulator.add(line)))

--- a/adam-core/src/main/scala/org/bdgenomics/adam/rdd/variant/VariantContextDataset.scala
+++ b/adam-core/src/main/scala/org/bdgenomics/adam/rdd/variant/VariantContextDataset.scala
@@ -17,6 +17,7 @@
  */
 package org.bdgenomics.adam.rdd.variant
 
+import grizzled.slf4j.Logging
 import htsjdk.samtools.ValidationStringency
 import htsjdk.samtools.util.BlockCompressedOutputStream
 import htsjdk.variant.vcf.{
@@ -60,7 +61,6 @@ import org.bdgenomics.adam.rdd.{
 import org.bdgenomics.adam.sql.{ VariantContext => VariantContextProduct }
 import org.bdgenomics.adam.util.{ FileMerger, FileExtensions }
 import org.bdgenomics.formats.avro.Sample
-import org.bdgenomics.utils.misc.Logging
 import org.bdgenomics.utils.interval.array.{
   IntervalArray,
   IntervalArraySerializer
@@ -224,7 +224,7 @@ sealed abstract class VariantContextDataset extends MultisampleGenomicDataset[Va
                     pageSize: Int = 1 * 1024 * 1024,
                     compressCodec: CompressionCodecName = CompressionCodecName.GZIP,
                     disableDictionaryEncoding: Boolean = false) {
-    log.info("Saving directly as Parquet from SQL. Options other than compression codec are ignored.")
+    info("Saving directly as Parquet from SQL. Options other than compression codec are ignored.")
     dataset.toDF()
       .write
       .format("parquet")
@@ -359,7 +359,7 @@ sealed abstract class VariantContextDataset extends MultisampleGenomicDataset[Va
           .format(filePath))
     }
 
-    log.info(s"Writing $vcfFormat file to $filePath")
+    info(s"Writing $vcfFormat file to $filePath")
 
     // map samples to sample ids
     val sampleIds = samples.map(_.getId)

--- a/adam-core/src/main/scala/org/bdgenomics/adam/rdd/variant/VariantDataset.scala
+++ b/adam-core/src/main/scala/org/bdgenomics/adam/rdd/variant/VariantDataset.scala
@@ -153,7 +153,7 @@ case class DatasetBoundVariantDataset private[rdd] (
                              pageSize: Int = 1 * 1024 * 1024,
                              compressCodec: CompressionCodecName = CompressionCodecName.GZIP,
                              disableDictionaryEncoding: Boolean = false) {
-    log.info("Saving directly as Parquet from SQL. Options other than compression codec are ignored.")
+    info("Saving directly as Parquet from SQL. Options other than compression codec are ignored.")
     dataset.toDF()
       .write
       .format("parquet")

--- a/adam-core/src/main/scala/org/bdgenomics/adam/serialization/ADAMKryoRegistrator.scala
+++ b/adam-core/src/main/scala/org/bdgenomics/adam/serialization/ADAMKryoRegistrator.scala
@@ -24,12 +24,12 @@ import com.esotericsoftware.kryo.io.{
   Output
 }
 import com.esotericsoftware.kryo.{ Kryo, Serializer }
+import grizzled.slf4j.Logging
 import it.unimi.dsi.fastutil.io.{ FastByteArrayInputStream, FastByteArrayOutputStream }
 import org.apache.avro.io.{ BinaryDecoder, BinaryEncoder, DecoderFactory, EncoderFactory }
 import org.apache.avro.specific.{ SpecificDatumReader, SpecificDatumWriter, SpecificRecord }
 import org.apache.hadoop.io.Writable
 import org.apache.spark.serializer.KryoRegistrator
-import org.bdgenomics.utils.misc.Logging
 import scala.reflect.ClassTag
 
 case class InputStreamWithDecoder(size: Int) {
@@ -287,7 +287,7 @@ class ADAMKryoRegistrator extends KryoRegistrator with Logging {
       kryo.register(Class.forName("org.apache.spark.sql.execution.datasources.ExecutedWriteSummary"))
     } catch {
       case cnfe: java.lang.ClassNotFoundException => {
-        if (log.isDebugEnabled) log.debug("Did not find Spark internal class. This is expected for earlier Spark versions.")
+        debug("Did not find Spark internal class. This is expected for earlier Spark versions.")
       }
     }
     kryo.register(classOf[org.apache.spark.sql.catalyst.expressions.UnsafeRow])

--- a/adam-core/src/main/scala/org/bdgenomics/adam/util/FileMerger.scala
+++ b/adam-core/src/main/scala/org/bdgenomics/adam/util/FileMerger.scala
@@ -18,13 +18,13 @@
 package org.bdgenomics.adam.util
 
 import java.io.{ InputStream, OutputStream }
+import grizzled.slf4j.Logging
 import htsjdk.samtools.cram.build.CramIO
 import htsjdk.samtools.cram.common.CramVersions
 import htsjdk.samtools.util.BlockCompressedStreamConstants
 import org.apache.hadoop.conf.Configuration
 import org.apache.hadoop.fs.{ FileSystem, Path }
 import org.apache.spark.SparkContext
-import org.bdgenomics.utils.misc.Logging
 import scala.annotation.tailrec
 
 /**
@@ -184,7 +184,7 @@ private[adam] object FileMerger extends Logging {
 
     // optionally copy the header
     optHeaderPath.foreach(p => {
-      log.info("Copying header file (%s)".format(p))
+      info("Copying header file (%s)".format(p))
 
       // open our input file
       val is = fsIn.open(p)
@@ -202,7 +202,7 @@ private[adam] object FileMerger extends Logging {
     tailFiles.toSeq.foreach(p => {
 
       // print a bit of progress logging
-      log.info("Copying file %s, file %d of %d.".format(
+      info("Copying file %s, file %d of %d.".format(
         p.toString,
         filesCopied,
         numFiles))

--- a/adam-core/src/main/scala/org/bdgenomics/adam/util/IndexedFastaFile.scala
+++ b/adam-core/src/main/scala/org/bdgenomics/adam/util/IndexedFastaFile.scala
@@ -18,6 +18,7 @@
 
 package org.bdgenomics.adam.util
 
+import grizzled.slf4j.Logging
 import htsjdk.samtools.ValidationStringency
 import htsjdk.samtools.reference.{ FastaSequenceIndex, IndexedFastaSequenceFile }
 import java.net.URI
@@ -25,7 +26,6 @@ import java.nio.file.Paths
 import org.apache.hadoop.fs.Path
 import org.apache.spark.SparkContext
 import org.bdgenomics.adam.models.{ SequenceDictionary, ReferenceRegion }
-import org.bdgenomics.utils.misc.Logging
 
 /**
  * Loads and extracts sequences directly from indexed fasta or fa files. filePath requires fai index in the
@@ -67,7 +67,7 @@ case class IndexedFastaFile(sc: SparkContext,
           throw e
         } else {
           if (stringency == ValidationStringency.LENIENT) {
-            log.warn("Caught exception %s when loading FASTA sequence dictionary. Using empty dictionary instead.".format(e))
+            warn("Caught exception %s when loading FASTA sequence dictionary. Using empty dictionary instead.".format(e))
           }
           SequenceDictionary.empty
         }

--- a/adam-core/src/main/scala/org/bdgenomics/adam/util/ParallelFileMerger.scala
+++ b/adam-core/src/main/scala/org/bdgenomics/adam/util/ParallelFileMerger.scala
@@ -17,6 +17,7 @@
  */
 package org.bdgenomics.adam.util
 
+import grizzled.slf4j.Logging
 import htsjdk.samtools.cram.build.CramIO
 import htsjdk.samtools.cram.common.CramVersions
 import htsjdk.samtools.util.BlockCompressedStreamConstants
@@ -24,7 +25,6 @@ import org.apache.hadoop.conf.Configuration
 import org.apache.hadoop.fs.{ FileSystem, Path }
 import org.apache.spark.SparkContext
 import org.apache.spark.broadcast.Broadcast
-import org.bdgenomics.utils.misc.Logging
 import scala.annotation.tailrec
 import scala.math.min
 

--- a/pom.xml
+++ b/pom.xml
@@ -28,7 +28,8 @@
     <hadoop-bam.version>7.9.2</hadoop-bam.version>
     <slf4j.version>1.7.25</slf4j.version>
     <bdg-formats.version>0.12.0</bdg-formats.version>
-    <bdg-utils.version>0.2.13</bdg-utils.version>
+    <bdg-utils.version>0.2.15-SNAPSHOT</bdg-utils.version>
+    <grizzled-slf4j.version>1.3.3</grizzled-slf4j.version>
     <htsjdk.version>2.18.2</htsjdk.version>
     <scoverage.plugin.version>1.1.1</scoverage.plugin.version>
   </properties>
@@ -126,12 +127,12 @@
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-deploy-plugin</artifactId>
-          <version>2.8.2</version>
+          <version>3.0.0-M1</version>
         </plugin>
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-enforcer-plugin</artifactId>
-          <version>1.4.1</version>
+          <version>3.0.0-M2</version>
           <executions>
             <execution>
               <id>enforce-versions</id>
@@ -141,8 +142,8 @@
               <configuration>
                 <rules>
                   <requireMavenVersion>
-                    <version>[3.1.1,)</version>
-                    <message>ADAM requires Maven 3.1.1 or greater</message>
+                    <version>[3.3.9,)</version>
+                    <message>ADAM requires Maven 3.3.9 or greater</message>
                   </requireMavenVersion>
                   <requireJavaVersion>
                     <version>[1.8,)</version>
@@ -156,17 +157,17 @@
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-install-plugin</artifactId>
-          <version>2.5.2</version>
+          <version>3.0.0-M1</version>
         </plugin>
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-jar-plugin</artifactId>
-          <version>3.1.0</version>
+          <version>3.1.1</version>
         </plugin>
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-resources-plugin</artifactId>
-          <version>3.0.1</version>
+          <version>3.1.0</version>
         </plugin>
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
@@ -181,7 +182,7 @@
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-surefire-plugin</artifactId>
-          <version>2.22.1</version>
+          <version>3.0.0-M3</version>
         </plugin>
         <plugin>
           <groupId>org.codehaus.mojo</groupId>
@@ -191,7 +192,7 @@
         <plugin>
           <groupId>org.scalatest</groupId>
           <artifactId>scalatest-maven-plugin</artifactId>
-          <version>1.0</version>
+          <version>2.0.0</version>
         </plugin>
         <plugin>
           <groupId>pl.project13.maven</groupId>
@@ -543,13 +544,18 @@
       <dependency>
         <groupId>args4j</groupId>
         <artifactId>args4j</artifactId>
-        <version>2.0.31</version> <!-- note: version 2.32 is not binary compatible -->
+        <version>2.33</version>
       </dependency>
       <dependency>
         <groupId>org.scalatest</groupId>
         <artifactId>scalatest_${scala.version.prefix}</artifactId>
-        <version>2.2.6</version>
+        <version>3.0.7</version>
         <scope>test</scope>
+      </dependency>
+      <dependency>
+        <groupId>org.clapper</groupId>
+        <artifactId>grizzled-slf4j_${scala.version.prefix}</artifactId>
+        <version>${grizzled-slf4j.version}</version>
       </dependency>
       <dependency>
         <groupId>org.slf4j</groupId>
@@ -574,7 +580,7 @@
       <dependency>
         <groupId>org.apache.httpcomponents</groupId>
         <artifactId>httpclient</artifactId>
-        <version>4.5.2</version>
+        <version>4.5.7</version>
       </dependency>
      <dependency>
         <groupId>com.google.guava</groupId>
@@ -584,7 +590,7 @@
       <dependency>
         <groupId>org.mockito</groupId>
         <artifactId>mockito-core</artifactId>
-        <version>2.23.0</version>
+        <version>2.25.1</version>
         <scope>test</scope>
       </dependency>
       <dependency>


### PR DESCRIPTION
Fixes #1712 

Unfortunately this requires changes in bdg-utils, and as such is blocked on an 0.2.15 release.