### PR TITLE
remove 2.7 support checks

### DIFF
--- a/scripts/jenkins-test
+++ b/scripts/jenkins-test
@@ -201,7 +201,7 @@ ASSEMBLY_JAR="$(ls -1 "$ASSEMBLY_DIR" | grep "^adam[0-9A-Za-z\_\.-]*\.jar$" | gr
 export PYSPARK_SUBMIT_ARGS="--conf spark.driver.memory=4g --conf spark.executor.memory=4g --jars ${ASSEMBLY_DIR}/${ASSEMBLY_JAR} --driver-class-path ${ASSEMBLY_DIR}/${ASSEMBLY_JAR} pyspark-shell"
 
 # create a conda environment for python build, if necessary
-pythons=( 2.7 3.6 )
+pythons=( 3.6 )
 
 for python in ${pythons[*]}
 do


### PR DESCRIPTION
Addresses https://github.com/bigdatagenomics/adam/issues/2221

We could also edit the Makefile to use python3, but we removed this in the pass to handle python2/3 support. I think we can just leave it for now.