### PR TITLE
Refactored MDTag.scala for consistency

### DIFF
--- a/adam-core/src/main/scala/org/bdgenomics/adam/models/MdTag.scala
+++ b/adam-core/src/main/scala/org/bdgenomics/adam/models/MdTag.scala
@@ -176,6 +176,9 @@ object MdTag {
 
           case (CigarOperator.INSERTION | CigarOperator.H | CigarOperator.S | CigarOperator.P, _) =>
             cigarIdx += 1
+
+          case _ =>
+          throw new UnsupportedOperationException(s"Unsupported CigarOperator: ${cigarElement.getOperator}")
         }
       }
       new MdTag(referenceStart, matches, mismatches, deletions)
@@ -245,7 +248,7 @@ object MdTag {
             readPos += cigarElement.getLength
           }
           if (cigarElement.getOperator.consumesReferenceBases) {
-            throw new IllegalArgumentException("Cannot handle operator: " + cigarElement.getOperator)
+            throw new UnsupportedOperationException("Cannot handle operator: " + cigarElement.getOperator)
           }
         }
       }
@@ -339,7 +342,7 @@ object MdTag {
             readPos += cigarElement.getLength
           }
           if (cigarElement.getOperator.consumesReferenceBases) {
-            throw new IllegalArgumentException("Cannot handle operator: " + cigarElement.getOperator)
+            throw new UnsupportedOperationException("Cannot handle operator: " + cigarElement.getOperator)
           }
         }
       }
@@ -511,7 +514,7 @@ case class MdTag(
             readPos += insLength
           }
           if (cigarElement.getOperator.consumesReferenceBases) {
-            throw new IllegalArgumentException("Cannot handle operator: " + cigarElement.getOperator)
+            throw new UnsupportedOperationException("Cannot handle operator: " + cigarElement.getOperator)
           }
         }
       }


### PR DESCRIPTION
Refactored exception handling to be more consistent, resolving issue #2401. 
IllegalArgumentException for issues arising from input-related issues.
IllegalStateException for issues arising from internal logic issues.
UnsupportedOperationException for cases when a called method is not meant for use. 