### PR TITLE
Remove dependency on parquet-scala

### DIFF
--- a/adam-cli/src/main/scala/org/bdgenomics/adam/cli/TransformAlignments.scala
+++ b/adam-cli/src/main/scala/org/bdgenomics/adam/cli/TransformAlignments.scala
@@ -19,7 +19,6 @@ package org.bdgenomics.adam.cli
 
 import htsjdk.samtools.ValidationStringency
 import java.time.Instant
-import org.apache.parquet.filter2.dsl.Dsl._
 import org.apache.spark.SparkContext
 import org.apache.spark.storage.StorageLevel
 import org.bdgenomics.adam.algorithms.consensus._

--- a/adam-core/pom.xml
+++ b/adam-core/pom.xml
@@ -243,11 +243,6 @@
       <scope>compile</scope>
     </dependency>
     <dependency>
-      <groupId>org.apache.parquet</groupId>
-      <artifactId>parquet-scala_2.10</artifactId>
-      <scope>compile</scope>
-    </dependency>
-    <dependency>
       <groupId>org.seqdoop</groupId>
       <artifactId>hadoop-bam</artifactId>
       <scope>compile</scope>

--- a/adam-core/src/test/scala/org/bdgenomics/adam/rdd/ADAMContextSuite.scala
+++ b/adam-core/src/test/scala/org/bdgenomics/adam/rdd/ADAMContextSuite.scala
@@ -23,10 +23,11 @@ import htsjdk.samtools.{
   ValidationStringency
 }
 import java.io.{ File, FileNotFoundException }
+import java.lang.{ Long => JLong }
 import com.google.common.io.Files
 import org.apache.hadoop.fs.Path
-import org.apache.parquet.filter2.dsl.Dsl._
-import org.apache.parquet.filter2.predicate.FilterPredicate
+import org.apache.parquet.filter2.predicate.Operators.LongColumn
+import org.apache.parquet.filter2.predicate.{ FilterApi, FilterPredicate }
 import org.apache.parquet.hadoop.metadata.CompressionCodecName
 import org.apache.spark.rdd.RDD
 import org.bdgenomics.adam.models._
@@ -355,7 +356,8 @@ class ADAMContextSuite extends ADAMFunSuite {
     val loc = tmpLocation()
     variants.saveAsParquet(loc, 1024, 1024) // force more than one row group (block)
 
-    val pred: FilterPredicate = (LongColumn("start") === 16097631L)
+    val pred: FilterPredicate = FilterApi.eq[JLong, LongColumn](
+      FilterApi.longColumn("start"), 16097631L)
     // the following only reads one row group
     val adamVariants = sc.loadParquetVariants(loc, optPredicate = Some(pred))
     assert(adamVariants.rdd.count === 1)

--- a/scripts/jenkins-test
+++ b/scripts/jenkins-test
@@ -39,7 +39,7 @@ fi
 
 set -e
 
-if [ ${SPARK_VERSION} == 2.2.3 ];
+if [ ${SPARK_VERSION} == 2.3.3 ];
 then
     # shouldn't be able to move to spark 2 twice
     set +e
@@ -132,7 +132,7 @@ fi
 
 # run integration tests
 # prebuilt spark distributions are scala 2.11 for spark 2.x
-if [[ ( ${SPARK_VERSION} == 2.2.3 && ${SCALAVER} == 2.11 ) ]];
+if [[ ( ${SPARK_VERSION} == 2.3.3 && ${SCALAVER} == 2.11 ) ]];
 then
 
     # make a temp directory
@@ -204,7 +204,7 @@ then
         popd
     	
     	# we only support SparkR on Spark 2.x
-    	if [ ${SPARK_VERSION} == 2.2.3 ];
+        if [ ${SPARK_VERSION} == 2.3.3 ];
     	then
     	    
     	    # make a directory to install SparkR into, and set the R user libs path


### PR DESCRIPTION
As mentioned in #2108 , the available version of parquet-scala is stuck in 2.10. The cleanest way to get around this issue is probably to just remove this dependency.