### PR TITLE
Remove Avro 1.8.x download step from Jenkins Scala 2.12 installation.

### DIFF
--- a/scripts/jenkins-test
+++ b/scripts/jenkins-test
@@ -171,9 +171,9 @@ then
     find hadoop-2.7.7 -name *.jar | grep avro | xargs rm
 
     # download avro 1.8.x
-    curl \
-        -L "http://repo1.maven.org/maven2/org/apache/avro/avro/1.8.2/avro-1.8.2.jar" \
-        -o hadoop-2.7.7/share/hadoop/common/avro-1.8.2.jar
+    #curl \
+    #    -L "http://repo1.maven.org/maven2/org/apache/avro/avro/1.8.2/avro-1.8.2.jar" \
+    #    -o hadoop-2.7.7/share/hadoop/common/avro-1.8.2.jar
 
     export SPARK_DIST_CLASSPATH=$(hadoop-2.7.7/bin/hadoop classpath)
 else


### PR DESCRIPTION
Jenkins CI for #2203 was run against Spark 2.4.3, it is possible Spark 2.4.4 no longer requires Avro 1.8.x download step when installing for Scala 2.12.