### PR TITLE
Performance improvements to SAM reading and processing

### DIFF
--- a/adam-core/src/main/scala/org/bdgenomics/adam/models/Attribute.scala
+++ b/adam-core/src/main/scala/org/bdgenomics/adam/models/Attribute.scala
@@ -36,16 +36,20 @@ case class Attribute(tag: String, tagType: TagType.Value, value: Any) {
     val byteSequenceTypes = Array(TagType.NumericByteSequence, TagType.NumericUnsignedByteSequence)
     val intSequenceTypes = Array(TagType.NumericIntSequence, TagType.NumericUnsignedIntSequence)
     val shortSequenceTypes = Array(TagType.NumericShortSequence, TagType.NumericUnsignedShortSequence)
+    val sb = new StringBuilder
+    sb.append(tag)
+    sb.append(":")
+    sb.append(tagType)
     if (byteSequenceTypes contains tagType) {
-      "%s:%s,%s".format(tag, tagType, value.asInstanceOf[Array[Byte]].mkString(","))
+      sb.append(",").append(value.asInstanceOf[Array[Byte]].mkString(",")).toString()
     } else if (shortSequenceTypes contains tagType) {
-      "%s:%s,%s".format(tag, tagType, value.asInstanceOf[Array[Short]].mkString(","))
+      sb.append(",").append(value.asInstanceOf[Array[Short]].mkString(",")).toString()
     } else if (intSequenceTypes contains tagType) {
-      "%s:%s,%s".format(tag, tagType, value.asInstanceOf[Array[Int]].mkString(","))
+      sb.append(",").append(value.asInstanceOf[Array[Int]].mkString(",")).toString()
     } else if (tagType == TagType.NumericFloatSequence) {
-      "%s:%s,%s".format(tag, tagType, value.asInstanceOf[Array[Float]].mkString(","))
+      sb.append(",").append(value.asInstanceOf[Array[Float]].mkString(",")).toString()
     } else {
-      "%s:%s:%s".format(tag, tagType, value.toString)
+      sb.append(":").append(value).toString()
     }
   }
 }

--- a/adam-core/src/main/scala/org/bdgenomics/adam/models/SequenceDictionary.scala
+++ b/adam-core/src/main/scala/org/bdgenomics/adam/models/SequenceDictionary.scala
@@ -259,7 +259,7 @@ class SequenceDictionary(val records: Vector[SequenceRecord]) extends Serializab
   }
 
   override def toString: String = {
-    records.map(_.toString).mkString(",")
+    records.map(_.toString).mkString("SequenceDictionary{", "\n", "}")
   }
 
   private[adam] def toAvro: Seq[Reference] = {

--- a/adam-core/src/main/scala/org/bdgenomics/adam/models/SequenceDictionary.scala
+++ b/adam-core/src/main/scala/org/bdgenomics/adam/models/SequenceDictionary.scala
@@ -184,7 +184,7 @@ class SequenceDictionary(val records: Vector[SequenceRecord]) extends Serializab
    * @return Returns a SAM formatted sequence dictionary.
    */
   def toSAMSequenceDictionary: SAMSequenceDictionary = {
-    new SAMSequenceDictionary(records.iterator.map(_.toSAMSequenceRecord).toList)
+    new SAMSequenceDictionary(records.map(_.toSAMSequenceRecord).asJava)
   }
 
   /**
@@ -259,7 +259,7 @@ class SequenceDictionary(val records: Vector[SequenceRecord]) extends Serializab
   }
 
   override def toString: String = {
-    records.map(_.toString).fold("SequenceDictionary{")(_ + "\n" + _) + "}"
+    records.map(_.toString).mkString(",")
   }
 
   private[adam] def toAvro: Seq[Reference] = {


### PR DESCRIPTION
These changes significantly affect the performance of processing SAM/BAM files (x60 in my test cases).

The changes:

1. StringBuilder usage instead of many String.format, and using native Scala mkString.
2. While using the object SAMSequenceDictionary from the Samtools package, we pass a Scala implementation of an iterator, which, unfortunately, takes O(n) time to check its length.

Keep up the great work!
